### PR TITLE
fix: Use SHA reference for Netlify action

### DIFF
--- a/.github/workflows/preview-docs.yml
+++ b/.github/workflows/preview-docs.yml
@@ -50,7 +50,7 @@ jobs:
         run: pnpm build
 
       - name: Deploy to Netlify
-        uses: nwtgck/actions-netlify@v3.0
+        uses: nwtgck/actions-netlify@4cbaf4c08f1a7bfa537d6113472ef4424e4eb654
         with:
           publish-dir: './website/build'
           production-deploy: false


### PR DESCRIPTION
<!--
Thanks very much for contributing to Apache Fesod (Incubating)! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

Closed: #ISSUE
Related: #ISSUE

-->

## Purpose of the pull request

<!-- Describe the purpose of this pull request. For example: Closed: #ISSUE-->
This PR uses SHA reference for Netlify action to comply with Apache Infrastructure policy.
Closed: #678 


## What's changed?

<!--- Describe the change below, including rationale and design decisions -->
This PR changed the Netlify action reference in `.github/workflows/preview-docs.yml` from version tag `@v3.0` to commit SHA `@4cbaf4c08f1a7bfa537d6113472ef4424e4eb654`.
Related: [comment](https://github.com/apache/fesod/issues/678#issuecomment-3498281624)


## Checklist

- [x] I have read the [Contributor Guide](https://fesod.apache.org/community/contribution/).
- [x] I have written the necessary doc or comment.
- [ ] I have added the necessary unit tests and all cases have passed.
