### PR TITLE
fix: ensure converter isolation across ExcelWriter and ExcelReader

### DIFF
--- a/fesod/src/main/java/org/apache/fesod/sheet/converters/DefaultConverterLoader.java
+++ b/fesod/src/main/java/org/apache/fesod/sheet/converters/DefaultConverterLoader.java
@@ -19,6 +19,7 @@
 
 package org.apache.fesod.sheet.converters;
 
+import java.util.Collections;
 import java.util.Map;
 import org.apache.fesod.sheet.converters.ConverterKeyBuild.ConverterKey;
 import org.apache.fesod.sheet.converters.bigdecimal.BigDecimalBooleanConverter;
@@ -175,10 +176,10 @@ public class DefaultConverterLoader {
     /**
      * Load default write converter
      *
-     * @return
+     * @return Unmodifiable map of default write converters
      */
     public static Map<ConverterKey, Converter<?>> loadDefaultWriteConverter() {
-        return defaultWriteConverter;
+        return Collections.unmodifiableMap(defaultWriteConverter);
     }
 
     private static void putWriteConverter(Converter<?> converter) {
@@ -193,7 +194,7 @@ public class DefaultConverterLoader {
     /**
      * Load default read converter
      *
-     * @return
+     * @return Unmodifiable map of default read converters
      */
     public static Map<ConverterKey, Converter<?>> loadDefaultReadConverter() {
         return loadAllConverter();
@@ -202,10 +203,10 @@ public class DefaultConverterLoader {
     /**
      * Load all converter
      *
-     * @return
+     * @return Unmodifiable map of all converters
      */
     public static Map<ConverterKey, Converter<?>> loadAllConverter() {
-        return allConverter;
+        return Collections.unmodifiableMap(allConverter);
     }
 
     private static void putAllConverter(Converter<?> converter) {

--- a/fesod/src/main/java/org/apache/fesod/sheet/read/metadata/holder/AbstractReadHolder.java
+++ b/fesod/src/main/java/org/apache/fesod/sheet/read/metadata/holder/AbstractReadHolder.java
@@ -114,7 +114,7 @@ public abstract class AbstractReadHolder extends AbstractHolder implements ReadH
         }
 
         if (parentAbstractReadHolder == null) {
-            setConverterMap(DefaultConverterLoader.loadDefaultReadConverter());
+            setConverterMap(new HashMap<>(DefaultConverterLoader.loadDefaultReadConverter()));
         } else {
             setConverterMap(new HashMap<>(parentAbstractReadHolder.getConverterMap()));
         }

--- a/fesod/src/main/java/org/apache/fesod/sheet/write/metadata/holder/AbstractWriteHolder.java
+++ b/fesod/src/main/java/org/apache/fesod/sheet/write/metadata/holder/AbstractWriteHolder.java
@@ -255,7 +255,7 @@ public abstract class AbstractWriteHolder extends AbstractHolder implements Writ
 
         // Set converterMap
         if (parentAbstractWriteHolder == null) {
-            setConverterMap(DefaultConverterLoader.loadDefaultWriteConverter());
+            setConverterMap(new HashMap<>(DefaultConverterLoader.loadDefaultWriteConverter()));
         } else {
             setConverterMap(new HashMap<>(parentAbstractWriteHolder.getConverterMap()));
         }

--- a/fesod/src/test/java/org/apache/fesod/sheet/converter/ConverterIsolationTest.java
+++ b/fesod/src/test/java/org/apache/fesod/sheet/converter/ConverterIsolationTest.java
@@ -32,8 +32,11 @@ import org.apache.fesod.sheet.metadata.data.ReadCellData;
 import org.apache.fesod.sheet.metadata.data.WriteCellData;
 import org.apache.fesod.sheet.metadata.property.ExcelContentProperty;
 import org.apache.fesod.sheet.util.TestFileUtil;
+import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
 
+@TestMethodOrder(MethodOrderer.MethodName.class)
 public class ConverterIsolationTest {
 
     public static class TestData {}

--- a/fesod/src/test/java/org/apache/fesod/sheet/converter/ConverterIsolationTest.java
+++ b/fesod/src/test/java/org/apache/fesod/sheet/converter/ConverterIsolationTest.java
@@ -32,11 +32,8 @@ import org.apache.fesod.sheet.metadata.data.ReadCellData;
 import org.apache.fesod.sheet.metadata.data.WriteCellData;
 import org.apache.fesod.sheet.metadata.property.ExcelContentProperty;
 import org.apache.fesod.sheet.util.TestFileUtil;
-import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestMethodOrder;
 
-@TestMethodOrder(MethodOrderer.MethodName.class)
 public class ConverterIsolationTest {
 
     public static class TestData {}

--- a/fesod/src/test/java/org/apache/fesod/sheet/converter/ConverterIsolationTest.java
+++ b/fesod/src/test/java/org/apache/fesod/sheet/converter/ConverterIsolationTest.java
@@ -22,7 +22,6 @@ package org.apache.fesod.sheet.converter;
 import static org.junit.jupiter.api.Assertions.*;
 import java.io.File;
 import java.util.ArrayList;
-
 import org.apache.fesod.sheet.ExcelReader;
 import org.apache.fesod.sheet.ExcelWriter;
 import org.apache.fesod.sheet.FesodSheet;
@@ -97,19 +96,15 @@ public class ConverterIsolationTest {
     public void testReaderConverterIsolation() {
         File testFile = TestFileUtil.createNewFile("converter_isolation_test.xlsx");
 
-        FesodSheet.write(testFile, TestData.class)
-                .sheet()
-                .doWrite(new ArrayList<>());
+        FesodSheet.write(testFile, TestData.class).sheet().doWrite(new ArrayList<>());
 
         ExcelReader reader1 = FesodSheet.read(testFile, TestData.class, null)
                 .registerConverter(new ReadConverterA())
                 .build();
 
-        ExcelReader reader2 = FesodSheet.read(testFile, TestData.class, null)
-                .build();
+        ExcelReader reader2 = FesodSheet.read(testFile, TestData.class, null).build();
 
-        boolean leaked = reader2.analysisContext().currentReadHolder()
-                .converterMap().values().stream()
+        boolean leaked = reader2.analysisContext().currentReadHolder().converterMap().values().stream()
                 .anyMatch(c -> c instanceof ReadConverterA);
 
         reader1.finish();

--- a/fesod/src/test/java/org/apache/fesod/sheet/converter/ConverterIsolationTest.java
+++ b/fesod/src/test/java/org/apache/fesod/sheet/converter/ConverterIsolationTest.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.fesod.sheet.converter;
+
+import static org.junit.jupiter.api.Assertions.*;
+import java.io.File;
+import org.apache.fesod.sheet.ExcelWriter;
+import org.apache.fesod.sheet.FesodSheet;
+import org.apache.fesod.sheet.converters.Converter;
+import org.apache.fesod.sheet.enums.CellDataTypeEnum;
+import org.apache.fesod.sheet.metadata.GlobalConfiguration;
+import org.apache.fesod.sheet.metadata.data.WriteCellData;
+import org.apache.fesod.sheet.metadata.property.ExcelContentProperty;
+import org.apache.fesod.sheet.util.TestFileUtil;
+import org.junit.jupiter.api.Test;
+
+public class ConverterIsolationTest {
+
+    public static class TestData {}
+
+    public static class ConverterA implements Converter<String> {
+
+        @Override
+        public Class<String> supportJavaTypeKey() {
+            return String.class;
+        }
+
+        @Override
+        public CellDataTypeEnum supportExcelTypeKey() {
+            return CellDataTypeEnum.STRING;
+        }
+
+        @Override
+        public WriteCellData<?> convertToExcelData(String value, ExcelContentProperty p, GlobalConfiguration g) {
+            return new WriteCellData<>("A-" + value);
+        }
+    }
+
+    @Test
+    public void testConverterIsolation() {
+        ExcelWriter writer1 = FesodSheet.write(new File(TestFileUtil.getPath() + "writer1.xlsx"), TestData.class)
+                .registerConverter(new ConverterA())
+                .build();
+
+        ExcelWriter writer2 = FesodSheet.write(new File(TestFileUtil.getPath() + "writer2.xlsx"), TestData.class)
+                .build();
+
+        boolean writer2HasConverterA = writer2.writeContext().currentWriteHolder().converterMap().values().stream()
+                .anyMatch(c -> c instanceof ConverterA);
+
+        writer1.finish();
+        writer2.finish();
+
+        assertFalse(writer2HasConverterA, "Custom converter should not leak between ExcelWriter instances");
+    }
+}


### PR DESCRIPTION
## Purpose of the pull request

Closes #729

Fixes converter isolation bug where custom converters registered in one `ExcelWriter` or `ExcelReader` instance would leak to other instances.

## What's changed?

- Modified `DefaultConverterLoader.loadDefaultWriteConverter()` and `DefaultConverterLoader.loadAllConverter()` to return unmodifiable map
- Modified `AbstractWriteHolder` and `AbstractReadHolder` to create mutable copies from the unmodifiable maps
- Added `ConverterIsolationTest` to verify converters are properly isolated between instances

## Checklist

- [x] I have read the [Contributor Guide](https://fesod.apache.org/community/contribution/).
- [x] I have written the necessary doc or comment.
- [x] I have added the necessary unit tests and all cases have passed.