### PR TITLE
feat: remove docusaurus-plugin-matomo and add custom Matomo tracking script

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -86,8 +86,7 @@ const config = {
                 editUrl: `${repoUrl}/edit/${branch}/website/`,
                 editLocalizedFiles: true,
             },
-        ],
-        'docusaurus-plugin-matomo'
+        ]
     ],
     themeConfig: ({
         image: 'img/logo.svg',
@@ -198,16 +197,31 @@ const config = {
             theme: prismThemes.github,
             darkTheme: prismThemes.oneDark,
             additionalLanguages: ['java', 'bash']
-        },
-        matomo: {
-            matomoUrl: 'https://analytics.apache.org/',
-            siteId: '83',
-            phpLoader: 'matomo.php',
-            jsLoader: 'matomo.js',
         }
     }),
     themes: ['@docusaurus/theme-mermaid'],
-    headTags: [],
+    headTags: [
+        {
+            tagName: 'script',
+            attributes: {
+                type: 'text/javascript',
+            },
+            innerHTML: `
+              var _paq = window._paq = window._paq || [];
+               /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+              _paq.push(["disableCookies"]);
+              _paq.push(['trackPageView']);
+              _paq.push(['enableLinkTracking']);
+              (function() {
+                var u="https://analytics.apache.org/";
+                _paq.push(['setTrackerUrl', u+'matomo.php']);
+                _paq.push(['setSiteId', '83']);
+                var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+                g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
+              })();
+            `,
+        },
+    ],
     markdown: {
         format: 'md',
         mermaid: true,

--- a/website/package.json
+++ b/website/package.json
@@ -23,7 +23,6 @@
     "@docusaurus/theme-mermaid": "^3.9.1",
     "@mdx-js/react": "^3.0.0",
     "clsx": "^2.0.0",
-    "docusaurus-plugin-matomo": "^0.0.8",
     "markdownlint-cli2": "^0.18.1",
     "prism-react-renderer": "^2.3.0",
     "react": "^19.0.0",


### PR DESCRIPTION
<!--
Thanks very much for contributing to Apache Fesod (Incubating)! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

Closed: #ISSUE
Related: #ISSUE

-->

## Purpose of the pull request

remove docusaurus-plugin-matomo and add custom Matomo tracking script

## What's changed?

before change:
Fesod website can't load the matomo.js
<img width="2246" height="1192" alt="image" src="https://github.com/user-attachments/assets/b703c8b0-582b-4a51-9da8-8c4c06cec4b4" />
<img width="1997" height="217" alt="image" src="https://github.com/user-attachments/assets/7a852ef0-1462-4b09-827b-9d3824de59d6" />

But it's fine in private mode
<img width="1902" height="1532" alt="image" src="https://github.com/user-attachments/assets/b45a6a4b-6177-45a4-8c61-c14146c039e7" />


Try to diff from Maven, fesod has additional setting as "setDoNotTrack"
<img width="1304" height="422" alt="image" src="https://github.com/user-attachments/assets/170b8b55-44ba-4b65-945a-1e7771323cc3" />
<img width="1204" height="544" alt="image" src="https://github.com/user-attachments/assets/ff541795-a9b8-4fd4-a060-7147f87f6ad7" />

So try to reset the tracking script without above tag.


## Checklist

- [X] I have read the [Contributor Guide](https://fesod.apache.org/community/contribution/).
- [ ] I have written the necessary doc or comment.
- [ ] I have added the necessary unit tests and all cases have passed.
