### PR TITLE
javadoc: Deprecate legacy classes and add migration guidance to FesodSheet

### DIFF
--- a/fesod/src/main/java/org/apache/fesod/sheet/EasyExcel.java
+++ b/fesod/src/main/java/org/apache/fesod/sheet/EasyExcel.java
@@ -20,11 +20,50 @@
 package org.apache.fesod.sheet;
 
 /**
- * An alias class for {@link FesodSheet}.
- * This class is deprecated; use {@link FesodSheet} instead.
- * <p>
- * This class will be removed in future versions.
- * </p>
+ * Legacy alias for {@link FesodSheet}.
+ *
+ * <p><strong>DEPRECATED:</strong> This class has been deprecated as part of the project's transition
+ * to the Apache Fesod branding. Users should migrate to {@link FesodSheet} for all new development.
+ *
+ * <h3>Migration Guide</h3>
+ * <p>Replace all occurrences of {@code EasyExcel} with {@code FesodSheet} in your codebase:
+ *
+ * <table border="1">
+ *   <caption>Migration Examples</caption>
+ *   <tr>
+ *     <th>Old Code (Deprecated)</th>
+ *     <th>New Code (Recommended)</th>
+ *   </tr>
+ *   <tr>
+ *     <td>{@code EasyExcel.read(file, DemoData.class, listener)}</td>
+ *     <td>{@code FesodSheet.read(file, DemoData.class, listener)}</td>
+ *   </tr>
+ *   <tr>
+ *     <td>{@code EasyExcel.write(file, DemoData.class)}</td>
+ *     <td>{@code FesodSheet.write(file, DemoData.class)}</td>
+ *   </tr>
+ *   <tr>
+ *     <td>{@code EasyExcel.readSheet(0)}</td>
+ *     <td>{@code FesodSheet.readSheet(0)}</td>
+ *   </tr>
+ *   <tr>
+ *     <td>{@code EasyExcel.writerSheet("Sheet1")}</td>
+ *     <td>{@code FesodSheet.writerSheet("Sheet1")}</td>
+ *   </tr>
+ * </table>
+ *
+ * <h3>Why Deprecated?</h3>
+ * <p>This class was originally named "EasyExcel" but has been superseded by "FesodSheet"
+ * to align with Apache Fesod's official branding and naming conventions. The functionality
+ * remains identical; only the class name has changed.
+ *
+ * <h3>Removal Timeline</h3>
+ * <p>This class is marked for removal in a future major version. All functionality is
+ * available in {@link FesodSheet}.
+ *
+ * @deprecated Since version 1.0.0. Use {@link FesodSheet} instead.
+ *             This class will be removed in a future major release.
+ * @see FesodSheet
  */
 @Deprecated
 public class EasyExcel extends FesodSheet {}

--- a/fesod/src/main/java/org/apache/fesod/sheet/FastExcel.java
+++ b/fesod/src/main/java/org/apache/fesod/sheet/FastExcel.java
@@ -20,11 +20,62 @@
 package org.apache.fesod.sheet;
 
 /**
- * An alias class for {@link FesodSheet}.
- * This class is deprecated; use {@link FesodSheet} instead.
- * <p>
- * This class will be removed in future versions.
- * </p>
+ * Legacy short alias for {@link FesodSheet}.
+ *
+ * <p><strong>DEPRECATED:</strong> This class has been deprecated as part of the project's evolution
+ * from "FastExcel" to "Apache Fesod". Users should migrate to {@link FesodSheet} for all new development.
+ *
+ * <h3>Migration Guide</h3>
+ * <p>Replace all occurrences of {@code FastExcel} with {@code FesodSheet} in your codebase:
+ *
+ * <table border="1">
+ *   <caption>Migration Examples</caption>
+ *   <tr>
+ *     <th>Old Code (Deprecated)</th>
+ *     <th>New Code (Recommended)</th>
+ *   </tr>
+ *   <tr>
+ *     <td>{@code FastExcel.read("data.xlsx", DemoData.class, listener)}</td>
+ *     <td>{@code FesodSheet.read("data.xlsx", DemoData.class, listener)}</td>
+ *   </tr>
+ *   <tr>
+ *     <td>{@code FastExcel.write("output.xlsx", DemoData.class)}</td>
+ *     <td>{@code FesodSheet.write("output.xlsx", DemoData.class)}</td>
+ *   </tr>
+ *   <tr>
+ *     <td>{@code FastExcel.readSheet(0)}</td>
+ *     <td>{@code FesodSheet.readSheet(0)}</td>
+ *   </tr>
+ *   <tr>
+ *     <td>{@code FastExcel.writerSheet("MySheet")}</td>
+ *     <td>{@code FesodSheet.writerSheet("MySheet")}</td>
+ *   </tr>
+ * </table>
+ *
+ * <h3>Why Deprecated?</h3>
+ * <p>This class was originally named "FastExcel" to provide a short, memorable entry point
+ * for the library. However, following the project's acceptance into the Apache Software Foundation
+ * as Apache Fesod (incubating), it has been superseded by "FesodSheet" to align with the official
+ * project branding. The functionality remains identical; only the class name has changed.
+ *
+ * <h3>Historical Context</h3>
+ * <p>The name "FastExcel" emphasized the library's high-performance characteristics and ease of use.
+ * The Apache Fesod name (Fast Easy Spreadsheet and Other Documents) retains this heritage while
+ * fitting Apache naming conventions.
+ *
+ * <h3>Relationship with FastExcelFactory</h3>
+ * <p>Both {@code FastExcel} and {@link FastExcelFactory} are deprecated aliases pointing to
+ * the same underlying implementation. {@code FastExcel} was the short, convenient alias while
+ * {@code FastExcelFactory} used the explicit "Factory" suffix.
+ *
+ * <h3>Removal Timeline</h3>
+ * <p>This class is marked for removal in a future major version. All functionality is
+ * available in {@link FesodSheet}.
+ *
+ * @deprecated Since version 1.0.0. Use {@link FesodSheet} instead.
+ *             This class will be removed in a future major release.
+ * @see FesodSheet
+ * @see FastExcelFactory
  */
 @Deprecated
 public class FastExcel extends FesodSheet {}

--- a/fesod/src/main/java/org/apache/fesod/sheet/FastExcelFactory.java
+++ b/fesod/src/main/java/org/apache/fesod/sheet/FastExcelFactory.java
@@ -20,11 +20,56 @@
 package org.apache.fesod.sheet;
 
 /**
- * An alias class for {@link FesodSheet}.
- * This class is deprecated; use {@link FesodSheet} instead.
- * <p>
- * This class will be removed in future versions.
- * </p>
+ * Legacy factory class alias for {@link FesodSheet}.
+ *
+ * <p><strong>DEPRECATED:</strong> This class has been deprecated as part of the project's evolution
+ * from "FastExcel" to "Apache Fesod". Users should migrate to {@link FesodSheet} for all new development.
+ *
+ * <h3>Migration Guide</h3>
+ * <p>Replace all occurrences of {@code FastExcelFactory} with {@code FesodSheet} in your codebase:
+ *¡
+ * <table border="1">
+ *   <caption>Migration Examples</caption>
+ *   <tr>
+ *     <th>Old Code (Deprecated)</th>
+ *     <th>New Code (Recommended)</th>¡
+ *   </tr>
+ *   <tr>
+ *     <td>{@code FastExcelFactory.read(inputStream, DemoData.class, listener)}</td>
+ *     <td>{@code FesodSheet.read(inputStream, DemoData.class, listener)}</td>
+ *   </tr>
+ *   <tr>
+ *     <td>{@code FastExcelFactory.write(outputStream, DemoData.class)}</td>
+ *     <td>{@code FesodSheet.write(outputStream, DemoData.class)}</td>
+ *   </tr>
+ *   <tr>
+ *     <td>{@code FastExcelFactory.readSheet(0, "Sheet1")}</td>
+ *     <td>{@code FesodSheet.readSheet(0, "Sheet1")}</td>
+ *   </tr>
+ *   <tr>
+ *     <td>{@code FastExcelFactory.writerTable(0)}</td>
+ *     <td>{@code FesodSheet.writerTable(0)}</td>
+ *   </tr>
+ * </table>
+ *
+ * <h3>Why Deprecated?</h3>
+ * <p>This class was part of the original "FastExcel" branding but has been superseded by
+ * "FesodSheet" following the project's acceptance into the Apache Software Foundation as
+ * Apache Fesod (incubating). The functionality remains identical; only the class name has changed.
+ *
+ * <h3>Relationship with FastExcel</h3>
+ * <p>Both {@link FastExcel} and {@code FastExcelFactory} are deprecated aliases pointing to
+ * the same underlying implementation. {@code FastExcel} was the short alias while
+ * {@code FastExcelFactory} used the explicit "Factory" suffix.
+ *
+ * <h3>Removal Timeline</h3>
+ * <p>This class is marked for removal in a future major version. All functionality is
+ * available in {@link FesodSheet}.
+ *
+ * @deprecated Since version 1.0.0. Use {@link FesodSheet} instead.
+ *             This class will be removed in a future major release.
+ * @see FesodSheet
+ * @see FastExcel
  */
 @Deprecated
 public class FastExcelFactory extends FesodSheet {}

--- a/fesod/src/main/java/org/apache/fesod/sheet/FastExcelFactory.java
+++ b/fesod/src/main/java/org/apache/fesod/sheet/FastExcelFactory.java
@@ -27,12 +27,12 @@ package org.apache.fesod.sheet;
  *
  * <h3>Migration Guide</h3>
  * <p>Replace all occurrences of {@code FastExcelFactory} with {@code FesodSheet} in your codebase:
- *¡
+ *
  * <table border="1">
  *   <caption>Migration Examples</caption>
  *   <tr>
  *     <th>Old Code (Deprecated)</th>
- *     <th>New Code (Recommended)</th>¡
+ *     <th>New Code (Recommended)</th>
  *   </tr>
  *   <tr>
  *     <td>{@code FastExcelFactory.read(inputStream, DemoData.class, listener)}</td>

--- a/fesod/src/main/java/org/apache/fesod/sheet/FesodSheet.java
+++ b/fesod/src/main/java/org/apache/fesod/sheet/FesodSheet.java
@@ -30,7 +30,67 @@ import org.apache.fesod.sheet.write.builder.ExcelWriterSheetBuilder;
 import org.apache.fesod.sheet.write.builder.ExcelWriterTableBuilder;
 
 /**
- * Core classes of the Fesod spreadsheet processor
+ * Core factory class providing static methods for creating Excel readers and writers.
+ *
+ * <p>This class serves as the primary entry point for the Fesod library, offering a fluent API
+ * for both reading and writing Excel files. It provides a unified interface to simplify Excel
+ * operations through the builder pattern.
+ *
+ * <h3>Key Features</h3>
+ * <ul>
+ *   <li>Supports multiple input/output sources: File, String path, InputStream, OutputStream</li>
+ *   <li>Provides builder pattern for flexible configuration</li>
+ *   <li>Supports annotation-driven mapping via {@code @ExcelProperty}</li>
+ *   <li>Handles both .xls (Excel 97-2003) and .xlsx (Excel 2007+) formats</li>
+ *   <li>Enables stream-based processing for memory efficiency</li>
+ * </ul>
+ *
+ * <h3>Reading Examples</h3>
+ * <pre>{@code
+ * // Simple read with listener
+ * FesodSheet.read("demo.xlsx", DemoData.class, new DemoDataListener())
+ *     .sheet()
+ *     .doRead();
+ *
+ * // Advanced read with custom configuration
+ * try (ExcelReader excelReader = FesodSheet.read(file)
+ *         .headRowNumber(1)
+ *         .ignoreEmptyRow(true)
+ *         .build()) {
+ *     ReadSheet readSheet = FesodSheet.readSheet(0).build();
+ *     excelReader.read(readSheet);
+ * }
+ * }</pre>
+ *
+ * <h3>Writing Examples</h3>
+ * <pre>{@code
+ * // Simple write
+ * FesodSheet.write("output.xlsx", DemoData.class)
+ *     .sheet("Sheet1")
+ *     .doWrite(dataList);
+ *
+ * // Advanced write with custom configuration
+ * try (ExcelWriter excelWriter = FesodSheet.write(outputStream)
+ *         .build()) {
+ *     WriteSheet writeSheet = FesodSheet.writerSheet(0, "Template").build();
+ *     excelWriter.write(dataList, writeSheet);
+ * }
+ * }</pre>
+ *
+ * <h3>Deprecated Aliases</h3>
+ * <p>The following classes are deprecated aliases that extend FesodSheet:
+ * <ul>
+ *   <li>{@link EasyExcel} - Legacy alias from the EasyExcel branding</li>
+ *   <li>{@link FastExcel} - Legacy short alias from the FastExcel branding</li>
+ *   <li>{@link FastExcelFactory} - Legacy factory alias from the FastExcel branding</li>
+ * </ul>
+ * All new code should use {@code FesodSheet} directly.
+ *
+ * @see ExcelReader
+ * @see ExcelWriter
+ * @see org.apache.fesod.sheet.read.builder.ExcelReaderBuilder
+ * @see org.apache.fesod.sheet.write.builder.ExcelWriterBuilder
+ * @since 1.0.0
  */
 public class FesodSheet {
 


### PR DESCRIPTION
## Description

This PR adds deprecation notices to `EasyExcel`, `FastExcel`, and `FastExcelFactory` classes, providing clear migration guidance to use `FesodSheet`. It also enhances the Javadoc for `FesodSheet` and `FesodSheetFactory`.

## Motivation

As part of the rebranding from FastExcel to Fesod, it is important to guide users away from the old entry points and towards the new `FesodSheet` API. This ensures a smoother transition and better developer experience.