### PR TITLE
docs: Fix incorrect link to docs contribution guide

### DIFF
--- a/website/community/contribution.md
+++ b/website/community/contribution.md
@@ -68,7 +68,7 @@ Any contribution of test cases is encouraged, especially unit tests. It is recom
 
 ## Contribution Document
 
-Documentation is an important component of the project official website and serves as a vital bridge between the project and the community. Please refer to [Docs Contribution](./contribution/contribute-code.md) for information on how to contribute document.
+Documentation is an important component of the project official website and serves as a vital bridge between the project and the community. Please refer to [Docs Contribution](./contribution/contribute-doc.md) for information on how to contribute document.
 
 ## Other Ways to Contribute
 


### PR DESCRIPTION
<!--
Thanks very much for contributing to Apache Fesod (Incubating)! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

Closed: #ISSUE
Related: #ISSUE

-->

## Purpose of the pull request

<!-- Describe the purpose of this pull request. For example: Closed: #ISSUE-->
This PR fixes incorrect documentation link in the contribution guide.

## What's changed?

<!--- Describe the change below, including rationale and design decisions -->
This PR updated the `Docs Contribution` link to point to `contribute-doc.md` instead of `contribute-code.md`.

## Checklist

- [x] I have read the [Contributor Guide](https://fesod.apache.org/community/contribution/).
- [x] I have written the necessary doc or comment.
- [ ] I have added the necessary unit tests and all cases have passed.
