### PR TITLE
refactor: Replace FastExcel with FesodSheet in examples module

### DIFF
--- a/fesod-examples/src/test/java/org/apache/fesod/sheet/demo/fill/FillTest.java
+++ b/fesod-examples/src/test/java/org/apache/fesod/sheet/demo/fill/FillTest.java
@@ -25,7 +25,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.apache.fesod.sheet.ExcelWriter;
-import org.apache.fesod.sheet.FastExcel;
+import org.apache.fesod.sheet.FesodSheet;
 import org.apache.fesod.sheet.enums.WriteDirectionEnum;
 import org.apache.fesod.sheet.util.ListUtils;
 import org.apache.fesod.sheet.util.MapUtils;
@@ -63,7 +63,7 @@ public class FillTest {
         FillData fillData = new FillData();
         fillData.setName("Zhang San");
         fillData.setNumber(5.2);
-        FastExcel.write(fileName).withTemplate(templateFileName).sheet().doFill(fillData);
+        FesodSheet.write(fileName).withTemplate(templateFileName).sheet().doFill(fillData);
 
         // Option 2: Fill based on a Map
         fileName = TestFileUtil.getPath() + "simpleFill" + System.currentTimeMillis() + ".xlsx";
@@ -71,7 +71,7 @@ public class FillTest {
         Map<String, Object> map = MapUtils.newHashMap();
         map.put("name", "Zhang San");
         map.put("number", 5.2);
-        FastExcel.write(fileName).withTemplate(templateFileName).sheet().doFill(map);
+        FesodSheet.write(fileName).withTemplate(templateFileName).sheet().doFill(map);
     }
 
     /**
@@ -92,13 +92,13 @@ public class FillTest {
         // Option 1: Load all data into memory at once and fill
         String fileName = TestFileUtil.getPath() + "listFill" + System.currentTimeMillis() + ".xlsx";
         // This will fill the first sheet, and the file stream will be automatically closed.
-        FastExcel.write(fileName).withTemplate(templateFileName).sheet().doFill(data());
+        FesodSheet.write(fileName).withTemplate(templateFileName).sheet().doFill(data());
 
         // Option 2: Fill in multiple passes, using file caching (saves memory)
         fileName = TestFileUtil.getPath() + "listFill" + System.currentTimeMillis() + ".xlsx";
         try (ExcelWriter excelWriter =
-                FastExcel.write(fileName).withTemplate(templateFileName).build()) {
-            WriteSheet writeSheet = FastExcel.writerSheet().build();
+                FesodSheet.write(fileName).withTemplate(templateFileName).build()) {
+            WriteSheet writeSheet = FesodSheet.writerSheet().build();
             excelWriter.fill(data(), writeSheet);
             excelWriter.fill(data(), writeSheet);
         }
@@ -120,8 +120,8 @@ public class FillTest {
         String fileName = TestFileUtil.getPath() + "complexFill" + System.currentTimeMillis() + ".xlsx";
         // Option 1
         try (ExcelWriter excelWriter =
-                FastExcel.write(fileName).withTemplate(templateFileName).build()) {
-            WriteSheet writeSheet = FastExcel.writerSheet().build();
+                FesodSheet.write(fileName).withTemplate(templateFileName).build()) {
+            WriteSheet writeSheet = FesodSheet.writerSheet().build();
             // Note: The forceNewRow parameter is used here. When writing a list, it will always create a new row, and
             // the data below will be shifted down. Default is false, which will use the next row if available,
             // otherwise create a new one.
@@ -160,8 +160,8 @@ public class FillTest {
 
         // Option 1
         try (ExcelWriter excelWriter =
-                FastExcel.write(fileName).withTemplate(templateFileName).build()) {
-            WriteSheet writeSheet = FastExcel.writerSheet().build();
+                FesodSheet.write(fileName).withTemplate(templateFileName).build()) {
+            WriteSheet writeSheet = FesodSheet.writerSheet().build();
             // Directly write data
             excelWriter.fill(data(), writeSheet);
             excelWriter.fill(data(), writeSheet);
@@ -206,8 +206,8 @@ public class FillTest {
         String fileName = TestFileUtil.getPath() + "horizontalFill" + System.currentTimeMillis() + ".xlsx";
         // Option 1
         try (ExcelWriter excelWriter =
-                FastExcel.write(fileName).withTemplate(templateFileName).build()) {
-            WriteSheet writeSheet = FastExcel.writerSheet().build();
+                FesodSheet.write(fileName).withTemplate(templateFileName).build()) {
+            WriteSheet writeSheet = FesodSheet.writerSheet().build();
             FillConfig fillConfig = FillConfig.builder()
                     .direction(WriteDirectionEnum.HORIZONTAL)
                     .build();
@@ -238,8 +238,8 @@ public class FillTest {
 
         // Option 1
         try (ExcelWriter excelWriter =
-                FastExcel.write(fileName).withTemplate(templateFileName).build()) {
-            WriteSheet writeSheet = FastExcel.writerSheet().build();
+                FesodSheet.write(fileName).withTemplate(templateFileName).build()) {
+            WriteSheet writeSheet = FesodSheet.writerSheet().build();
             FillConfig fillConfig = FillConfig.builder()
                     .direction(WriteDirectionEnum.HORIZONTAL)
                     .build();
@@ -278,7 +278,7 @@ public class FillTest {
 
         // Fill the template with data.
         // The dates in the data will be formatted according to the template's settings.
-        FastExcel.write(fileName).withTemplate(templateFileName).sheet().doFill(data());
+        FesodSheet.write(fileName).withTemplate(templateFileName).sheet().doFill(data());
     }
 
     @Test
@@ -289,7 +289,7 @@ public class FillTest {
         FillData fillData = new FillData();
         fillData.setName("Zhang San");
         fillData.setNumber(5.2);
-        FastExcel.write(fileName)
+        FesodSheet.write(fileName)
                 .withTemplate(templateFileName)
                 .sheet()
                 .registerWriteHandler(new SheetWriteHandler() {

--- a/fesod-examples/src/test/java/org/apache/fesod/sheet/demo/rare/WriteTest.java
+++ b/fesod-examples/src/test/java/org/apache/fesod/sheet/demo/rare/WriteTest.java
@@ -24,7 +24,7 @@ import java.util.Date;
 import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.fesod.sheet.ExcelWriter;
-import org.apache.fesod.sheet.FastExcel;
+import org.apache.fesod.sheet.FesodSheet;
 import org.apache.fesod.sheet.demo.read.DemoData;
 import org.apache.fesod.sheet.util.FileUtils;
 import org.apache.fesod.sheet.util.ListUtils;
@@ -61,7 +61,7 @@ public class WriteTest {
         File file = TestFileUtil.createNewFile("rare/compressedTemporaryFile" + System.currentTimeMillis() + ".xlsx");
 
         // Specify which class to use for writing here
-        try (ExcelWriter excelWriter = FastExcel.write(file, DemoData.class)
+        try (ExcelWriter excelWriter = FesodSheet.write(file, DemoData.class)
                 .registerWriteHandler(new WorkbookWriteHandler() {
 
                     /**
@@ -83,7 +83,7 @@ public class WriteTest {
                 })
                 .build()) {
             // Note that the same sheet should only be created once
-            WriteSheet writeSheet = FastExcel.writerSheet("Template").build();
+            WriteSheet writeSheet = FesodSheet.writerSheet("Template").build();
             // 100,000 data entries to ensure sufficient space
             for (int i = 0; i < 10000; i++) {
                 // Query data from the database page by page. Here you can query data for each page from the database
@@ -107,7 +107,7 @@ public class WriteTest {
         // event
         // If it is after the last row, since there will be no more data afterwards, just intercept the
         // afterWorkbookDispose event and write the data when the Excel file is almost done
-        FastExcel.write(file, DemoData.class)
+        FesodSheet.write(file, DemoData.class)
                 // Writing value before the last row
                 .registerWriteHandler(new RowWriteHandler() {
                     @Override

--- a/fesod-examples/src/test/java/org/apache/fesod/sheet/demo/read/ReadTest.java
+++ b/fesod-examples/src/test/java/org/apache/fesod/sheet/demo/read/ReadTest.java
@@ -25,7 +25,7 @@ import java.util.List;
 import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.fesod.sheet.ExcelReader;
-import org.apache.fesod.sheet.FastExcel;
+import org.apache.fesod.sheet.FesodSheet;
 import org.apache.fesod.sheet.annotation.ExcelProperty;
 import org.apache.fesod.sheet.annotation.format.DateTimeFormat;
 import org.apache.fesod.sheet.annotation.format.NumberFormat;
@@ -55,7 +55,7 @@ public class ReadTest {
      * <p>
      * 1. Create an entity class corresponding to the Excel data structure. Refer to {@link DemoData}.
      * <p>
-     * 2. Since FastExcel reads Excel files row by row, you need to create a callback listener for each row. Refer to {@link DemoDataListener}.
+     * 2. Since Fesod reads Excel files row by row, you need to create a callback listener for each row. Refer to {@link DemoDataListener}.
      * <p>
      * 3. Directly read the file.
      */
@@ -67,7 +67,7 @@ public class ReadTest {
         // Specify the class to read the data, then read the first sheet. The file stream will be automatically closed.
         // By default, it reads 100 rows at a time. You can process the data directly.
         // The number of rows to read can be set in the constructor of `PageReadListener`.
-        FastExcel.read(fileName, DemoData.class, new PageReadListener<DemoData>(dataList -> {
+        FesodSheet.read(fileName, DemoData.class, new PageReadListener<DemoData>(dataList -> {
                     for (DemoData demoData : dataList) {
                         log.info("Reading a row of data: {}", JSON.toJSONString(demoData));
                     }
@@ -80,7 +80,7 @@ public class ReadTest {
         // Anonymous inner class, no need to create a separate DemoDataListener
         fileName = TestFileUtil.getPath() + "demo" + File.separator + "demo.xlsx";
         // Specify the class to read the data, then read the first sheet. The file stream will be automatically closed.
-        FastExcel.read(fileName, DemoData.class, new ReadListener<DemoData>() {
+        FesodSheet.read(fileName, DemoData.class, new ReadListener<DemoData>() {
                     /**
                      * Batch size for caching data
                      */
@@ -121,15 +121,17 @@ public class ReadTest {
         // Approach 3:
         fileName = TestFileUtil.getPath() + "demo" + File.separator + "demo.xlsx";
         // Specify the class to read the data, then read the first sheet. The file stream will be automatically closed.
-        FastExcel.read(fileName, DemoData.class, new DemoDataListener()).sheet().doRead();
+        FesodSheet.read(fileName, DemoData.class, new DemoDataListener())
+                .sheet()
+                .doRead();
 
         // Approach 4
         fileName = TestFileUtil.getPath() + "demo" + File.separator + "demo.xlsx";
         // One reader per file
-        try (ExcelReader excelReader =
-                FastExcel.read(fileName, DemoData.class, new DemoDataListener()).build()) {
+        try (ExcelReader excelReader = FesodSheet.read(fileName, DemoData.class, new DemoDataListener())
+                .build()) {
             // Build a sheet. You can specify the name or index.
-            ReadSheet readSheet = FastExcel.readSheet(0).build();
+            ReadSheet readSheet = FesodSheet.readSheet(0).build();
             readSheet.setNumRows(2);
             // Read a single sheet
             excelReader.read(readSheet);
@@ -141,7 +143,7 @@ public class ReadTest {
         String fileName = TestFileUtil.getPath() + "demo" + File.separator + "generic-demo.xlsx";
         // Simulate obtaining the Excel header's Class<?> object through any possible means
         Class<?> excelHeaderClass = DemoDataAnother.class;
-        FastExcel.read(fileName, excelHeaderClass, GenericHeaderTypeDataListener.build(excelHeaderClass))
+        FesodSheet.read(fileName, excelHeaderClass, GenericHeaderTypeDataListener.build(excelHeaderClass))
                 .sheet()
                 .doRead();
     }
@@ -151,7 +153,7 @@ public class ReadTest {
      * <p>
      * 1. Create an entity class corresponding to the Excel data structure and use the {@link ExcelProperty} annotation. Refer to {@link IndexOrNameData}.
      * <p>
-     * 2. Since FastExcel reads Excel files row by row, you need to create a callback listener for each row. Refer to {@link IndexOrNameDataListener}.
+     * 2. Since Fesod reads Excel files row by row, you need to create a callback listener for each row. Refer to {@link IndexOrNameDataListener}.
      * <p>
      * 3. Directly read the file.
      */
@@ -159,7 +161,7 @@ public class ReadTest {
     public void indexOrNameRead() {
         String fileName = TestFileUtil.getPath() + "demo" + File.separator + "demo.xlsx";
         // By default, read the first sheet
-        FastExcel.read(fileName, IndexOrNameData.class, new IndexOrNameDataListener())
+        FesodSheet.read(fileName, IndexOrNameData.class, new IndexOrNameDataListener())
                 .numRows(1)
                 .sheet()
                 .doRead();
@@ -170,7 +172,7 @@ public class ReadTest {
      * <p>
      * 1. Create an entity class corresponding to the Excel data structure. Refer to {@link DemoData}.
      * <p>
-     * 2. Since FastExcel reads Excel files row by row, you need to create a callback listener for each row. Refer to {@link DemoDataListener}.
+     * 2. Since Fesod reads Excel files row by row, you need to create a callback listener for each row. Refer to {@link DemoDataListener}.
      * <p>
      * 3. Directly read the file.
      */
@@ -180,20 +182,20 @@ public class ReadTest {
         // Read all sheets
         // Note: The `doAfterAllAnalysed` method of DemoDataListener will be called once after each sheet is read.
         // All sheets will write to the same DemoDataListener.
-        FastExcel.read(fileName, DemoData.class, new DemoDataListener()).doReadAll();
+        FesodSheet.read(fileName, DemoData.class, new DemoDataListener()).doReadAll();
 
         // Read some sheets
         fileName = TestFileUtil.getPath() + "demo" + File.separator + "demo.xlsx";
 
         // Method 1
-        try (ExcelReader excelReader = FastExcel.read(fileName).build()) {
+        try (ExcelReader excelReader = FesodSheet.read(fileName).build()) {
             // For simplicity, the same head and Listener are registered here.
             // In actual use, different Listeners must be used.
-            ReadSheet readSheet1 = FastExcel.readSheet(0)
+            ReadSheet readSheet1 = FesodSheet.readSheet(0)
                     .head(DemoData.class)
                     .registerReadListener(new DemoDataListener())
                     .build();
-            ReadSheet readSheet2 = FastExcel.readSheet(1)
+            ReadSheet readSheet2 = FesodSheet.readSheet(1)
                     .head(DemoData.class)
                     .registerReadListener(new DemoDataListener())
                     .build();
@@ -211,7 +213,7 @@ public class ReadTest {
      * 1. Create an entity class corresponding to the Excel data structure. Refer to {@link ConverterData}.
      * Annotations such as {@link DateTimeFormat}, {@link NumberFormat}, or custom annotations can be used.
      * <p>
-     * 2. Since FastExcel reads Excel files row by row, you need to create a callback listener for each row. Refer to {@link ConverterDataListener}.
+     * 2. Since Fesod reads Excel files row by row, you need to create a callback listener for each row. Refer to {@link ConverterDataListener}.
      * <p>
      * 3. Directly read the file.
      */
@@ -219,7 +221,7 @@ public class ReadTest {
     public void converterRead() {
         String fileName = TestFileUtil.getPath() + "demo" + File.separator + "demo.xlsx";
         // Specify the class to read, then read the first sheet
-        FastExcel.read(fileName, ConverterData.class, new ConverterDataListener())
+        FesodSheet.read(fileName, ConverterData.class, new ConverterDataListener())
                 // Note: We can also register a custom converter using `registerConverter`.
                 // However, this converter will be global, and all fields with Java type `String` and Excel type
                 // `String` will use this converter.
@@ -236,7 +238,7 @@ public class ReadTest {
      * <p>
      * 1. Create an entity class corresponding to the Excel data structure. Refer to {@link DemoData}.
      * <p>
-     * 2. Since FastExcel reads Excel files row by row, you need to create a callback listener for each row. Refer to {@link DemoDataListener}.
+     * 2. Since Fesod reads Excel files row by row, you need to create a callback listener for each row. Refer to {@link DemoDataListener}.
      * <p>
      * 3. Set the `headRowNumber` parameter, then read. Note that if `headRowNumber` is not specified,
      * the number of rows will be determined by the number of headers in the `@ExcelProperty#value()` of the class you provide.
@@ -246,7 +248,7 @@ public class ReadTest {
     public void complexHeaderRead() {
         String fileName = TestFileUtil.getPath() + "demo" + File.separator + "demo.xlsx";
         // Specify the class to read, then read the first sheet
-        FastExcel.read(fileName, DemoData.class, new DemoDataListener())
+        FesodSheet.read(fileName, DemoData.class, new DemoDataListener())
                 .sheet()
                 // Set to 1 here because the header is one row. For multi-row headers, set to other values.
                 // You can also omit this, as the default behavior will parse based on DemoData, which does not specify
@@ -265,7 +267,7 @@ public class ReadTest {
      * </p>
      *
      * <p>
-     * 2. Since FastExcel reads the Excel file row by row by default, you need to create a listener that handles each
+     * 2. Since Fesod reads the Excel file row by row by default, you need to create a listener that handles each
      * row's data accordingly. Refer to {@link DemoCompatibleHeaderDataListener} for implementation details. In this
      * listener, you should override the `invokeHead` method to transform the uploaded headers as needed.
      * </p>
@@ -278,7 +280,7 @@ public class ReadTest {
     public void compatibleHeaderRead() {
         String fileName = TestFileUtil.getPath() + "demo" + File.separator + "demo.xlsx";
         // Specify the class used for reading and choose to read the first sheet.
-        FastExcel.read(fileName, DemoCompatibleHeaderData.class, new DemoCompatibleHeaderDataListener())
+        FesodSheet.read(fileName, DemoCompatibleHeaderData.class, new DemoCompatibleHeaderDataListener())
                 .sheet()
                 .doRead();
     }
@@ -289,7 +291,7 @@ public class ReadTest {
      * <p>
      * 1. Create an entity object corresponding to the Excel data structure. Refer to {@link DemoData}.
      * <p>
-     * 2. Since FastExcel reads Excel files row by row, you need to create a callback listener for each row. Refer to {@link DemoHeadDataListener}.
+     * 2. Since Fesod reads Excel files row by row, you need to create a callback listener for each row. Refer to {@link DemoHeadDataListener}.
      * <p>
      * 3. Directly read the file.
      */
@@ -297,7 +299,7 @@ public class ReadTest {
     public void headerRead() {
         String fileName = TestFileUtil.getPath() + "demo" + File.separator + "demo.xlsx";
         // Specify the class to read, then read the first sheet
-        FastExcel.read(fileName, DemoData.class, new DemoHeadDataListener())
+        FesodSheet.read(fileName, DemoData.class, new DemoHeadDataListener())
                 .sheet()
                 .doRead();
     }
@@ -311,7 +313,7 @@ public class ReadTest {
      * <p>
      * 1. Create an entity object corresponding to the Excel data structure. Refer to {@link DemoExtraData}.
      * <p>
-     * 2. Since FastExcel reads Excel files row by row by default, you need to create a callback listener for each row. Refer to {@link DemoExtraListener}.
+     * 2. Since Fesod reads Excel files row by row by default, you need to create a callback listener for each row. Refer to {@link DemoExtraListener}.
      * <p>
      * 3. Directly read the file.
      *
@@ -321,7 +323,7 @@ public class ReadTest {
     public void extraRead() {
         String fileName = TestFileUtil.getPath() + "demo" + File.separator + "extra.xlsx";
         // Specify the class to read, then read the first sheet
-        FastExcel.read(fileName, DemoExtraData.class, new DemoExtraListener())
+        FesodSheet.read(fileName, DemoExtraData.class, new DemoExtraListener())
                 // Read comments (default is not to read)
                 .extraRead(CellExtraTypeEnum.COMMENT)
                 // Read hyperlinks (default is not to read)
@@ -338,7 +340,7 @@ public class ReadTest {
      * <p>
      * 1. Create an entity object corresponding to the Excel data structure. Refer to {@link CellDataReadDemoData}.
      * <p>
-     * 2. Since FastExcel reads Excel files row by row by default, you need to create a callback listener for each row. Refer to {@link CellDataDemoHeadDataListener}.
+     * 2. Since Fesod reads Excel files row by row by default, you need to create a callback listener for each row. Refer to {@link CellDataDemoHeadDataListener}.
      * <p>
      * 3. Directly read the file.
      *
@@ -348,7 +350,7 @@ public class ReadTest {
     public void cellDataRead() {
         String fileName = TestFileUtil.getPath() + "demo" + File.separator + "cellDataDemo.xlsx";
         // Specify the class to read, then read the first sheet
-        FastExcel.read(fileName, CellDataReadDemoData.class, new CellDataDemoHeadDataListener())
+        FesodSheet.read(fileName, CellDataReadDemoData.class, new CellDataDemoHeadDataListener())
                 .sheet()
                 .doRead();
     }
@@ -359,7 +361,7 @@ public class ReadTest {
      * <p>
      * 1. Create an entity object corresponding to the Excel data structure. Refer to {@link ExceptionDemoData}.
      * <p>
-     * 2. Since FastExcel reads Excel files row by row by default, you need to create a callback listener for each row. Refer to {@link DemoExceptionListener}.
+     * 2. Since Fesod reads Excel files row by row by default, you need to create a callback listener for each row. Refer to {@link DemoExceptionListener}.
      * <p>
      * 3. Directly read the file.
      */
@@ -367,7 +369,7 @@ public class ReadTest {
     public void exceptionRead() {
         String fileName = TestFileUtil.getPath() + "demo" + File.separator + "demo.xlsx";
         // Specify the class to read, then read the first sheet
-        FastExcel.read(fileName, ExceptionDemoData.class, new DemoExceptionListener())
+        FesodSheet.read(fileName, ExceptionDemoData.class, new DemoExceptionListener())
                 .sheet()
                 .doRead();
     }
@@ -380,14 +382,14 @@ public class ReadTest {
         String fileName = TestFileUtil.getPath() + "demo" + File.separator + "demo.xlsx";
         // Specify the class to read, then read the first sheet. Synchronous reading will automatically finish.
         List<DemoData> list =
-                FastExcel.read(fileName).head(DemoData.class).sheet().doReadSync();
+                FesodSheet.read(fileName).head(DemoData.class).sheet().doReadSync();
         for (DemoData data : list) {
             log.info("Read data:{}", JSON.toJSONString(data));
         }
 
         // Alternatively, you can read without specifying a class, returning a list, then read the first sheet.
         // Synchronous reading will automatically finish.
-        List<Map<Integer, String>> listMap = FastExcel.read(fileName).sheet().doReadSync();
+        List<Map<Integer, String>> listMap = FesodSheet.read(fileName).sheet().doReadSync();
         for (Map<Integer, String> data : listMap) {
             // Return key-value pairs for each data item, representing the column index and its value.
             log.info("Read data:{}", JSON.toJSONString(data));
@@ -401,7 +403,7 @@ public class ReadTest {
     public void noModelRead() {
         String fileName = TestFileUtil.getPath() + "demo" + File.separator + "demo.xlsx";
         // Simply read the first sheet. Synchronous reading will automatically finish.
-        FastExcel.read(fileName, new NoModelDataListener()).sheet().doRead();
+        FesodSheet.read(fileName, new NoModelDataListener()).sheet().doRead();
     }
 
     /**
@@ -413,7 +415,7 @@ public class ReadTest {
         @Test
         void asNormalJavaBean() {
             String fileName = TestFileUtil.getPath() + "demo" + File.separator + "demo.csv";
-            try (ExcelReader excelReader = FastExcel.read(fileName, DemoData.class, new DemoDataListener())
+            try (ExcelReader excelReader = FesodSheet.read(fileName, DemoData.class, new DemoDataListener())
                     .build()) {
                 // Check if it is a CSV file
                 if (excelReader.analysisContext().readWorkbookHolder() instanceof CsvReadWorkbookHolder) {
@@ -428,7 +430,7 @@ public class ReadTest {
                 // Get all sheets
                 List<ReadSheet> readSheetList = excelReader.excelExecutor().sheetList();
                 // If you only want to read the first sheet, you can pass the parameter accordingly.
-                // ReadSheet readSheet = FastExcel.readSheet(0).build();
+                // ReadSheet readSheet = FesodSheet.readSheet(0).build();
                 excelReader.read(readSheetList);
             }
         }
@@ -436,7 +438,7 @@ public class ReadTest {
         @Test
         void asChainedAccessorsJavaBean() {
             String fileName = TestFileUtil.getPath() + "demo" + File.separator + "demo.csv";
-            try (ExcelReader excelReader = FastExcel.read(
+            try (ExcelReader excelReader = FesodSheet.read(
                             fileName, DemoChainAccessorsData.class, new ReadListener<DemoChainAccessorsData>() {
                                 @Override
                                 public void invoke(DemoChainAccessorsData data, AnalysisContext context) {

--- a/fesod-examples/src/test/java/org/apache/fesod/sheet/demo/web/FesodApplication.java
+++ b/fesod-examples/src/test/java/org/apache/fesod/sheet/demo/web/FesodApplication.java
@@ -23,9 +23,9 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
 @SpringBootApplication
-public class FastExcelApplication {
+public class FesodApplication {
 
     public static void main(String[] args) {
-        SpringApplication.run(FastExcelApplication.class, args);
+        SpringApplication.run(FesodApplication.class, args);
     }
 }

--- a/fesod-examples/src/test/java/org/apache/fesod/sheet/demo/web/WebTest.java
+++ b/fesod-examples/src/test/java/org/apache/fesod/sheet/demo/web/WebTest.java
@@ -26,7 +26,7 @@ import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import javax.servlet.http.HttpServletResponse;
-import org.apache.fesod.sheet.FastExcel;
+import org.apache.fesod.sheet.FesodSheet;
 import org.apache.fesod.sheet.util.ListUtils;
 import org.apache.fesod.sheet.util.MapUtils;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -62,11 +62,11 @@ public class WebTest {
         // Postman
         response.setContentType("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet");
         response.setCharacterEncoding("utf-8");
-        // Here URLEncoder.encode can prevent Chinese character encoding issues, which is unrelated to FastExcel
+        // Here URLEncoder.encode can prevent Chinese character encoding issues, which is unrelated to Fesod
         String fileName = URLEncoder.encode("test", "UTF-8").replaceAll("\\+", "%20");
         response.setHeader("Content-disposition", "attachment;filename*=utf-8''" + fileName + ".xlsx");
 
-        FastExcel.write(response.getOutputStream(), DownloadData.class)
+        FesodSheet.write(response.getOutputStream(), DownloadData.class)
                 .sheet("Template")
                 .doWrite(data());
     }
@@ -83,11 +83,11 @@ public class WebTest {
         try {
             response.setContentType("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet");
             response.setCharacterEncoding("utf-8");
-            // Here URLEncoder.encode can prevent Chinese character encoding issues, which is unrelated to FastExcel
+            // Here URLEncoder.encode can prevent Chinese character encoding issues, which is unrelated to Fesod
             String fileName = URLEncoder.encode("test", "UTF-8").replaceAll("\\+", "%20");
             response.setHeader("Content-disposition", "attachment;filename*=utf-8''" + fileName + ".xlsx");
             // Here we need to set not to close the stream
-            FastExcel.write(response.getOutputStream(), DownloadData.class)
+            FesodSheet.write(response.getOutputStream(), DownloadData.class)
                     .autoCloseStream(Boolean.FALSE)
                     .sheet("Template")
                     .doWrite(data());
@@ -115,7 +115,7 @@ public class WebTest {
     @PostMapping("upload")
     @ResponseBody
     public String upload(MultipartFile file) throws IOException {
-        FastExcel.read(file.getInputStream(), UploadData.class, new UploadDataListener(uploadDAO))
+        FesodSheet.read(file.getInputStream(), UploadData.class, new UploadDataListener(uploadDAO))
                 .sheet()
                 .doRead();
         return "success";

--- a/fesod-examples/src/test/java/org/apache/fesod/sheet/demo/write/EscapeHexCellWriteHandlerTest.java
+++ b/fesod-examples/src/test/java/org/apache/fesod/sheet/demo/write/EscapeHexCellWriteHandlerTest.java
@@ -26,7 +26,7 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
-import org.apache.fesod.sheet.FastExcel;
+import org.apache.fesod.sheet.FesodSheet;
 import org.apache.fesod.sheet.support.ExcelTypeEnum;
 import org.apache.fesod.sheet.write.handler.EscapeHexCellWriteHandler;
 import org.apache.poi.ss.usermodel.Cell;
@@ -57,7 +57,7 @@ public class EscapeHexCellWriteHandlerTest {
         list.add(createDemoData("_xB9f0_"));
 
         File file = tempDir.resolve("testEscapeHex.xlsx").toFile();
-        FastExcel.write(file, DemoData.class)
+        FesodSheet.write(file, DemoData.class)
                 .registerWriteHandler(new EscapeHexCellWriteHandler())
                 .sheet("TestSheet")
                 .doWrite(list);
@@ -79,7 +79,7 @@ public class EscapeHexCellWriteHandlerTest {
         list.add(createDemoData("_xB9f0_"));
 
         File file = tempDir.resolve("testEscapeHex.xls").toFile();
-        FastExcel.write(file, DemoData.class)
+        FesodSheet.write(file, DemoData.class)
                 .excelType(ExcelTypeEnum.XLS)
                 .registerWriteHandler(new EscapeHexCellWriteHandler())
                 .sheet("TestSheet")
@@ -101,7 +101,7 @@ public class EscapeHexCellWriteHandlerTest {
         list.add(createDemoData("_xB9f0_"));
 
         File file = tempDir.resolve("testEscapeHex.csv").toFile();
-        FastExcel.write(file, DemoData.class)
+        FesodSheet.write(file, DemoData.class)
                 .excelType(ExcelTypeEnum.CSV)
                 .registerWriteHandler(new EscapeHexCellWriteHandler())
                 .sheet("TestSheet")
@@ -124,7 +124,7 @@ public class EscapeHexCellWriteHandlerTest {
         list.add(createDemoData("_xB9f0_ and _x1234_ and _xABCD_"));
 
         File file = tempDir.resolve("testMultipleHex.xlsx").toFile();
-        FastExcel.write(file, DemoData.class)
+        FesodSheet.write(file, DemoData.class)
                 .registerWriteHandler(new EscapeHexCellWriteHandler())
                 .sheet("TestSheet")
                 .doWrite(list);
@@ -144,7 +144,7 @@ public class EscapeHexCellWriteHandlerTest {
         list.add(createDemoData("normalString"));
 
         File file = tempDir.resolve("testNoHex.xlsx").toFile();
-        FastExcel.write(file, DemoData.class)
+        FesodSheet.write(file, DemoData.class)
                 .registerWriteHandler(new EscapeHexCellWriteHandler())
                 .sheet("TestSheet")
                 .doWrite(list);
@@ -163,7 +163,7 @@ public class EscapeHexCellWriteHandlerTest {
         list.add(createDemoData("_x123_ _xABC_ _x12345_")); // Invalid patterns
 
         File file = tempDir.resolve("testPartialHex.xlsx").toFile();
-        FastExcel.write(file, DemoData.class)
+        FesodSheet.write(file, DemoData.class)
                 .registerWriteHandler(new EscapeHexCellWriteHandler())
                 .sheet("TestSheet")
                 .doWrite(list);
@@ -183,7 +183,7 @@ public class EscapeHexCellWriteHandlerTest {
         list.add(createDemoData("_x1234_ _x123_ _xABCD_ _xGHIJ_"));
 
         File file = tempDir.resolve("testMixedHex.xlsx").toFile();
-        FastExcel.write(file, DemoData.class)
+        FesodSheet.write(file, DemoData.class)
                 .registerWriteHandler(new EscapeHexCellWriteHandler())
                 .sheet("TestSheet")
                 .doWrite(list);
@@ -206,7 +206,7 @@ public class EscapeHexCellWriteHandlerTest {
         list.add(data2);
 
         File file = tempDir.resolve("testEmptyNull.xlsx").toFile();
-        FastExcel.write(file, DemoData.class)
+        FesodSheet.write(file, DemoData.class)
                 .registerWriteHandler(new EscapeHexCellWriteHandler())
                 .sheet("TestSheet")
                 .doWrite(list);
@@ -234,7 +234,7 @@ public class EscapeHexCellWriteHandlerTest {
         list.add(createDemoData("_x1a2B_ _XC3d4_ _x9F8e_"));
 
         File file = tempDir.resolve("testCaseInsensitive.xlsx").toFile();
-        FastExcel.write(file, DemoData.class)
+        FesodSheet.write(file, DemoData.class)
                 .registerWriteHandler(new EscapeHexCellWriteHandler())
                 .sheet("TestSheet")
                 .doWrite(list);
@@ -256,14 +256,14 @@ public class EscapeHexCellWriteHandlerTest {
 
         // Test xlsx
         File xlsxFile = tempDir.resolve("testFormats.xlsx").toFile();
-        FastExcel.write(xlsxFile, DemoData.class)
+        FesodSheet.write(xlsxFile, DemoData.class)
                 .registerWriteHandler(new EscapeHexCellWriteHandler())
                 .sheet("TestSheet")
                 .doWrite(list);
 
         // Test xls
         File xlsFile = tempDir.resolve("testFormats.xls").toFile();
-        FastExcel.write(xlsFile, DemoData.class)
+        FesodSheet.write(xlsFile, DemoData.class)
                 .excelType(ExcelTypeEnum.XLS)
                 .registerWriteHandler(new EscapeHexCellWriteHandler())
                 .sheet("TestSheet")
@@ -271,7 +271,7 @@ public class EscapeHexCellWriteHandlerTest {
 
         // Test csv
         File csvFile = tempDir.resolve("testFormats.csv").toFile();
-        FastExcel.write(csvFile, DemoData.class)
+        FesodSheet.write(csvFile, DemoData.class)
                 .excelType(ExcelTypeEnum.CSV)
                 .registerWriteHandler(new EscapeHexCellWriteHandler())
                 .sheet("TestSheet")

--- a/fesod-examples/src/test/java/org/apache/fesod/sheet/demo/write/WriteTest.java
+++ b/fesod-examples/src/test/java/org/apache/fesod/sheet/demo/write/WriteTest.java
@@ -28,7 +28,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import org.apache.fesod.sheet.ExcelWriter;
-import org.apache.fesod.sheet.FastExcel;
+import org.apache.fesod.sheet.FesodSheet;
 import org.apache.fesod.sheet.annotation.ExcelProperty;
 import org.apache.fesod.sheet.annotation.format.DateTimeFormat;
 import org.apache.fesod.sheet.annotation.format.NumberFormat;
@@ -91,7 +91,7 @@ public class WriteTest {
         String fileName = TestFileUtil.getPath() + "simpleWrite" + System.currentTimeMillis() + ".xlsx";
         // 这里 需要指定写用哪个class去写，然后写到第一个sheet，名字为模板 然后文件流会自动关闭
         // 如果这里想使用03 则 传入excelType参数即可
-        FastExcel.write(fileName, DemoData.class).sheet("模板").doWrite(() -> {
+        FesodSheet.write(fileName, DemoData.class).sheet("模板").doWrite(() -> {
             // 分页查询数据
             return data();
         });
@@ -100,13 +100,14 @@ public class WriteTest {
         fileName = TestFileUtil.getPath() + "simpleWrite" + System.currentTimeMillis() + ".xlsx";
         // 这里 需要指定写用哪个class去写，然后写到第一个sheet，名字为模板 然后文件流会自动关闭
         // 如果这里想使用03 则 传入excelType参数即可
-        FastExcel.write(fileName, DemoData.class).sheet("模板").doWrite(data());
+        FesodSheet.write(fileName, DemoData.class).sheet("模板").doWrite(data());
 
         // 写法3
         fileName = TestFileUtil.getPath() + "simpleWrite" + System.currentTimeMillis() + ".xlsx";
         // 这里 需要指定写用哪个class去写
-        try (ExcelWriter excelWriter = FastExcel.write(fileName, DemoData.class).build()) {
-            WriteSheet writeSheet = FastExcel.writerSheet("模板").build();
+        try (ExcelWriter excelWriter =
+                FesodSheet.write(fileName, DemoData.class).build()) {
+            WriteSheet writeSheet = FesodSheet.writerSheet("模板").build();
             excelWriter.write(data(), writeSheet);
         }
     }
@@ -114,7 +115,7 @@ public class WriteTest {
     @Test
     public void testEscapeHex() {
         String fileName = TestFileUtil.getPath() + "simpleWrite" + System.currentTimeMillis() + ".xlsx";
-        FastExcel.write(fileName, DemoData.class)
+        FesodSheet.write(fileName, DemoData.class)
                 .sheet("template")
                 .registerWriteHandler(new EscapeHexCellWriteHandler())
                 .doWrite(() -> {
@@ -142,7 +143,7 @@ public class WriteTest {
         Set<String> excludeColumnFieldNames = new HashSet<>();
         excludeColumnFieldNames.add("date");
         // 这里 需要指定写用哪个class去写，然后写到第一个sheet，名字为模板 然后文件流会自动关闭
-        FastExcel.write(fileName, DemoData.class)
+        FesodSheet.write(fileName, DemoData.class)
                 .excludeColumnFieldNames(excludeColumnFieldNames)
                 .sheet("模板")
                 .doWrite(data());
@@ -152,7 +153,7 @@ public class WriteTest {
         Set<String> includeColumnFieldNames = new HashSet<>();
         includeColumnFieldNames.add("date");
         // 这里 需要指定写用哪个class去写，然后写到第一个sheet，名字为模板 然后文件流会自动关闭
-        FastExcel.write(fileName, DemoData.class)
+        FesodSheet.write(fileName, DemoData.class)
                 .includeColumnFieldNames(includeColumnFieldNames)
                 .sheet("模板")
                 .doWrite(data());
@@ -171,7 +172,7 @@ public class WriteTest {
     public void indexWrite() {
         String fileName = TestFileUtil.getPath() + "indexWrite" + System.currentTimeMillis() + ".xlsx";
         // 这里 需要指定写用哪个class去写，然后写到第一个sheet，名字为模板 然后文件流会自动关闭
-        FastExcel.write(fileName, IndexData.class).sheet("模板").doWrite(data());
+        FesodSheet.write(fileName, IndexData.class).sheet("模板").doWrite(data());
     }
 
     /**
@@ -187,7 +188,7 @@ public class WriteTest {
     public void complexHeadWrite() {
         String fileName = TestFileUtil.getPath() + "complexHeadWrite" + System.currentTimeMillis() + ".xlsx";
         // 这里 需要指定写用哪个class去写，然后写到第一个sheet，名字为模板 然后文件流会自动关闭
-        FastExcel.write(fileName, ComplexHeadData.class).sheet("模板").doWrite(data());
+        FesodSheet.write(fileName, ComplexHeadData.class).sheet("模板").doWrite(data());
     }
 
     /**
@@ -204,9 +205,10 @@ public class WriteTest {
         // 方法1: 如果写到同一个sheet
         String fileName = TestFileUtil.getPath() + "repeatedWrite" + System.currentTimeMillis() + ".xlsx";
         // 这里 需要指定写用哪个class去写
-        try (ExcelWriter excelWriter = FastExcel.write(fileName, DemoData.class).build()) {
+        try (ExcelWriter excelWriter =
+                FesodSheet.write(fileName, DemoData.class).build()) {
             // 这里注意 如果同一个sheet只要创建一次
-            WriteSheet writeSheet = FastExcel.writerSheet("模板").build();
+            WriteSheet writeSheet = FesodSheet.writerSheet("模板").build();
             // 去调用写入,这里我调用了五次，实际使用时根据数据库分页的总的页数来
             for (int i = 0; i < 5; i++) {
                 // 分页去数据库查询数据 这里可以去数据库查询每一页的数据
@@ -218,11 +220,12 @@ public class WriteTest {
         // 方法2: 如果写到不同的sheet 同一个对象
         fileName = TestFileUtil.getPath() + "repeatedWrite" + System.currentTimeMillis() + ".xlsx";
         // 这里 指定文件
-        try (ExcelWriter excelWriter = FastExcel.write(fileName, DemoData.class).build()) {
+        try (ExcelWriter excelWriter =
+                FesodSheet.write(fileName, DemoData.class).build()) {
             // 去调用写入,这里我调用了五次，实际使用时根据数据库分页的总的页数来。这里最终会写到5个sheet里面
             for (int i = 0; i < 5; i++) {
                 // 每次都要创建writeSheet 这里注意必须指定sheetNo 而且sheetName必须不一样
-                WriteSheet writeSheet = FastExcel.writerSheet(i, "模板" + i).build();
+                WriteSheet writeSheet = FesodSheet.writerSheet(i, "模板" + i).build();
                 // 分页去数据库查询数据 这里可以去数据库查询每一页的数据
                 List<DemoData> data = data();
                 excelWriter.write(data, writeSheet);
@@ -232,13 +235,13 @@ public class WriteTest {
         // 方法3 如果写到不同的sheet 不同的对象
         fileName = TestFileUtil.getPath() + "repeatedWrite" + System.currentTimeMillis() + ".xlsx";
         // 这里 指定文件
-        try (ExcelWriter excelWriter = FastExcel.write(fileName).build()) {
+        try (ExcelWriter excelWriter = FesodSheet.write(fileName).build()) {
             // 去调用写入,这里我调用了五次，实际使用时根据数据库分页的总的页数来。这里最终会写到5个sheet里面
             for (int i = 0; i < 5; i++) {
                 // 每次都要创建writeSheet 这里注意必须指定sheetNo 而且sheetName必须不一样。这里注意DemoData.class 可以每次都变，我这里为了方便 所以用的同一个class
                 // 实际上可以一直变
                 WriteSheet writeSheet =
-                        FastExcel.writerSheet(i, "模板" + i).head(DemoData.class).build();
+                        FesodSheet.writerSheet(i, "模板" + i).head(DemoData.class).build();
                 // 分页去数据库查询数据 这里可以去数据库查询每一页的数据
                 List<DemoData> data = data();
                 excelWriter.write(data, writeSheet);
@@ -259,7 +262,7 @@ public class WriteTest {
     public void converterWrite() {
         String fileName = TestFileUtil.getPath() + "converterWrite" + System.currentTimeMillis() + ".xlsx";
         // 这里 需要指定写用哪个class去写，然后写到第一个sheet，名字为模板 然后文件流会自动关闭
-        FastExcel.write(fileName, ConverterData.class).sheet("模板").doWrite(data());
+        FesodSheet.write(fileName, ConverterData.class).sheet("模板").doWrite(data());
     }
 
     /**
@@ -337,10 +340,10 @@ public class WriteTest {
             imageData.setRelativeLastColumnIndex(1);
 
             // 写入数据
-            FastExcel.write(fileName, ImageDemoData.class).sheet().doWrite(list);
+            FesodSheet.write(fileName, ImageDemoData.class).sheet().doWrite(list);
             // 如果图片资源不可访问，XLSX格式会报错 SXSSFWorkbook - Failed to dispose sheet
             // 也可以考虑声明为XLS格式
-            // FastExcel.write(fileName, ImageDemoData.class).excelType(ExcelTypeEnum.XLS).sheet().doWrite(list);
+            // FesodSheet.write(fileName, ImageDemoData.class).excelType(ExcelTypeEnum.XLS).sheet().doWrite(list);
         }
     }
 
@@ -416,7 +419,7 @@ public class WriteTest {
 
         List<WriteCellDemoData> data = new ArrayList<>();
         data.add(writeCellDemoData);
-        FastExcel.write(fileName, WriteCellDemoData.class)
+        FesodSheet.write(fileName, WriteCellDemoData.class)
                 .inMemory(true)
                 .sheet("模板")
                 .doWrite(data);
@@ -440,7 +443,7 @@ public class WriteTest {
         // 这里 需要指定写用哪个class去写，然后写到第一个sheet，名字为模板 然后文件流会自动关闭
         // 这里要注意 withTemplate 的模板文件会全量存储在内存里面，所以尽量不要用于追加文件，如果文件模板文件过大会OOM
         // 如果要再文件中追加（无法在一个线程里面处理，可以在一个线程的建议参照多次写入的demo） 建议临时存储到数据库 或者 磁盘缓存(ehcache) 然后再一次性写入
-        FastExcel.write(fileName, DemoData.class)
+        FesodSheet.write(fileName, DemoData.class)
                 .withTemplate(templateFileName)
                 .sheet()
                 .doWrite(data());
@@ -459,7 +462,7 @@ public class WriteTest {
     public void widthAndHeightWrite() {
         String fileName = TestFileUtil.getPath() + "widthAndHeightWrite" + System.currentTimeMillis() + ".xlsx";
         // 这里 需要指定写用哪个class去写，然后写到第一个sheet，名字为模板 然后文件流会自动关闭
-        FastExcel.write(fileName, WidthAndHeightData.class).sheet("模板").doWrite(data());
+        FesodSheet.write(fileName, WidthAndHeightData.class).sheet("模板").doWrite(data());
     }
 
     /**
@@ -475,7 +478,7 @@ public class WriteTest {
     public void annotationStyleWrite() {
         String fileName = TestFileUtil.getPath() + "annotationStyleWrite" + System.currentTimeMillis() + ".xlsx";
         // 这里 需要指定写用哪个class去写，然后写到第一个sheet，名字为模板 然后文件流会自动关闭
-        FastExcel.write(fileName, DemoStyleData.class).sheet("模板").doWrite(data());
+        FesodSheet.write(fileName, DemoStyleData.class).sheet("模板").doWrite(data());
     }
 
     /**
@@ -515,7 +518,7 @@ public class WriteTest {
                 new HorizontalCellStyleStrategy(headWriteCellStyle, contentWriteCellStyle);
 
         // 这里 需要指定写用哪个class去写，然后写到第一个sheet，名字为模板 然后文件流会自动关闭
-        FastExcel.write(fileName, DemoData.class)
+        FesodSheet.write(fileName, DemoData.class)
                 .registerWriteHandler(horizontalCellStyleStrategy)
                 .sheet("模板")
                 .doWrite(data());
@@ -523,7 +526,7 @@ public class WriteTest {
         // 方法2: 使用FastExcel的方式完全自己写 不太推荐 尽量使用已有策略
         // @since 3.0.0-beta2
         fileName = TestFileUtil.getPath() + "handlerStyleWrite" + System.currentTimeMillis() + ".xlsx";
-        FastExcel.write(fileName, DemoData.class)
+        FesodSheet.write(fileName, DemoData.class)
                 .registerWriteHandler(new CellWriteHandler() {
                     @Override
                     public void afterCellDispose(CellWriteHandlerContext context) {
@@ -554,7 +557,7 @@ public class WriteTest {
         // 坑1：style里面有dataformat 用来格式化数据的 所以自己设置可能导致格式化注解不生效
         // 坑2：不要一直去创建style 记得缓存起来 最多创建6W个就挂了
         fileName = TestFileUtil.getPath() + "handlerStyleWrite" + System.currentTimeMillis() + ".xlsx";
-        FastExcel.write(fileName, DemoData.class)
+        FesodSheet.write(fileName, DemoData.class)
                 .registerWriteHandler(new CellWriteHandler() {
                     @Override
                     public void afterCellDispose(CellWriteHandlerContext context) {
@@ -601,14 +604,14 @@ public class WriteTest {
         String fileName = TestFileUtil.getPath() + "mergeWrite" + System.currentTimeMillis() + ".xlsx";
         // 在DemoStyleData里面加上ContentLoopMerge注解
         // 这里 需要指定写用哪个class去写，然后写到第一个sheet，名字为模板 然后文件流会自动关闭
-        FastExcel.write(fileName, DemoMergeData.class).sheet("模板").doWrite(data());
+        FesodSheet.write(fileName, DemoMergeData.class).sheet("模板").doWrite(data());
 
         // 方法2 自定义合并单元格策略
         fileName = TestFileUtil.getPath() + "mergeWrite" + System.currentTimeMillis() + ".xlsx";
         // 每隔2行会合并 把eachColumn 设置成 3 也就是我们数据的长度，所以就第一列会合并。当然其他合并策略也可以自己写
         LoopMergeStrategy loopMergeStrategy = new LoopMergeStrategy(2, 0);
         // 这里 需要指定写用哪个class去写，然后写到第一个sheet，名字为模板 然后文件流会自动关闭
-        FastExcel.write(fileName, DemoData.class)
+        FesodSheet.write(fileName, DemoData.class)
                 .registerWriteHandler(loopMergeStrategy)
                 .sheet("模板")
                 .doWrite(data());
@@ -626,15 +629,16 @@ public class WriteTest {
         String fileName = TestFileUtil.getPath() + "tableWrite" + System.currentTimeMillis() + ".xlsx";
         // 方法1 这里直接写多个table的案例了，如果只有一个 也可以直一行代码搞定，参照其他案
         // 这里 需要指定写用哪个class去写
-        try (ExcelWriter excelWriter = FastExcel.write(fileName, DemoData.class).build()) {
+        try (ExcelWriter excelWriter =
+                FesodSheet.write(fileName, DemoData.class).build()) {
             // 把sheet设置为不需要头 不然会输出sheet的头 这样看起来第一个table 就有2个头了
             WriteSheet writeSheet =
-                    FastExcel.writerSheet("模板").needHead(Boolean.FALSE).build();
+                    FesodSheet.writerSheet("模板").needHead(Boolean.FALSE).build();
             // 这里必须指定需要头，table 会继承sheet的配置，sheet配置了不需要，table 默认也是不需要
             WriteTable writeTable0 =
-                    FastExcel.writerTable(0).needHead(Boolean.TRUE).build();
+                    FesodSheet.writerTable(0).needHead(Boolean.TRUE).build();
             WriteTable writeTable1 =
-                    FastExcel.writerTable(1).needHead(Boolean.TRUE).build();
+                    FesodSheet.writerTable(1).needHead(Boolean.TRUE).build();
             // 第一次写入会创建头
             excelWriter.write(data(), writeSheet, writeTable0);
             // 第二次写如也会创建头，然后在第一次的后面写入数据
@@ -655,7 +659,7 @@ public class WriteTest {
     @Test
     public void dynamicHeadWrite() {
         String fileName = TestFileUtil.getPath() + "dynamicHeadWrite" + System.currentTimeMillis() + ".xlsx";
-        FastExcel.write(fileName)
+        FesodSheet.write(fileName)
                 // 这里放入动态头
                 .head(head())
                 .sheet("模板")
@@ -683,7 +687,7 @@ public class WriteTest {
         String fileName =
                 TestFileUtil.getPath() + "longestMatchColumnWidthWrite" + System.currentTimeMillis() + ".xlsx";
         // 这里 需要指定写用哪个class去写，然后写到第一个sheet，名字为模板 然后文件流会自动关闭
-        FastExcel.write(fileName, LongestMatchColumnWidthData.class)
+        FesodSheet.write(fileName, LongestMatchColumnWidthData.class)
                 .registerWriteHandler(new LongestMatchColumnWidthStyleStrategy())
                 .sheet("模板")
                 .doWrite(dataLong());
@@ -704,7 +708,7 @@ public class WriteTest {
     public void customHandlerWrite() {
         String fileName = TestFileUtil.getPath() + "customHandlerWrite" + System.currentTimeMillis() + ".xlsx";
         // 这里 需要指定写用哪个class去写，然后写到第一个sheet，名字为模板 然后文件流会自动关闭
-        FastExcel.write(fileName, DemoData.class)
+        FesodSheet.write(fileName, DemoData.class)
                 .registerWriteHandler(new CustomSheetWriteHandler())
                 .registerWriteHandler(new CustomCellWriteHandler())
                 .sheet("模板")
@@ -725,7 +729,7 @@ public class WriteTest {
         String fileName = TestFileUtil.getPath() + "commentWrite" + System.currentTimeMillis() + ".xlsx";
         // 这里 需要指定写用哪个class去写，然后写到第一个sheet，名字为模板 然后文件流会自动关闭
         // 这里要注意inMemory 要设置为true，才能支持批注。目前没有好的办法解决 不在内存处理批注。这个需要自己选择。
-        FastExcel.write(fileName, DemoData.class)
+        FesodSheet.write(fileName, DemoData.class)
                 .inMemory(Boolean.TRUE)
                 .registerWriteHandler(new CommentWriteHandler())
                 .sheet("模板")
@@ -746,7 +750,7 @@ public class WriteTest {
         // 写法1
         String fileName = TestFileUtil.getPath() + "variableTitleWrite" + System.currentTimeMillis() + ".xlsx";
         // 这里 需要指定写用哪个class去写，然后写到第一个sheet，名字为模板 然后文件流会自动关闭
-        FastExcel.write(fileName, ConverterData.class)
+        FesodSheet.write(fileName, ConverterData.class)
                 .head(variableTitleHead())
                 .sheet("模板")
                 .doWrite(data());
@@ -760,13 +764,13 @@ public class WriteTest {
         // 写法1
         String fileName = TestFileUtil.getPath() + "noModelWrite" + System.currentTimeMillis() + ".xlsx";
         // 这里 需要指定写用哪个class去写，然后写到第一个sheet，名字为模板 然后文件流会自动关闭
-        FastExcel.write(fileName).head(head()).sheet("模板").doWrite(dataList());
+        FesodSheet.write(fileName).head(head()).sheet("模板").doWrite(dataList());
     }
 
     @Test
     public void sheetDisposeTest() {
         String fileName = TestFileUtil.getPath() + "simpleWrite" + System.currentTimeMillis() + ".xlsx";
-        FastExcel.write(fileName, DemoData.class)
+        FesodSheet.write(fileName, DemoData.class)
                 .sheet("模板")
                 .registerWriteHandler(new SheetWriteHandler() {
                     @Override

--- a/fesod-examples/src/test/java/org/apache/fesod/sheet/demo/write/WriteWithColorTest.java
+++ b/fesod-examples/src/test/java/org/apache/fesod/sheet/demo/write/WriteWithColorTest.java
@@ -21,7 +21,7 @@ package org.apache.fesod.sheet.demo.write;
 
 import java.util.LinkedList;
 import java.util.List;
-import org.apache.fesod.sheet.FastExcel;
+import org.apache.fesod.sheet.FesodSheet;
 import org.apache.fesod.sheet.util.TestFileUtil;
 import org.junit.jupiter.api.Test;
 
@@ -34,7 +34,7 @@ public class WriteWithColorTest {
     @Test
     public void write() {
         String fileName = TestFileUtil.getPath() + "simpleWrite" + System.currentTimeMillis() + ".xlsx";
-        FastExcel.write(fileName, ColorDemoData.class).sheet("模板").doWrite(this::data);
+        FesodSheet.write(fileName, ColorDemoData.class).sheet("模板").doWrite(this::data);
         System.out.println(fileName);
     }
 


### PR DESCRIPTION
## Description
This PR continues the refactoring effort to replace `FastExcel` with `FesodSheet` throughout the codebase, focusing on the examples module's demo package.

## Motivation
This refactoring aligns the examples module with the project's rebranding from FastExcel to Fesod, ensuring consistency across the codebase and documentation.

## Impact
- All example code now uses the updated `FesodSheet` API