### PR TITLE
docs: Add Apache License header to lombok.config

### DIFF
--- a/lombok.config
+++ b/lombok.config
@@ -1,2 +1,19 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 lombok.toString.callSuper = CALL
 lombok.equalsAndHashCode.callSuper= CALL


### PR DESCRIPTION
## Description

This PR adds the Apache License header to the `lombok.config` file to ensure proper licensing compliance across all configuration files in the project.

## Key Changes

- Added Apache License version 2.0 header to `lombok.config`.