### PR TITLE
fix: correct wrong class reference in website documentation

### DIFF
--- a/website/docs/sheet/help/faq.md
+++ b/website/docs/sheet/help/faq.md
@@ -122,9 +122,21 @@ This section describes common issues that may arise when using this project.
 - **A:** You can customize cell styles by implementing the `WriteHandler` interface. For example:
 
   ```java
-  public class CustomCellStyleWriteHandler extends AbstractCellStyleWriteHandler {
+  public class CustomCellStyleWriteHandler extends AbstractCellStyleStrategy {
+    
       @Override
-      protected void setCellStyle(Cell cell, Head head, Integer relativeRowIndex) {
+      public int order() {
+          // Customize the execution order
+          return OrderConstant.SHEET_ORDER;
+      }
+
+      @Override
+      protected void setHeadCellStyle(CellWriteHandlerContext context) {
+          // Customize the head cell style
+      }
+  
+      @Override
+      protected void setContentCellStyle(Cell cell, Head head, Integer relativeRowIndex) {
           CellStyle style = cell.getSheet().getWorkbook().createCellStyle();
           style.setFillForegroundColor(IndexedColors.RED.getIndex());
           style.setFillPattern(FillPatternType.SOLID_FOREGROUND);
@@ -274,13 +286,25 @@ This section describes common issues that may arise when using this project.
 - **A:** You can customize the header style by implementing the `WriteHandler` interface. For example:
 
   ```java
-  public class CustomHeadStyleWriteHandler extends AbstractHeadStyleWriteHandler {
+  public class CustomHeadStyleWriteHandler extends AbstractCellStyleStrategy {
+  
+      @Override
+      public int order() {
+          // Customize the execution order
+          return OrderConstant.SHEET_ORDER;
+      }
+  
       @Override
       protected void setHeadCellStyle(Cell cell, Head head, Integer relativeRowIndex) {
           CellStyle style = cell.getSheet().getWorkbook().createCellStyle();
           style.setFillForegroundColor(IndexedColors.YELLOW.getIndex());
           style.setFillPattern(FillPatternType.SOLID_FOREGROUND);
           cell.setCellStyle(style);
+      }
+  
+      @Override
+      protected void setContentCellStyle(Cell cell, Head head, Integer relativeRowIndex) {
+          // Customize the content cell style
       }
   }
   ```
@@ -316,9 +340,21 @@ This section describes common issues that may arise when using this project.
 - **A:** You can set the font by creating a `Font` object and applying it to the `CellStyle`. For example:
 
   ```java
-  public class CustomFontWriteHandler extends AbstractCellStyleWriteHandler {
+  public class CustomFontWriteHandler extends AbstractCellStyleStrategy {
+  
       @Override
-      protected void setCellStyle(Cell cell, Head head, Integer relativeRowIndex) {
+      public int order() {
+          // Customize the execution order
+          return OrderConstant.SHEET_ORDER;
+      }
+
+      @Override
+      protected void setHeadCellStyle(CellWriteHandlerContext context) {
+          // Customize the head cell style
+      }
+  
+      @Override
+      protected void setContentCellStyle(Cell cell, Head head, Integer relativeRowIndex) {
           Workbook workbook = cell.getSheet().getWorkbook();
           Font font = workbook.createFont();
           font.setFontName("Arial");

--- a/website/i18n/zh-cn/docusaurus-plugin-content-docs/current/sheet/help/faq.md
+++ b/website/i18n/zh-cn/docusaurus-plugin-content-docs/current/sheet/help/faq.md
@@ -107,9 +107,21 @@ title: '常见问题'
 - **A:** 可以通过实现`WriteHandler`接口来自定义单元格样式。例如：
 
   ```java
-  public class CustomCellStyleWriteHandler extends AbstractCellStyleWriteHandler {
+  public class CustomCellStyleWriteHandler extends AbstractCellStyleStrategy {
+  
       @Override
-      protected void setCellStyle(Cell cell, Head head, Integer relativeRowIndex) {
+      public int order() {
+          // 自定义执行顺序
+          return OrderConstant.SHEET_ORDER;
+      }
+
+      @Override
+      protected void setHeadCellStyle(CellWriteHandlerContext context) {
+          // 自定义表头单元格样式
+      }
+  
+      @Override
+      protected void setContentCellStyle(Cell cell, Head head, Integer relativeRowIndex) {
           CellStyle style = cell.getSheet().getWorkbook().createCellStyle();
           style.setFillForegroundColor(IndexedColors.RED.getIndex());
           style.setFillPattern(FillPatternType.SOLID_FOREGROUND);
@@ -257,13 +269,25 @@ title: '常见问题'
 - **A:** 可以通过实现`WriteHandler`接口来自定义表头样式。例如：
 
   ```java
-  public class CustomHeadStyleWriteHandler extends AbstractHeadStyleWriteHandler {
+  public class CustomHeadStyleWriteHandler extends AbstractCellStyleStrategy {
+  
+       @Override
+      public int order() {
+          // 自定义执行顺序
+          return OrderConstant.SHEET_ORDER;
+      }
+  
       @Override
       protected void setHeadCellStyle(Cell cell, Head head, Integer relativeRowIndex) {
           CellStyle style = cell.getSheet().getWorkbook().createCellStyle();
           style.setFillForegroundColor(IndexedColors.YELLOW.getIndex());
           style.setFillPattern(FillPatternType.SOLID_FOREGROUND);
           cell.setCellStyle(style);
+      }
+  
+      @Override
+      protected void setContentCellStyle(Cell cell, Head head, Integer relativeRowIndex) {
+          // 自定义内容单元格样式
       }
   }
   ```
@@ -299,9 +323,21 @@ title: '常见问题'
 - **A:** 可以通过创建`Font`对象并应用到`CellStyle`中来设置字体。例如：
 
   ```java
-  public class CustomFontWriteHandler extends AbstractCellStyleWriteHandler {
+  public class CustomFontWriteHandler extends AbstractCellStyleStrategy {
+  
       @Override
-      protected void setCellStyle(Cell cell, Head head, Integer relativeRowIndex) {
+      public int order() {
+          // 自定义执行顺序
+          return OrderConstant.SHEET_ORDER;
+      }
+
+      @Override
+      protected void setHeadCellStyle(CellWriteHandlerContext context) {
+          // 自定义表头单元格样式
+      }
+  
+      @Override
+      protected void setContentCellStyle(Cell cell, Head head, Integer relativeRowIndex) {
           Workbook workbook = cell.getSheet().getWorkbook();
           Font font = workbook.createFont();
           font.setFontName("Arial");


### PR DESCRIPTION
<!--
Thanks very much for contributing to Apache Fesod (Incubating)! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

Closed: #ISSUE
Related: #ISSUE

-->

## Purpose of the pull request

Related: #835  

<!-- Describe the purpose of this pull request. For example: Closed: #ISSUE-->

## What's changed?

Correct the documentation by replacing the non‑existent `AbstractCellStyleWriteHandler` with the correct class `AbstractCellStyleStrategy`.

<!--- Describe the change below, including rationale and design decisions -->

## Checklist

- [x] I have read the [Contributor Guide](https://fesod.apache.org/community/contribution/).
- [x] I have written the necessary doc or comment.
- [ ] I have added the necessary unit tests and all cases have passed.
