### PR TITLE
fix: Use GitHub Actions for markdown linting in `ci-docs`

### DIFF
--- a/.github/workflows/ci-docs.yml
+++ b/.github/workflows/ci-docs.yml
@@ -55,4 +55,5 @@ jobs:
       - name: Lint markdown files
         uses: DavidAnson/markdownlint-cli2-action@992badcdf24e3b8eb7e87ff9287fe931bcb00c6e
         with:
+          globs: 'website/**/*.md'
           config: 'website/.markdownlint-cli2.jsonc'

--- a/website/test-markdown.md
+++ b/website/test-markdown.md
@@ -1,9 +1,0 @@
-### This is h3 without h1 first
-
-Some content here.
-
-```
-code without language specified
-```
-
-This file also has no trailing newline


### PR DESCRIPTION
<!--
Thanks very much for contributing to Apache Fesod (Incubating)! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

Closed: #ISSUE
Related: #ISSUE

-->
Related: https://github.com/apache/fesod/issues/703#issuecomment-3589750412

## Purpose of the pull request

<!-- Describe the purpose of this pull request. For example: Closed: #ISSUE-->
The markdown linting step in `ci-docs` wasn't working properly where the bash script had git reference errors that caused it to skip linting.

## What's changed?

<!--- Describe the change below, including rationale and design decisions -->
This PR replaces the bash script with GitHub Actions for markdown linting. It uses:
1. [DavidAnson/markdownlint-cli2-action](https://github.com/DavidAnson/markdownlint-cli2-action) to lint all markdown files



## Checklist

- [x] I have read the [Contributor Guide](https://fesod.apache.org/community/contribution/).
- [x] I have written the necessary doc or comment.
- [ ] I have added the necessary unit tests and all cases have passed.
