### PR TITLE
chore(ci): update Java version to 25 in CI configuration files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v5
         with:
-          java-version: 21
+          java-version: 25
           distribution: 'temurin'
       - name: Check code style
         run: ./mvnw spotless:check
@@ -61,7 +61,7 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       matrix:
-        java: [ 8, 11, 17, 21, 25-ea ]
+        java: [ 8, 11, 17, 21, 25 ]
         distribution: [ 'temurin' ]
       fail-fast: false
       max-parallel: 5

--- a/.github/workflows/fuzz-tests.yml
+++ b/.github/workflows/fuzz-tests.yml
@@ -39,7 +39,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
-          java-version: '21'
+          java-version: '25'
           cache: 'maven'
 
       - name: Run fuzz tests (fesod module)

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       matrix:
-        java: [ 8, 11, 17, 21, 25-ea ]
+        java: [ 8, 11, 17, 21, 25 ]
         distribution: [ 'temurin' ]
       fail-fast: false
       max-parallel: 5


### PR DESCRIPTION


<!--
Thanks very much for contributing to Apache Fesod (Incubating)! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

Closed: #ISSUE
Related: #ISSUE

-->

## Purpose of the pull request

As https://github.com/actions/setup-java/issues/899 mentioned, replace 25-ea with 25 for stable version 

## What's changed?

Updated the Java version from 21 to 25 in the CI configuration files to ensure compatibility with the latest features and improvements.

- Updated fuzz-tests.yml
- Updated ci.yml
- Updated nightly.yml

## Checklist

- [X] I have read the [Contributor Guide](https://fesod.apache.org/community/contribution/).
- [X] I have written the necessary doc or comment.
- [X] I have added the necessary unit tests and all cases have passed.
