### PR TITLE
ci: add concurrency control to GitHub Actions workflows

### DIFF
--- a/.github/workflows/ci-docs.yml
+++ b/.github/workflows/ci-docs.yml
@@ -22,6 +22,10 @@ on:
     paths:
       - 'website/**'
 
+concurrency:
+  group: ci-docs-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build-and-lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,10 @@ on:
       - 'LICENSE'
       - 'NOTICE'
 
+concurrency:
+  group: ci-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   checks: write
   pull-requests: write

--- a/.github/workflows/codeql-scan.yml
+++ b/.github/workflows/codeql-scan.yml
@@ -27,6 +27,10 @@ on:
   schedule:
     - cron: '0 0 * * *' # 每天0点自动扫描
 
+concurrency:
+  group: codeql-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   codeql:
     if: (github.event_name == 'schedule' && github.repository == 'apache/fesod') || (github.event_name != 'schedule')

--- a/.github/workflows/license-check.yml
+++ b/.github/workflows/license-check.yml
@@ -19,6 +19,10 @@ name: Check License Header
 
 on: [ push, pull_request ]
 
+concurrency:
+  group: license-check-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   license:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

This PR adds concurrency control to GitHub Actions workflows to optimize CI resource usage and provide faster feedback.

### Changes

- **CodeQL Security Scan**: Added concurrency group `codeql-${{ github.event.pull_request.number || github.ref }}`
- **Java CI**: Added concurrency group `ci-${{ github.event.pull_request.number || github.ref }}`
- **License Check**: Added concurrency group `license-check-${{ github.event.pull_request.number || github.ref }}`
- **Documentation CI**: Added concurrency group `ci-docs-${{ github.event.pull_request.number || github.ref }}`

### Benefits

- **Resource Optimization**: Automatically cancels outdated workflow runs when new commits are pushed
- **Faster Feedback**: Developers get CI results for the latest changes more quickly
- **Cost Reduction**: Prevents redundant workflow executions

### Implementation

Each workflow now includes:
```yaml
concurrency:
  group: <workflow-name>-${{ github.event.pull_request.number || github.ref }}
  cancel-in-progress: true
```

This ensures only one workflow run per PR or branch ref executes at a time.