### PR TITLE
feat: Add workflow to automatically close stale issues

### DIFF
--- a/.github/workflows/issue-close-stale.yml
+++ b/.github/workflows/issue-close-stale.yml
@@ -1,0 +1,43 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+name: Close Stale Issues
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+
+permissions:
+  issues: write
+
+jobs:
+  stale:
+    if: (github.event_name == 'schedule' && github.repository == 'apache/fesod') || (github.event_name != 'schedule')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v10
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          only-issue-labels: 'waiting for feedback'
+          days-before-issue-stale: 30
+          days-before-issue-close: 7
+          stale-issue-message: 'This issue has been automatically marked as stale because it has not had recent activity for 30 days. It will be closed in next 7 days if no further activity occurs.'
+          close-issue-message: 'This issue has been closed because it has not received response for too long time. You could reopen it if you encountered similar problems in the future.'
+          stale-issue-label: 'stale'
+          days-before-pr-stale: -1
+          days-before-pr-close: -1


### PR DESCRIPTION
<!--
Thanks very much for contributing to Apache Fesod (Incubating)! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

Closed: #ISSUE
Related: #ISSUE

-->
Related: #681 

## Purpose of the pull request

<!-- Describe the purpose of this pull request. For example: Closed: #ISSUE-->
This PR adds an automated workflow to help maintain our issue tracker by closing issues that have been waiting for user feedback but haven't received any response. When maintainers are waiting for additional information from issue reporters, they can apply the `waiting for feedback` label. If the issue remains inactive for 30 days, the workflow will add a `stale` label and post a warning. If there's still no response after another 7 days, it automatically closes the issue with a message letting the user know they can reopen it if needed.

## What's changed?

<!--- Describe the change below, including rationale and design decisions -->
A new GitHub Actions workflow file `issue-close-stale.yml` has been added that runs daily to check for inactive issues. 

## Checklist

- [x] I have read the [Contributor Guide](https://fesod.apache.org/community/contribution/).
- [x] I have written the necessary doc or comment.
- [ ] I have added the necessary unit tests and all cases have passed.
