### PR TITLE
chore(fuzz-tests): update Maven command to package for fuzz tests

### DIFF
--- a/.github/workflows/fuzz-tests.yml
+++ b/.github/workflows/fuzz-tests.yml
@@ -50,7 +50,7 @@ jobs:
         run: |
           mkdir -p "${{ runner.temp }}/jazzer-artifacts/"
           # Execute only tests under fuzz package and force tests not to be skipped
-          mvn -B -pl fesod-sheet -am -D"maven.test.skip=false" -DtrimStackTrace=false -D"test=org.apache.fesod.sheet.fuzz.*Test"  -D"surefire.failIfNoSpecifiedTests=false"  test
+          mvn -B -pl fesod-sheet -am -D"maven.test.skip=false" -DtrimStackTrace=false -D"test=org.apache.fesod.sheet.fuzz.*Test"  -D"surefire.failIfNoSpecifiedTests=false"  package
 
       - name: Upload Jazzer artifacts (crashes, repros)
         if: always()


### PR DESCRIPTION
Modified the Maven command in the fuzz-tests.yml to use the 'package' goal instead of 'test', ensuring that the build process includes packaging the application along with running the tests.

This change aligns with the new structure and improves the fuzz testing workflow.

<!--
Thanks very much for contributing to Apache Fesod (Incubating)! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

Closed: #ISSUE
Related: #ISSUE

-->

## Purpose of the pull request

Fix https://github.com/apache/fesod/actions/runs/20823383992/job/59817886639#step:4:1799

## What's changed?

<!--- Describe the change below, including rationale and design decisions -->

## Checklist

- [X] I have read the [Contributor Guide](https://fesod.apache.org/community/contribution/).
- [X] I have written the necessary doc or comment.
- [X] I have added the necessary unit tests and all cases have passed.
<img width="1779" height="1032" alt="image" src="https://github.com/user-attachments/assets/fc437ade-6bc1-4141-b5c9-d40bfd2ff546" />

