### PR TITLE
fix: resolve SLF4J and Logback compatibility issues

### DIFF
--- a/fesod-examples/fesod-sheet-examples/pom.xml
+++ b/fesod-examples/fesod-sheet-examples/pom.xml
@@ -43,6 +43,23 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.springframework.boot</groupId>
+                    <artifactId>spring-boot-starter-logging</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-api</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <!-- Use Logback 1.2.x with SLF4J 1.7.x for Spring Boot 2.7.x compatibility -->
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <version>1.2.13</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 </project>

--- a/fesod-examples/fesod-sheet-examples/src/test/resources/logback.xml
+++ b/fesod-examples/fesod-sheet-examples/src/test/resources/logback.xml
@@ -20,16 +20,17 @@
 
 -->
 <configuration>
-    <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
-
     <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>${CONSOLE_LOG_PATTERN}</pattern>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
             <charset>utf8</charset>
         </encoder>
     </appender>
 
-    <root level="DEBUG">
+    <root level="INFO">
         <appender-ref ref="CONSOLE"/>
     </root>
+
+    <!-- Reduce noise from POI -->
+    <logger name="org.apache.poi" level="WARN"/>
 </configuration>

--- a/fesod-sheet/src/test/resources/logback.xml
+++ b/fesod-sheet/src/test/resources/logback.xml
@@ -20,16 +20,17 @@
 
 -->
 <configuration>
-    <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
-
     <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>${CONSOLE_LOG_PATTERN}</pattern>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
             <charset>utf8</charset>
         </encoder>
     </appender>
 
-    <root level="DEBUG">
+    <root level="INFO">
         <appender-ref ref="CONSOLE"/>
     </root>
+
+    <!-- Reduce noise from POI -->
+    <logger name="org.apache.poi" level="WARN"/>
 </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -70,15 +70,13 @@
         <poi.version>5.5.1</poi.version>
         <ehcache.version>3.9.11</ehcache.version>
         <commons-io.version>2.21.0</commons-io.version>
-        <slf4j-api.version>1.7.36</slf4j-api.version>
+        <slf4j-api.version>2.0.17</slf4j-api.version>
         <lombok.version>1.18.42</lombok.version>
         <spring-core.version>5.3.39</spring-core.version>
         <fastjson2.version>2.0.60</fastjson2.version>
         <spring-boot-starter-web.version>2.7.18</spring-boot-starter-web.version>
-        <slf4j-simple.version>1.7.36</slf4j-simple.version>
-        <jcl-over-slf4j.version>1.7.36</jcl-over-slf4j.version>
-        <log4j-over-slf4j.version>1.7.36</log4j-over-slf4j.version>
-        <logback-classic.version>1.5.24</logback-classic.version>
+        <log4j-to-slf4j.version>2.24.3</log4j-to-slf4j.version>
+        <logback-classic.version>1.3.14</logback-classic.version>
         <mockserver.version>5.15.0</mockserver.version>
         <jacoco.version>0.8.14</jacoco.version>
         <junit.version>5.13.4</junit.version>
@@ -188,19 +186,9 @@
                 <version>${fastjson2.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.slf4j</groupId>
-                <artifactId>slf4j-simple</artifactId>
-                <version>${slf4j-simple.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.slf4j</groupId>
-                <artifactId>jcl-over-slf4j</artifactId>
-                <version>${jcl-over-slf4j.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.slf4j</groupId>
-                <artifactId>log4j-over-slf4j</artifactId>
-                <version>${log4j-over-slf4j.version}</version>
+                <groupId>org.apache.logging.log4j</groupId>
+                <artifactId>log4j-to-slf4j</artifactId>
+                <version>${log4j-to-slf4j.version}</version>
             </dependency>
             <dependency>
                 <groupId>ch.qos.logback</groupId>
@@ -299,18 +287,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-simple</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>jcl-over-slf4j</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>log4j-over-slf4j</artifactId>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-to-slf4j</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
## Summary
This PR fixes the compatibility issue between logback-classic and slf4j-api, and removes the erroneous Spring Boot configuration from logback.xml.

## Changes

### 1. Update logback-classic version (pom.xml)
- Changed \`logback-classic.version\` from \`1.5.24\` to \`1.3.14\`
- **Logback 1.3.x** is the last version compatible with Java 8 (while supporting SLF4J 2.x)
- **Logback 1.4.x/1.5.x** requires Java 11+

### 2. Update slf4j-api version (pom.xml)
- Changed \`slf4j-api.version\` from \`1.7.36\` to \`2.0.17\`
- SLF4J 2.0.x is compatible with Java 8+ and works with Logback 1.3.x

### 3. Replace log bridging dependencies (pom.xml)
- Replaced \`slf4j-simple\`, \`jcl-over-slf4j\`, \`log4j-over-slf4j\` with \`log4j-to-slf4j\`
- Simplifies the logging configuration and avoids binding conflicts

### 4. Fix logback.xml configuration
- Removed \`<include resource=\"org/springframework/boot/logging/logback/defaults.xml\"/>\` (not available in test classpath)
- Added explicit log pattern definition
- Changed root log level from \`DEBUG\` to \`INFO\` for cleaner test output
- Added POI logger configuration to reduce noise

## Compatibility Matrix

| Component | Version | Java Compatibility |
|-----------|---------|-------------------|
| slf4j-api | 2.0.17 | Java 8+ |
| logback-classic | 1.3.14 | Java 8+ |
| logback-core | 1.3.14 | Java 8+ |