### PR TITLE
chore: add automatic license header management via Spotless

### DIFF
--- a/fesod/src/main/java/org/apache/fesod/excel/analysis/v07/handlers/sax/SharedStringsTableHandler.java
+++ b/fesod/src/main/java/org/apache/fesod/excel/analysis/v07/handlers/sax/SharedStringsTableHandler.java
@@ -17,23 +17,6 @@
  * under the License.
  */
 
-/* ====================================================================
-   Licensed to the Apache Software Foundation (ASF) under one or more
-   contributor license agreements.  See the NOTICE file distributed with
-   this work for additional information regarding copyright ownership.
-   The ASF licenses this file to You under the Apache License, Version 2.0
-   (the "License"); you may not use this file except in compliance with
-   the License.  You may obtain a copy of the License at
-
-       http://www.apache.org/licenses/LICENSE-2.0
-
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.
-==================================================================== */
-
 package org.apache.fesod.excel.analysis.v07.handlers.sax;
 
 import java.util.regex.Matcher;

--- a/fesod/src/main/java/org/apache/fesod/excel/util/DateUtils.java
+++ b/fesod/src/main/java/org/apache/fesod/excel/util/DateUtils.java
@@ -17,23 +17,6 @@
  * under the License.
  */
 
-/* ====================================================================
-   Licensed to the Apache Software Foundation (ASF) under one or more
-   contributor license agreements.  See the NOTICE file distributed with
-   this work for additional information regarding copyright ownership.
-   The ASF licenses this file to You under the Apache License, Version 2.0
-   (the "License"); you may not use this file except in compliance with
-   the License.  You may obtain a copy of the License at
-
-       http://www.apache.org/licenses/LICENSE-2.0
-
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.
-==================================================================== */
-
 package org.apache.fesod.excel.util;
 
 import java.math.BigDecimal;

--- a/fesod/src/main/java/org/apache/fesod/excel/util/FastExcelTempFileCreationStrategy.java
+++ b/fesod/src/main/java/org/apache/fesod/excel/util/FastExcelTempFileCreationStrategy.java
@@ -17,23 +17,6 @@
  * under the License.
  */
 
-/* ====================================================================
-   Licensed to the Apache Software Foundation (ASF) under one or more
-   contributor license agreements.  See the NOTICE file distributed with
-   this work for additional information regarding copyright ownership.
-   The ASF licenses this file to You under the Apache License, Version 2.0
-   (the "License"); you may not use this file except in compliance with
-   the License.  You may obtain a copy of the License at
-
-       http://www.apache.org/licenses/LICENSE-2.0
-
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.
-==================================================================== */
-
 package org.apache.fesod.excel.util;
 
 import static org.apache.poi.util.TempFile.JAVA_IO_TMPDIR;

--- a/license-header.txt
+++ b/license-header.txt
@@ -1,0 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+

--- a/pom.xml
+++ b/pom.xml
@@ -328,7 +328,7 @@
                 <plugin>
                     <groupId>com.diffplug.spotless</groupId>
                     <artifactId>spotless-maven-plugin</artifactId>
-                    <version>3.0.0</version>
+                    <version>2.46.1</version>
                 </plugin>
                 <plugin>
                     <groupId>org.jacoco</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -328,7 +328,7 @@
                 <plugin>
                     <groupId>com.diffplug.spotless</groupId>
                     <artifactId>spotless-maven-plugin</artifactId>
-                    <version>2.46.1</version>
+                    <version>3.0.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.jacoco</groupId>
@@ -475,6 +475,10 @@
                 <artifactId>spotless-maven-plugin</artifactId>
                 <configuration>
                     <java>
+                        <licenseHeader>
+                            <file>license-header.txt</file>
+                            <delimiter>package |import |module </delimiter>
+                        </licenseHeader>
                         <palantirJavaFormat>
                             <version>2.72.0</version>
                         </palantirJavaFormat>


### PR DESCRIPTION
<!--
Thanks very much for contributing to Apache Fesod (Incubating)! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

Closed: #ISSUE
Related: #ISSUE

-->

## Purpose of the pull request

Related: #438 
This change will add license header via spotless:apply

## What's changed?

<!--- Describe the change below, including rationale and design decisions -->

## Checklist

- [X] I have read the [Contributor Guide](https://fesod.apache.org/community/contribution).
- [X] I have written the necessary doc or comment.
- [X] I have added the necessary unit tests and all cases have passed.
