### PR TITLE
fix: update Maven command for fuzz tests to reflect new package structure

### DIFF
--- a/.github/workflows/fuzz-tests.yml
+++ b/.github/workflows/fuzz-tests.yml
@@ -50,7 +50,7 @@ jobs:
         run: |
           mkdir -p "${{ runner.temp }}/jazzer-artifacts/"
           # Execute only tests under fuzz package and force tests not to be skipped
-          mvn -B -pl fesod -am -D"maven.test.skip=false" -DtrimStackTrace=false -D"test=org.apache.fesod.sheet.fuzz.*Test" test
+          mvn -B -pl fesod-sheet -am -D"maven.test.skip=false" -DtrimStackTrace=false -D"test=org.apache.fesod.sheet.fuzz.*Test"  -D"surefire.failIfNoSpecifiedTests=false"  test
 
       - name: Upload Jazzer artifacts (crashes, repros)
         if: always()


### PR DESCRIPTION



<!--
Thanks very much for contributing to Apache Fesod (Incubating)! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

Closed: #ISSUE
Related: #ISSUE

-->

## Purpose of the pull request

Adjusted the Maven command in the fuzz-tests.yml to use the correct package path for the fuzz tests. This change ensures that the tests are executed properly under the updated project structure.

- Added sure-fire option to prevent failure if no specified tests are found
Fix https://github.com/apache/fesod/actions/runs/20465655490/job/58808625062

## What's changed?

fuzz-tests.yml

## Checklist

- [X] I have read the [Contributor Guide](https://fesod.apache.org/community/contribution/).
- [ ] I have written the necessary doc or comment.
- [X] I have added the necessary unit tests and all cases have passed.
