### PR TITLE
refactor: support disabling CSV quote parsing by NONE_QUOTE

### DIFF
--- a/fesod-sheet/src/main/java/org/apache/fesod/sheet/metadata/csv/CsvConstant.java
+++ b/fesod-sheet/src/main/java/org/apache/fesod/sheet/metadata/csv/CsvConstant.java
@@ -34,6 +34,12 @@ public class CsvConstant {
     public static final char DOUBLE_QUOTE = '"';
 
     /**
+     * Represents a disabled quote character.
+     * When the quote is set to this value, the CSV parser will treat all quote characters as regular text.
+     */
+    public static final char NONE_QUOTE = '\0';
+
+    /**
      * line break
      */
     public static final String CR = "\r";

--- a/fesod-sheet/src/main/java/org/apache/fesod/sheet/read/builder/CsvReaderBuilder.java
+++ b/fesod-sheet/src/main/java/org/apache/fesod/sheet/read/builder/CsvReaderBuilder.java
@@ -61,6 +61,11 @@ public class CsvReaderBuilder extends AbstractExcelReaderParameterBuilder<CsvRea
 
     /**
      * Sets the quote character
+     * <p>
+     * If set to {@link org.apache.fesod.sheet.metadata.csv.CsvConstant#NONE_QUOTE}, the quote parsing logic will be disabled,
+     * and quote characters will be treated as regular text.This is equivalent to setting
+     * {@code quote} to {@code null} in Apache Commons CSV.
+     * </p>
      *
      * @param quote the quote character
      * @return Returns a CsvReaderBuilder object, enabling method chaining


### PR DESCRIPTION
- Add NONE_QUOTE constant in CsvConstant.
- Add Javadoc to CsvReaderBuilder#quote(Character quote) for NONE_QUOTE usage

## Purpose of the pull request

Closed: #846

## What's changed?

Rationale
Currently, the quote configuration in CsvReaderBuilder does not support an explicit "disabled" state. Setting it to null is ambiguous (could mean "use default" or "disable"). This PR introduces a special constant to explicitly disable quote parsing, which is essential for processing raw TSV/CSV data (like Amazon reports) where quotes are part of the literal content and should not be escaped or wrapped.

Design Decisions
Introduced CsvConstant.NONE_QUOTE ('\0'): Followed the industrial practice of Apache Commons CSV (where withQuote(null) disables quoting).

Enhanced Javadoc: Added clear instructions in CsvReaderBuilder#quote to guide users on how to use NONE_QUOTE.

## Checklist

- [✓] I have read the [Contributor Guide](https://fesod.apache.org/community/contribution/).
- [✓] I have written the necessary doc or comment.
- [✓] I have added the necessary unit tests and all cases have passed.
