### PR TITLE
refactor: replace FastExcel with FesodSheet in header merge strategy

### DIFF
--- a/fesod-sheet/src/test/java/org/apache/fesod/sheet/head/HeaderMergeStrategyTest.java
+++ b/fesod-sheet/src/test/java/org/apache/fesod/sheet/head/HeaderMergeStrategyTest.java
@@ -23,7 +23,7 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import org.apache.fesod.sheet.FastExcel;
+import org.apache.fesod.sheet.FesodSheet;
 import org.apache.fesod.sheet.enums.HeaderMergeStrategy;
 import org.apache.fesod.sheet.util.TestFileUtil;
 import org.apache.poi.ss.usermodel.Sheet;
@@ -59,7 +59,7 @@ public class HeaderMergeStrategyTest {
     @Test
     public void testNoneStrategy() {
         List<List<String>> head = createTestHead();
-        FastExcel.write(fileNone)
+        FesodSheet.write(fileNone)
                 .head(head)
                 .headerMergeStrategy(HeaderMergeStrategy.NONE)
                 .sheet()
@@ -79,7 +79,7 @@ public class HeaderMergeStrategyTest {
     @Test
     public void testHorizontalOnlyStrategy() {
         List<List<String>> head = createTestHead();
-        FastExcel.write(fileHorizontalOnly)
+        FesodSheet.write(fileHorizontalOnly)
                 .head(head)
                 .headerMergeStrategy(HeaderMergeStrategy.HORIZONTAL_ONLY)
                 .sheet()
@@ -107,7 +107,7 @@ public class HeaderMergeStrategyTest {
     @Test
     public void testVerticalOnlyStrategy() {
         List<List<String>> head = createTestHead();
-        FastExcel.write(fileVerticalOnly)
+        FesodSheet.write(fileVerticalOnly)
                 .head(head)
                 .headerMergeStrategy(HeaderMergeStrategy.VERTICAL_ONLY)
                 .sheet()
@@ -135,7 +135,7 @@ public class HeaderMergeStrategyTest {
     @Test
     public void testFullRectangleStrategy() {
         List<List<String>> head = createTestHead();
-        FastExcel.write(fileFullRectangle)
+        FesodSheet.write(fileFullRectangle)
                 .head(head)
                 .headerMergeStrategy(HeaderMergeStrategy.FULL_RECTANGLE)
                 .sheet()
@@ -164,7 +164,7 @@ public class HeaderMergeStrategyTest {
     @Test
     public void testAutoStrategy() {
         List<List<String>> head = createTestHead();
-        FastExcel.write(fileAuto)
+        FesodSheet.write(fileAuto)
                 .head(head)
                 .headerMergeStrategy(HeaderMergeStrategy.AUTO)
                 .sheet()

--- a/website/docs/sheet/help/parameter.md
+++ b/website/docs/sheet/help/parameter.md
@@ -186,7 +186,7 @@ The `headerMergeStrategy` parameter provides fine-grained control over how heade
 **Example**:
 
 ```java
-FastExcel.write(fileName)
+FesodSheet.write(fileName)
     .head(head)
     .headerMergeStrategy(HeaderMergeStrategy.FULL_RECTANGLE)
     .sheet()

--- a/website/docs/sheet/write/head.md
+++ b/website/docs/sheet/write/head.md
@@ -85,7 +85,7 @@ public void dynamicHeadWrite() {
 
 ### Overview
 
-By default, FastExcel automatically merges header cells with the same name. However, you can control the merge behavior using the `headerMergeStrategy` parameter.
+By default, Fesod automatically merges header cells with the same name. However, you can control the merge behavior using the `headerMergeStrategy` parameter.
 
 ### Merge Strategies
 
@@ -107,7 +107,7 @@ public void dynamicHeadWriteWithStrategy() {
         Collections.singletonList("动态数字标题"),
         Collections.singletonList("动态日期标题"));
 
-    FastExcel.write(fileName)
+    FesodSheet.write(fileName)
         .head(head)
         .headerMergeStrategy(HeaderMergeStrategy.FULL_RECTANGLE)
         .sheet()
@@ -120,7 +120,7 @@ public void dynamicHeadWriteWithStrategy() {
 **Disable merging**: Use `NONE` to completely disable automatic merging:
 
 ```java
-FastExcel.write(fileName)
+FesodSheet.write(fileName)
     .head(head)
     .headerMergeStrategy(HeaderMergeStrategy.NONE)
     .sheet()

--- a/website/i18n/zh-cn/docusaurus-plugin-content-docs/current/sheet/help/parameter.md
+++ b/website/i18n/zh-cn/docusaurus-plugin-content-docs/current/sheet/help/parameter.md
@@ -186,7 +186,7 @@ WriteWorkbook  --|>  WriteBasicParameter
 **示例**:
 
 ```java
-FastExcel.write(fileName)
+FesodSheet.write(fileName)
     .head(head)
     .headerMergeStrategy(HeaderMergeStrategy.FULL_RECTANGLE)
     .sheet()

--- a/website/i18n/zh-cn/docusaurus-plugin-content-docs/current/sheet/write/head.md
+++ b/website/i18n/zh-cn/docusaurus-plugin-content-docs/current/sheet/write/head.md
@@ -85,7 +85,7 @@ public void dynamicHeadWrite() {
 
 ### 概述
 
-默认情况下，FastExcel 会自动合并名称相同的表头单元格。但是，您可以使用 `headerMergeStrategy` 参数来控制合并行为。
+默认情况下，Fesod 会自动合并名称相同的表头单元格。但是，您可以使用 `headerMergeStrategy` 参数来控制合并行为。
 
 ### 合并策略
 
@@ -107,7 +107,7 @@ public void dynamicHeadWriteWithStrategy() {
         Collections.singletonList("动态数字标题"),
         Collections.singletonList("动态日期标题"));
 
-    FastExcel.write(fileName)
+    FesodSheet.write(fileName)
         .head(head)
         .headerMergeStrategy(HeaderMergeStrategy.FULL_RECTANGLE)
         .sheet()
@@ -120,7 +120,7 @@ public void dynamicHeadWriteWithStrategy() {
 **禁用合并**: 使用 `NONE` 完全禁用自动合并：
 
 ```java
-FastExcel.write(fileName)
+FesodSheet.write(fileName)
     .head(head)
     .headerMergeStrategy(HeaderMergeStrategy.NONE)
     .sheet()


### PR DESCRIPTION
## Description

This PR updates the remaining FastExcel references to FesodSheet in files introduced by PR #674.

## Changes
- Replace FastExcel class import with FesodSheet in HeaderMergeStrategyTest
- Update FastExcel.write() calls to FesodSheet.write() in test cases
- Update documentation references from FastExcel to Fesod in English and Chinese docs

## Related PR
- Related to #674 - This PR completes the refactoring by updating FastExcel references

## Files Modified
- fesod-sheet/src/test/java/org/apache/fesod/sheet/head/HeaderMergeStrategyTest.java
- website/docs/sheet/help/parameter.md
- website/docs/sheet/write/head.md
- website/i18n/zh-cn/docusaurus-plugin-content-docs/current/sheet/help/parameter.md
- website/i18n/zh-cn/docusaurus-plugin-content-docs/current/sheet/write/head.md
