### PR TITLE
refactor: Split license check into standalone workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,8 +32,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
-      - name: Check License Header
-        uses: korandoru/hawkeye@v6
       - name: Cache Local Maven Repository
         uses: actions/cache@v4
         with:

--- a/.github/workflows/license-check.yml
+++ b/.github/workflows/license-check.yml
@@ -1,0 +1,28 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+name: Check License Header
+
+on: [ push, pull_request ]
+
+jobs:
+  license:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - name: Check License Header
+        uses: korandoru/hawkeye@v6


### PR DESCRIPTION
<!--
Thanks very much for contributing to Apache Fesod (Incubating)! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

Closed: #ISSUE
Related: #ISSUE

-->
Related: #703 

## Purpose of the pull request

<!-- Describe the purpose of this pull request. For example: Closed: #ISSUE-->
This PR splits the license header check into its own workflow so it runs on all file changes.

## What's changed?

<!--- Describe the change below, including rationale and design decisions -->
This PR created a new `ci-license.yml` workflow that runs license checks on all PRs and removed the license check step from `ci.yml` to keep it focused on Java CI only.

## Checklist

- [x] I have read the [Contributor Guide](https://fesod.apache.org/community/contribution/).
- [x] I have written the necessary doc or comment.
- [ ] I have added the necessary unit tests and all cases have passed.
