### PR TITLE
refactor: Remove @EqualsAndHashCode annotation from AnalysisCell class

### DIFF
--- a/fesod/src/main/java/org/apache/fesod/sheet/write/metadata/fill/AnalysisCell.java
+++ b/fesod/src/main/java/org/apache/fesod/sheet/write/metadata/fill/AnalysisCell.java
@@ -20,7 +20,6 @@
 package org.apache.fesod.sheet.write.metadata.fill;
 
 import java.util.List;
-import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
 import org.apache.fesod.sheet.enums.WriteTemplateAnalysisCellTypeEnum;
@@ -32,7 +31,6 @@ import org.apache.fesod.sheet.enums.WriteTemplateAnalysisCellTypeEnum;
  **/
 @Getter
 @Setter
-@EqualsAndHashCode
 public class AnalysisCell {
     private int columnIndex;
     private int rowIndex;


### PR DESCRIPTION
## Purpose of the pull request

Fix Lombok configuration issues by removing unnecessary `@EqualsAndHashCode` annotation from AnalysisCell class.

## What's changed?

- Removed `@EqualsAndHashCode` annotation from `AnalysisCell` class in `fesod/src/main/java/org/apache/fesod/sheet/write/metadata/fill/AnalysisCell.java`
- This simplifies the class and addresses Lombok-related concerns

## Checklist

- [x] I have read the [Contributor Guide](https://fesod.apache.org/community/contribution/).
- [x] I have written the necessary doc or comment.
- [x] I have added the necessary unit tests and all cases have passed.