### PR TITLE
refactor: Consolidate documentation CI with markdown linting

### DIFF
--- a/.github/workflows/ci-docs.yml
+++ b/.github/workflows/ci-docs.yml
@@ -15,19 +15,16 @@
 # specific language governing permissions and limitations
 # under the License.
 
-name: Markdown Lint
+name: Documentation CI
 
 on:
   pull_request:
     paths:
-      - '**/*.md'
-  push:
-    paths:
+      - 'website/**'
       - '**/*.md'
 
 jobs:
-  markdownlint:
-    if: github.event_name == 'push' || github.event_name == 'pull_request'
+  lint-and-build:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -67,3 +64,21 @@ jobs:
           else
             echo "No markdown files changed, skipping lint."
           fi
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 8
+          run_install: false
+
+      - name: Enable corepack
+        working-directory: website
+        run: npm i -g --force corepack && corepack enable
+
+      - name: Install dependencies
+        working-directory: website
+        run: pnpm install
+
+      - name: Build website
+        working-directory: website
+        run: pnpm build


### PR DESCRIPTION
<!--
Thanks very much for contributing to Apache Fesod (Incubating)! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

Closed: #ISSUE
Related: #ISSUE

-->
Related: #703 https://github.com/apache/fesod/issues/703#issuecomment-3585603182

## Purpose of the pull request

<!-- Describe the purpose of this pull request. For example: Closed: #ISSUE-->
This PR consolidates the markdown linting workflow into the documentation CI workflow, making it easier to maintain while keeping all the same quality checks.


## What's changed?

<!--- Describe the change below, including rationale and design decisions -->
The workflow will lint all changed markdown files using `markdownlint-cli2` and build the website to verify everything works.

## Checklist

- [x] I have read the [Contributor Guide](https://fesod.apache.org/community/contribution/).
- [x] I have written the necessary doc or comment.
- [ ] I have added the necessary unit tests and all cases have passed.
