### PR TITLE
test(core): improve assertion usage for better clarity and order

### DIFF
--- a/fesod/src/test/java/org/apache/fesod/sheet/analysis/ExcelAnalyserOldBiffTest.java
+++ b/fesod/src/test/java/org/apache/fesod/sheet/analysis/ExcelAnalyserOldBiffTest.java
@@ -59,8 +59,9 @@ class ExcelAnalyserOldBiffTest {
         Assertions.assertEquals(
                 ExcelTypeEnum.XLS,
                 analyser.analysisContext().readWorkbookHolder().getExcelType());
-        Assertions.assertTrue(
-                analyser.excelExecutor() instanceof ExcelAnalyserImpl.NoopExcelReadExecutor,
+        Assertions.assertInstanceOf(
+                ExcelAnalyserImpl.NoopExcelReadExecutor.class,
+                analyser.excelExecutor(),
                 "Executor should be NoopExcelReadExecutor for old BIFF");
     }
 
@@ -84,8 +85,9 @@ class ExcelAnalyserOldBiffTest {
         Assertions.assertEquals(
                 ExcelTypeEnum.XLS,
                 analyser.analysisContext().readWorkbookHolder().getExcelType());
-        Assertions.assertTrue(
-                analyser.excelExecutor() instanceof ExcelAnalyserImpl.NoopExcelReadExecutor,
+        Assertions.assertInstanceOf(
+                ExcelAnalyserImpl.NoopExcelReadExecutor.class,
+                analyser.excelExecutor(),
                 "Executor should be NoopExcelReadExecutor for old BIFF");
     }
 }

--- a/fesod/src/test/java/org/apache/fesod/sheet/annotation/AnnotationDataListener.java
+++ b/fesod/src/test/java/org/apache/fesod/sheet/annotation/AnnotationDataListener.java
@@ -44,14 +44,14 @@ public class AnnotationDataListener extends AnalysisEventListener<AnnotationData
 
     @Override
     public void doAfterAllAnalysed(AnalysisContext context) {
-        Assertions.assertEquals(list.size(), 1);
+        Assertions.assertEquals(1, list.size());
         AnnotationData data = list.get(0);
         try {
             Assertions.assertEquals(data.getDate(), DateUtils.parseDate("2020-01-01 01:01:01"));
         } catch (ParseException e) {
             throw new ExcelCommonException("Test Exception", e);
         }
-        Assertions.assertEquals(data.getNumber(), 99.99, 0.00);
+        Assertions.assertEquals(99.99, data.getNumber(), 0.00);
         log.debug("First row:{}", JSON.toJSONString(list.get(0)));
     }
 }

--- a/fesod/src/test/java/org/apache/fesod/sheet/annotation/AnnotationIndexAndNameDataListener.java
+++ b/fesod/src/test/java/org/apache/fesod/sheet/annotation/AnnotationIndexAndNameDataListener.java
@@ -42,12 +42,12 @@ public class AnnotationIndexAndNameDataListener extends AnalysisEventListener<An
 
     @Override
     public void doAfterAllAnalysed(AnalysisContext context) {
-        Assertions.assertEquals(list.size(), 1);
+        Assertions.assertEquals(1, list.size());
         AnnotationIndexAndNameData data = list.get(0);
-        Assertions.assertEquals(data.getIndex0(), "第0个");
-        Assertions.assertEquals(data.getIndex1(), "第1个");
-        Assertions.assertEquals(data.getIndex2(), "第2个");
-        Assertions.assertEquals(data.getIndex4(), "第4个");
+        Assertions.assertEquals("第0个", data.getIndex0());
+        Assertions.assertEquals("第1个", data.getIndex1());
+        Assertions.assertEquals("第2个", data.getIndex2());
+        Assertions.assertEquals("第4个", data.getIndex4());
         log.debug("First row:{}", JSON.toJSONString(list.get(0)));
     }
 }

--- a/fesod/src/test/java/org/apache/fesod/sheet/bom/BomDataTest.java
+++ b/fesod/src/test/java/org/apache/fesod/sheet/bom/BomDataTest.java
@@ -96,7 +96,7 @@ public class BomDataTest {
 
                     @Override
                     public void doAfterAllAnalysed(AnalysisContext context) {
-                        Assertions.assertEquals(dataList.size(), 10);
+                        Assertions.assertEquals(10, dataList.size());
                         BomData bomData = dataList.get(0);
                         Assertions.assertEquals("姓名0", bomData.getName());
                         Assertions.assertEquals(20, (long) bomData.getAge());
@@ -125,7 +125,7 @@ public class BomDataTest {
 
                     @Override
                     public void doAfterAllAnalysed(AnalysisContext context) {
-                        Assertions.assertEquals(dataList.size(), 10);
+                        Assertions.assertEquals(10, dataList.size());
                         BomData bomData = dataList.get(0);
                         Assertions.assertEquals("姓名0", bomData.getName());
                         Assertions.assertEquals(20L, (long) bomData.getAge());

--- a/fesod/src/test/java/org/apache/fesod/sheet/celldata/CellDataDataListener.java
+++ b/fesod/src/test/java/org/apache/fesod/sheet/celldata/CellDataDataListener.java
@@ -43,15 +43,15 @@ public class CellDataDataListener extends AnalysisEventListener<CellDataReadData
 
     @Override
     public void doAfterAllAnalysed(AnalysisContext context) {
-        Assertions.assertEquals(list.size(), 1);
+        Assertions.assertEquals(1, list.size());
         CellDataReadData cellDataData = list.get(0);
 
         Assertions.assertEquals("2020年01月01日", cellDataData.getDate().getData());
-        Assertions.assertEquals((long) cellDataData.getInteger1().getData(), 2L);
-        Assertions.assertEquals((long) cellDataData.getInteger2(), 2L);
+        Assertions.assertEquals(2L, (long) cellDataData.getInteger1().getData());
+        Assertions.assertEquals(2L, (long) cellDataData.getInteger2());
         if (context.readWorkbookHolder().getExcelType() != ExcelTypeEnum.CSV) {
             Assertions.assertEquals(
-                    cellDataData.getFormulaValue().getFormulaData().getFormulaValue(), "B2+C2");
+                    "B2+C2", cellDataData.getFormulaValue().getFormulaData().getFormulaValue());
         } else {
             Assertions.assertNull(cellDataData.getFormulaValue().getData());
         }

--- a/fesod/src/test/java/org/apache/fesod/sheet/charset/CharsetDataTest.java
+++ b/fesod/src/test/java/org/apache/fesod/sheet/charset/CharsetDataTest.java
@@ -108,7 +108,7 @@ public class CharsetDataTest {
 
                     @Override
                     public void doAfterAllAnalysed(AnalysisContext context) {
-                        Assertions.assertEquals(dataList.size(), 10);
+                        Assertions.assertEquals(10, dataList.size());
                         CharsetData charsetData = dataList.get(0);
                         Assertions.assertEquals("姓名0", charsetData.getName());
                         Assertions.assertEquals(0, (long) charsetData.getAge());

--- a/fesod/src/test/java/org/apache/fesod/sheet/converter/ConverterDataListener.java
+++ b/fesod/src/test/java/org/apache/fesod/sheet/converter/ConverterDataListener.java
@@ -44,22 +44,22 @@ public class ConverterDataListener extends AnalysisEventListener<ConverterReadDa
 
     @Override
     public void doAfterAllAnalysed(AnalysisContext context) {
-        Assertions.assertEquals(list.size(), 1);
+        Assertions.assertEquals(1, list.size());
         ConverterReadData data = list.get(0);
         Assertions.assertEquals(TestUtil.TEST_DATE, data.getDate());
         Assertions.assertEquals(TestUtil.TEST_LOCAL_DATE, data.getLocalDate());
         Assertions.assertEquals(TestUtil.TEST_LOCAL_DATE_TIME, data.getLocalDateTime());
-        Assertions.assertEquals(data.getBooleanData(), Boolean.TRUE);
+        Assertions.assertEquals(Boolean.TRUE, data.getBooleanData());
         Assertions.assertEquals(data.getBigDecimal().doubleValue(), BigDecimal.ONE.doubleValue(), 0.0);
         Assertions.assertEquals(data.getBigInteger().intValue(), BigInteger.ONE.intValue(), 0.0);
-        Assertions.assertEquals((long) data.getLongData(), 1L);
-        Assertions.assertEquals((long) data.getIntegerData(), 1L);
-        Assertions.assertEquals((long) data.getShortData(), 1L);
-        Assertions.assertEquals((long) data.getByteData(), 1L);
-        Assertions.assertEquals(data.getDoubleData(), 1.0, 0.0);
-        Assertions.assertEquals(data.getFloatData(), (float) 1.0, 0.0);
-        Assertions.assertEquals(data.getString(), "测试");
-        Assertions.assertEquals(data.getCellData().getStringValue(), "自定义");
+        Assertions.assertEquals(1L, (long) data.getLongData());
+        Assertions.assertEquals(1L, (long) data.getIntegerData());
+        Assertions.assertEquals(1L, (long) data.getShortData());
+        Assertions.assertEquals(1L, (long) data.getByteData());
+        Assertions.assertEquals(1.0, data.getDoubleData(), 0.0);
+        Assertions.assertEquals((float) 1.0, data.getFloatData(), 0.0);
+        Assertions.assertEquals("测试", data.getString());
+        Assertions.assertEquals("自定义", data.getCellData().getStringValue());
         log.debug("First row:{}", JSON.toJSONString(list.get(0)));
     }
 }

--- a/fesod/src/test/java/org/apache/fesod/sheet/converter/ReadAllConverterDataListener.java
+++ b/fesod/src/test/java/org/apache/fesod/sheet/converter/ReadAllConverterDataListener.java
@@ -47,7 +47,7 @@ public class ReadAllConverterDataListener extends AnalysisEventListener<ReadAllC
 
     @Override
     public void doAfterAllAnalysed(AnalysisContext context) {
-        Assertions.assertEquals(list.size(), 1);
+        Assertions.assertEquals(1, list.size());
         ReadAllConverterData data = list.get(0);
         Assertions.assertEquals(data.getBigDecimalBoolean().doubleValue(), BigDecimal.ONE.doubleValue(), 0.0);
         Assertions.assertEquals(data.getBigDecimalNumber().doubleValue(), BigDecimal.ONE.doubleValue(), 0.0);
@@ -58,9 +58,9 @@ public class ReadAllConverterDataListener extends AnalysisEventListener<ReadAllC
         Assertions.assertTrue(data.getBooleanBoolean());
         Assertions.assertTrue(data.getBooleanNumber());
         Assertions.assertTrue(data.getBooleanString());
-        Assertions.assertEquals((long) data.getByteBoolean(), 1L);
-        Assertions.assertEquals((long) data.getByteNumber(), 1L);
-        Assertions.assertEquals((long) data.getByteString(), 1L);
+        Assertions.assertEquals(1L, (long) data.getByteBoolean());
+        Assertions.assertEquals(1L, (long) data.getByteNumber());
+        Assertions.assertEquals(1L, (long) data.getByteString());
         try {
             Assertions.assertEquals(data.getDateNumber(), DateUtils.parseDate("2020-01-01 01:01:01"));
             Assertions.assertEquals(data.getDateString(), DateUtils.parseDate("2020-01-01 01:01:01"));
@@ -71,32 +71,32 @@ public class ReadAllConverterDataListener extends AnalysisEventListener<ReadAllC
                 data.getLocalDateTimeNumber(), DateUtils.parseLocalDateTime("2020-01-01 01:01:01", null, null));
         Assertions.assertEquals(
                 data.getLocalDateTimeString(), DateUtils.parseLocalDateTime("2020-01-01 01:01:01", null, null));
-        Assertions.assertEquals(data.getDoubleBoolean(), 1.0, 0.0);
-        Assertions.assertEquals(data.getDoubleNumber(), 1.0, 0.0);
-        Assertions.assertEquals(data.getDoubleString(), 1.0, 0.0);
-        Assertions.assertEquals(data.getFloatBoolean(), (float) 1.0, 0.0);
-        Assertions.assertEquals(data.getFloatNumber(), (float) 1.0, 0.0);
-        Assertions.assertEquals(data.getFloatString(), (float) 1.0, 0.0);
-        Assertions.assertEquals((long) data.getIntegerBoolean(), 1L);
-        Assertions.assertEquals((long) data.getIntegerNumber(), 1L);
-        Assertions.assertEquals((long) data.getIntegerString(), 1L);
-        Assertions.assertEquals((long) data.getLongBoolean(), 1L);
-        Assertions.assertEquals((long) data.getLongNumber(), 1L);
-        Assertions.assertEquals((long) data.getLongString(), 1L);
-        Assertions.assertEquals((long) data.getShortBoolean(), 1L);
-        Assertions.assertEquals((long) data.getShortNumber(), 1L);
-        Assertions.assertEquals((long) data.getShortString(), 1L);
-        Assertions.assertEquals(data.getStringBoolean().toLowerCase(), "true");
-        Assertions.assertEquals(data.getStringString(), "测试");
-        Assertions.assertEquals(data.getStringError(), "#VALUE!");
+        Assertions.assertEquals(1.0, data.getDoubleBoolean(), 0.0);
+        Assertions.assertEquals(1.0, data.getDoubleNumber(), 0.0);
+        Assertions.assertEquals(1.0, data.getDoubleString(), 0.0);
+        Assertions.assertEquals((float) 1.0, data.getFloatBoolean(), 0.0);
+        Assertions.assertEquals((float) 1.0, data.getFloatNumber(), 0.0);
+        Assertions.assertEquals((float) 1.0, data.getFloatString(), 0.0);
+        Assertions.assertEquals(1L, (long) data.getIntegerBoolean());
+        Assertions.assertEquals(1L, (long) data.getIntegerNumber());
+        Assertions.assertEquals(1L, (long) data.getIntegerString());
+        Assertions.assertEquals(1L, (long) data.getLongBoolean());
+        Assertions.assertEquals(1L, (long) data.getLongNumber());
+        Assertions.assertEquals(1L, (long) data.getLongString());
+        Assertions.assertEquals(1L, (long) data.getShortBoolean());
+        Assertions.assertEquals(1L, (long) data.getShortNumber());
+        Assertions.assertEquals(1L, (long) data.getShortString());
+        Assertions.assertEquals("true", data.getStringBoolean().toLowerCase());
+        Assertions.assertEquals("测试", data.getStringString());
+        Assertions.assertEquals("#VALUE!", data.getStringError());
         if (context.readWorkbookHolder().getExcelType() != ExcelTypeEnum.CSV) {
             Assertions.assertEquals("2020-1-1 1:01", data.getStringNumberDate());
         } else {
             Assertions.assertEquals("2020-01-01 01:01:01", data.getStringNumberDate());
         }
         double doubleStringFormulaNumber = new BigDecimal(data.getStringFormulaNumber()).doubleValue();
-        Assertions.assertEquals(doubleStringFormulaNumber, 2.0, 0.0);
-        Assertions.assertEquals(data.getStringFormulaString(), "1测试");
+        Assertions.assertEquals(2.0, doubleStringFormulaNumber, 0.0);
+        Assertions.assertEquals("1测试", data.getStringFormulaString());
         log.debug("First row:{}", JSON.toJSONString(list.get(0)));
     }
 }

--- a/fesod/src/test/java/org/apache/fesod/sheet/encrypt/EncryptDataListener.java
+++ b/fesod/src/test/java/org/apache/fesod/sheet/encrypt/EncryptDataListener.java
@@ -42,17 +42,17 @@ public class EncryptDataListener extends AnalysisEventListener<EncryptData> {
 
     @Override
     public void doAfterAllAnalysed(AnalysisContext context) {
-        Assertions.assertEquals(list.size(), 10);
-        Assertions.assertEquals(list.get(0).getName(), "Name0");
-        Assertions.assertEquals((int) (context.readSheetHolder().getSheetNo()), 0);
+        Assertions.assertEquals(10, list.size());
+        Assertions.assertEquals("Name0", list.get(0).getName());
+        Assertions.assertEquals(0, (int) (context.readSheetHolder().getSheetNo()));
         Assertions.assertEquals(
+                "姓名",
                 context.readSheetHolder()
                         .getExcelReadHeadProperty()
                         .getHeadMap()
                         .get(0)
                         .getHeadNameList()
-                        .get(0),
-                "姓名");
+                        .get(0));
         log.debug("First row:{}", JSON.toJSONString(list.get(0)));
     }
 }

--- a/fesod/src/test/java/org/apache/fesod/sheet/exception/ExceptionDataListener.java
+++ b/fesod/src/test/java/org/apache/fesod/sheet/exception/ExceptionDataListener.java
@@ -54,17 +54,17 @@ public class ExceptionDataListener extends AnalysisEventListener<ExceptionData> 
 
     @Override
     public void doAfterAllAnalysed(AnalysisContext context) {
-        Assertions.assertEquals(list.size(), 8);
-        Assertions.assertEquals(list.get(0).getName(), "姓名0");
-        Assertions.assertEquals((int) (context.readSheetHolder().getSheetNo()), 0);
+        Assertions.assertEquals(8, list.size());
+        Assertions.assertEquals("姓名0", list.get(0).getName());
+        Assertions.assertEquals(0, (int) (context.readSheetHolder().getSheetNo()));
         Assertions.assertEquals(
+                "姓名",
                 context.readSheetHolder()
                         .getExcelReadHeadProperty()
                         .getHeadMap()
                         .get(0)
                         .getHeadNameList()
-                        .get(0),
-                "姓名");
+                        .get(0));
         log.debug("First row:{}", JSON.toJSONString(list.get(0)));
     }
 }

--- a/fesod/src/test/java/org/apache/fesod/sheet/fill/FillDataTest.java
+++ b/fesod/src/test/java/org/apache/fesod/sheet/fill/FillDataTest.java
@@ -209,7 +209,7 @@ public class FillDataTest {
         }
 
         List<Object> list = FastExcel.read(file).sheet().headRowNumber(0).doReadSync();
-        Assertions.assertEquals(list.size(), 5L);
+        Assertions.assertEquals(5L, list.size());
         Map<String, String> map0 = (Map<String, String>) list.get(0);
         Assertions.assertEquals("Zhang San", map0.get(2));
     }
@@ -230,7 +230,7 @@ public class FillDataTest {
             excelWriter.fill(map, writeSheet);
         }
         List<Object> list = FastExcel.read(file).sheet().headRowNumber(3).doReadSync();
-        Assertions.assertEquals(list.size(), 21L);
+        Assertions.assertEquals(21L, list.size());
         Map<String, String> map19 = (Map<String, String>) list.get(19);
         Assertions.assertEquals("Zhang San", map19.get(0));
     }

--- a/fesod/src/test/java/org/apache/fesod/sheet/fill/annotation/FillAnnotationDataTest.java
+++ b/fesod/src/test/java/org/apache/fesod/sheet/fill/annotation/FillAnnotationDataTest.java
@@ -110,7 +110,7 @@ public class FillAnnotationDataTest {
                 XSSFSheet xssfSheet = (XSSFSheet) sheet;
                 List<XSSFShape> shapeList = xssfSheet.getDrawingPatriarch().getShapes();
                 XSSFShape shape0 = shapeList.get(0);
-                Assertions.assertTrue(shape0 instanceof XSSFPicture);
+                Assertions.assertInstanceOf(XSSFPicture.class, shape0);
                 XSSFPicture picture0 = (XSSFPicture) shape0;
                 CTMarker ctMarker0 = picture0.getPreferredSize().getFrom();
                 Assertions.assertEquals(1, ctMarker0.getRow());
@@ -119,7 +119,7 @@ public class FillAnnotationDataTest {
                 HSSFSheet hssfSheet = (HSSFSheet) sheet;
                 List<HSSFShape> shapeList = hssfSheet.getDrawingPatriarch().getChildren();
                 HSSFShape shape0 = shapeList.get(0);
-                Assertions.assertTrue(shape0 instanceof HSSFPicture);
+                Assertions.assertInstanceOf(HSSFPicture.class, shape0);
                 HSSFPicture picture0 = (HSSFPicture) shape0;
                 HSSFClientAnchor anchor = (HSSFClientAnchor) picture0.getAnchor();
                 Assertions.assertEquals(1, anchor.getRow1());

--- a/fesod/src/test/java/org/apache/fesod/sheet/head/ComplexDataListener.java
+++ b/fesod/src/test/java/org/apache/fesod/sheet/head/ComplexDataListener.java
@@ -42,9 +42,9 @@ public class ComplexDataListener extends AnalysisEventListener<ComplexHeadData> 
 
     @Override
     public void doAfterAllAnalysed(AnalysisContext context) {
-        Assertions.assertEquals(list.size(), 1);
+        Assertions.assertEquals(1, list.size());
         ComplexHeadData data = list.get(0);
-        Assertions.assertEquals(data.getString4(), "字符串4");
+        Assertions.assertEquals("字符串4", data.getString4());
         log.debug("First row:{}", JSON.toJSONString(list.get(0)));
     }
 }

--- a/fesod/src/test/java/org/apache/fesod/sheet/head/ListHeadDataListener.java
+++ b/fesod/src/test/java/org/apache/fesod/sheet/head/ListHeadDataListener.java
@@ -53,7 +53,7 @@ public class ListHeadDataListener implements ReadListener<Map<Integer, String>> 
 
     @Override
     public void doAfterAllAnalysed(AnalysisContext context) {
-        Assertions.assertEquals(list.size(), 1);
+        Assertions.assertEquals(1, list.size());
         Map<Integer, String> data = list.get(0);
         Assertions.assertEquals("字符串0", data.get(0));
         Assertions.assertEquals("1", data.get(1));

--- a/fesod/src/test/java/org/apache/fesod/sheet/head/NoHeadDataListener.java
+++ b/fesod/src/test/java/org/apache/fesod/sheet/head/NoHeadDataListener.java
@@ -42,9 +42,9 @@ public class NoHeadDataListener extends AnalysisEventListener<NoHeadData> {
 
     @Override
     public void doAfterAllAnalysed(AnalysisContext context) {
-        Assertions.assertEquals(list.size(), 1);
+        Assertions.assertEquals(1, list.size());
         NoHeadData data = list.get(0);
-        Assertions.assertEquals(data.getString(), "字符串0");
+        Assertions.assertEquals("字符串0", data.getString());
         log.debug("First row:{}", JSON.toJSONString(list.get(0)));
     }
 }

--- a/fesod/src/test/java/org/apache/fesod/sheet/large/LargeDataListener.java
+++ b/fesod/src/test/java/org/apache/fesod/sheet/large/LargeDataListener.java
@@ -48,9 +48,9 @@ public class LargeDataListener extends AnalysisEventListener<LargeData> {
     public void doAfterAllAnalysed(AnalysisContext context) {
         log.info("Large row count:{}", count);
         if (context.readWorkbookHolder().getExcelType() != ExcelTypeEnum.CSV) {
-            Assertions.assertEquals(count, 464509);
+            Assertions.assertEquals(464509, count);
         } else {
-            Assertions.assertEquals(count, 499999);
+            Assertions.assertEquals(499999, count);
         }
     }
 }

--- a/fesod/src/test/java/org/apache/fesod/sheet/multiplesheets/MultipleSheetsListener.java
+++ b/fesod/src/test/java/org/apache/fesod/sheet/multiplesheets/MultipleSheetsListener.java
@@ -43,7 +43,7 @@ public class MultipleSheetsListener extends AnalysisEventListener<MultipleSheets
     @Override
     public void doAfterAllAnalysed(AnalysisContext context) {
         log.debug("A form is read finished.");
-        Assertions.assertEquals(list.get(0).getTitle(), "表1数据");
+        Assertions.assertEquals("表1数据", list.get(0).getTitle());
         log.debug("All row:{}", JSON.toJSONString(list));
     }
 

--- a/fesod/src/test/java/org/apache/fesod/sheet/noncamel/UnCamelDataListener.java
+++ b/fesod/src/test/java/org/apache/fesod/sheet/noncamel/UnCamelDataListener.java
@@ -38,12 +38,12 @@ public class UnCamelDataListener extends AnalysisEventListener<UnCamelData> {
     @Override
     public void invokeHeadMap(Map<Integer, String> headMap, AnalysisContext context) {
         log.debug("Head is:{}", JSON.toJSONString(headMap));
-        Assertions.assertEquals(headMap.get(0), "string1");
-        Assertions.assertEquals(headMap.get(1), "string2");
-        Assertions.assertEquals(headMap.get(2), "STring3");
-        Assertions.assertEquals(headMap.get(3), "STring4");
-        Assertions.assertEquals(headMap.get(4), "STRING5");
-        Assertions.assertEquals(headMap.get(5), "STRing6");
+        Assertions.assertEquals("string1", headMap.get(0));
+        Assertions.assertEquals("string2", headMap.get(1));
+        Assertions.assertEquals("STring3", headMap.get(2));
+        Assertions.assertEquals("STring4", headMap.get(3));
+        Assertions.assertEquals("STRING5", headMap.get(4));
+        Assertions.assertEquals("STRing6", headMap.get(5));
     }
 
     @Override
@@ -53,14 +53,14 @@ public class UnCamelDataListener extends AnalysisEventListener<UnCamelData> {
 
     @Override
     public void doAfterAllAnalysed(AnalysisContext context) {
-        Assertions.assertEquals(list.size(), 10);
+        Assertions.assertEquals(10, list.size());
         UnCamelData unCamelData = list.get(0);
-        Assertions.assertEquals(unCamelData.getString1(), "string1");
-        Assertions.assertEquals(unCamelData.getString2(), "string2");
-        Assertions.assertEquals(unCamelData.getSTring3(), "string3");
-        Assertions.assertEquals(unCamelData.getSTring4(), "string4");
-        Assertions.assertEquals(unCamelData.getSTRING5(), "string5");
-        Assertions.assertEquals(unCamelData.getSTRing6(), "string6");
+        Assertions.assertEquals("string1", unCamelData.getString1());
+        Assertions.assertEquals("string2", unCamelData.getString2());
+        Assertions.assertEquals("string3", unCamelData.getSTring3());
+        Assertions.assertEquals("string4", unCamelData.getSTring4());
+        Assertions.assertEquals("string5", unCamelData.getSTRING5());
+        Assertions.assertEquals("string6", unCamelData.getSTRing6());
         log.debug("First row:{}", JSON.toJSONString(list.get(0)));
     }
 }

--- a/fesod/src/test/java/org/apache/fesod/sheet/parameter/ParameterDataListener.java
+++ b/fesod/src/test/java/org/apache/fesod/sheet/parameter/ParameterDataListener.java
@@ -42,17 +42,17 @@ public class ParameterDataListener extends AnalysisEventListener<ParameterData> 
 
     @Override
     public void doAfterAllAnalysed(AnalysisContext context) {
-        Assertions.assertEquals(list.size(), 10);
-        Assertions.assertEquals(list.get(0).getName(), "姓名0");
-        Assertions.assertEquals((int) (context.readSheetHolder().getSheetNo()), 0);
+        Assertions.assertEquals(10, list.size());
+        Assertions.assertEquals("姓名0", list.get(0).getName());
+        Assertions.assertEquals(0, (int) (context.readSheetHolder().getSheetNo()));
         Assertions.assertEquals(
+                "姓名",
                 context.readSheetHolder()
                         .getExcelReadHeadProperty()
                         .getHeadMap()
                         .get(0)
                         .getHeadNameList()
-                        .get(0),
-                "姓名");
+                        .get(0));
         log.debug("First row:{}", JSON.toJSONString(list.get(0)));
     }
 }

--- a/fesod/src/test/java/org/apache/fesod/sheet/repetition/RepetitionDataListener.java
+++ b/fesod/src/test/java/org/apache/fesod/sheet/repetition/RepetitionDataListener.java
@@ -42,9 +42,9 @@ public class RepetitionDataListener extends AnalysisEventListener<RepetitionData
 
     @Override
     public void doAfterAllAnalysed(AnalysisContext context) {
-        Assertions.assertEquals(list.size(), 2);
-        Assertions.assertEquals(list.get(0).getString(), "字符串0");
-        Assertions.assertEquals(list.get(1).getString(), "字符串0");
+        Assertions.assertEquals(2, list.size());
+        Assertions.assertEquals("字符串0", list.get(0).getString());
+        Assertions.assertEquals("字符串0", list.get(1).getString());
         log.debug("First row:{}", JSON.toJSONString(list.get(0)));
     }
 }

--- a/fesod/src/test/java/org/apache/fesod/sheet/simple/SimpleDataListener.java
+++ b/fesod/src/test/java/org/apache/fesod/sheet/simple/SimpleDataListener.java
@@ -48,7 +48,7 @@ public class SimpleDataListener extends AnalysisEventListener<SimpleData> {
     @Override
     public void invokeHeadMap(Map<Integer, String> headMap, AnalysisContext context) {
         log.debug("Head is:{}", JSON.toJSONString(headMap));
-        Assertions.assertEquals(headMap.get(0), "姓名");
+        Assertions.assertEquals("姓名", headMap.get(0));
     }
 
     /**
@@ -74,17 +74,17 @@ public class SimpleDataListener extends AnalysisEventListener<SimpleData> {
     @Override
     public void doAfterAllAnalysed(AnalysisContext context) {
         // check the results
-        Assertions.assertEquals(list.size(), 10);
-        Assertions.assertEquals(list.get(0).getName(), "姓名0");
-        Assertions.assertEquals((int) (context.readSheetHolder().getSheetNo()), 0);
+        Assertions.assertEquals(10, list.size());
+        Assertions.assertEquals("姓名0", list.get(0).getName());
+        Assertions.assertEquals(0, (int) (context.readSheetHolder().getSheetNo()));
         Assertions.assertEquals(
+                "姓名",
                 context.readSheetHolder()
                         .getExcelReadHeadProperty()
                         .getHeadMap()
                         .get(0)
                         .getHeadNameList()
-                        .get(0),
-                "姓名");
+                        .get(0));
         log.debug("First row:{}", JSON.toJSONString(list.get(0)));
     }
 }

--- a/fesod/src/test/java/org/apache/fesod/sheet/simple/SimpleDataSheetNameListener.java
+++ b/fesod/src/test/java/org/apache/fesod/sheet/simple/SimpleDataSheetNameListener.java
@@ -41,8 +41,8 @@ public class SimpleDataSheetNameListener extends AnalysisEventListener<SimpleDat
 
     @Override
     public void doAfterAllAnalysed(AnalysisContext context) {
-        Assertions.assertEquals(list.size(), 1);
-        Assertions.assertEquals(list.get(0).getName(), "张三");
+        Assertions.assertEquals(1, list.size());
+        Assertions.assertEquals("张三", list.get(0).getName());
         log.debug("First row:{}", JSON.toJSONString(list.get(0)));
     }
 }

--- a/fesod/src/test/java/org/apache/fesod/sheet/simple/SimpleDataTest.java
+++ b/fesod/src/test/java/org/apache/fesod/sheet/simple/SimpleDataTest.java
@@ -207,9 +207,9 @@ public class SimpleDataTest {
     private void synchronousRead(File file) {
         // Synchronous read file
         List<Object> list = FastExcel.read(file).head(SimpleData.class).sheet().doReadSync();
-        Assertions.assertEquals(list.size(), 10);
-        Assertions.assertTrue(list.get(0) instanceof SimpleData);
-        Assertions.assertEquals(((SimpleData) list.get(0)).getName(), "姓名0");
+        Assertions.assertEquals(10, list.size());
+        Assertions.assertInstanceOf(SimpleData.class, list.get(0));
+        Assertions.assertEquals("姓名0", ((SimpleData) list.get(0)).getName());
     }
 
     /**

--- a/fesod/src/test/java/org/apache/fesod/sheet/sort/SortDataListener.java
+++ b/fesod/src/test/java/org/apache/fesod/sheet/sort/SortDataListener.java
@@ -41,7 +41,7 @@ public class SortDataListener extends AnalysisEventListener<SortData> {
 
     @Override
     public void doAfterAllAnalysed(AnalysisContext context) {
-        Assertions.assertEquals(list.size(), 1);
+        Assertions.assertEquals(1, list.size());
         SortData sortData = list.get(0);
         Assertions.assertEquals("column1", sortData.getColumn1());
         Assertions.assertEquals("column2", sortData.getColumn2());

--- a/fesod/src/test/java/org/apache/fesod/sheet/style/StyleDataListener.java
+++ b/fesod/src/test/java/org/apache/fesod/sheet/style/StyleDataListener.java
@@ -41,9 +41,9 @@ public class StyleDataListener extends AnalysisEventListener<StyleData> {
 
     @Override
     public void doAfterAllAnalysed(AnalysisContext context) {
-        Assertions.assertEquals(list.size(), 2);
-        Assertions.assertEquals(list.get(0).getString(), "字符串0");
-        Assertions.assertEquals(list.get(1).getString(), "字符串1");
+        Assertions.assertEquals(2, list.size());
+        Assertions.assertEquals("字符串0", list.get(0).getString());
+        Assertions.assertEquals("字符串1", list.get(1).getString());
         log.debug("First row:{}", JSON.toJSONString(list.get(0)));
     }
 }

--- a/fesod/src/test/java/org/apache/fesod/sheet/template/TemplateDataListener.java
+++ b/fesod/src/test/java/org/apache/fesod/sheet/template/TemplateDataListener.java
@@ -42,9 +42,9 @@ public class TemplateDataListener extends AnalysisEventListener<TemplateData> {
 
     @Override
     public void doAfterAllAnalysed(AnalysisContext context) {
-        Assertions.assertEquals(list.size(), 2);
-        Assertions.assertEquals(list.get(0).getString0(), "字符串0");
-        Assertions.assertEquals(list.get(1).getString0(), "字符串1");
+        Assertions.assertEquals(2, list.size());
+        Assertions.assertEquals("字符串0", list.get(0).getString0());
+        Assertions.assertEquals("字符串1", list.get(1).getString0());
         log.debug("First row:{}", JSON.toJSONString(list.get(0)));
     }
 }


### PR DESCRIPTION
## Changes

### Corrected assertion parameter order
Changed from assertEquals(actual, expected) to assertEquals(expected, actual)
Follows JUnit conventions where expected value comes first
Results in clearer failure messages: "Expected: X, but was: Y"