### PR TITLE
feat(skill): add migration skill for transitioning from FastExcel to Fesod

### DIFF
--- a/.github/skills/fastexcel-to-fesod/SKILL.md
+++ b/.github/skills/fastexcel-to-fesod/SKILL.md
@@ -196,7 +196,7 @@ Then continue with the specific import mappings below.
 | `import cn.idev.excel.read.listener.PageReadListener;` | `import org.apache.fesod.sheet.read.listener.PageReadListener;` |
 | `import cn.idev.excel.read.metadata.ReadSheet;` | `import org.apache.fesod.sheet.read.metadata.ReadSheet;` |
 | `import cn.idev.excel.read.metadata.ReadWorkbook;` | `import org.apache.fesod.sheet.read.metadata.ReadWorkbook;` |
-| `import cn.idev.excel.read.metadata.ReadTable;` | `import org.apache.fesod.sheet.read.metadata.ReadTable;` |
+| `import cn.idev.excel.read.metadata.ReadBasicParameter;` | `import org.apache.fesod.sheet.read.metadata.ReadBasicParameter;` |
 | `import cn.idev.excel.read.builder.ExcelReaderBuilder;` | `import org.apache.fesod.sheet.read.builder.ExcelReaderBuilder;` |
 | `import cn.idev.excel.read.builder.ExcelReaderSheetBuilder;` | `import org.apache.fesod.sheet.read.builder.ExcelReaderSheetBuilder;` |
 | `import cn.idev.excel.context.AnalysisContext;` | `import org.apache.fesod.sheet.context.AnalysisContext;` |
@@ -209,6 +209,7 @@ Then continue with the specific import mappings below.
 | `import cn.idev.excel.write.metadata.WriteSheet;` | `import org.apache.fesod.sheet.write.metadata.WriteSheet;` |
 | `import cn.idev.excel.write.metadata.WriteWorkbook;` | `import org.apache.fesod.sheet.write.metadata.WriteWorkbook;` |
 | `import cn.idev.excel.write.metadata.WriteTable;` | `import org.apache.fesod.sheet.write.metadata.WriteTable;` |
+| `import cn.idev.excel.write.metadata.WriteBasicParameter;` | `import org.apache.fesod.sheet.write.metadata.WriteBasicParameter;` |
 | `import cn.idev.excel.write.builder.ExcelWriterBuilder;` | `import org.apache.fesod.sheet.write.builder.ExcelWriterBuilder;` |
 | `import cn.idev.excel.write.builder.ExcelWriterSheetBuilder;` | `import org.apache.fesod.sheet.write.builder.ExcelWriterSheetBuilder;` |
 | `import cn.idev.excel.write.builder.ExcelWriterTableBuilder;` | `import org.apache.fesod.sheet.write.builder.ExcelWriterTableBuilder;` |


### PR DESCRIPTION
<!--
Thanks very much for contributing to Apache Fesod (Incubating)! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

Closed: #ISSUE
Related: #857 

-->

## Purpose of the pull request

This commit introduces a new skill that facilitates the migration of Java projects from FastExcel 1.3 to Apache Fesod. The skill provides detailed instructions for updating dependencies, renaming packages, and handling breaking changes.
Related: #857

As Skill is an open standard for mostly IDE, so raise this as common upgrade script.

Here is one screenshot since Skill ran:
<img width="1867" height="993" alt="image" src="https://github.com/user-attachments/assets/a9f6b57c-31c3-4cec-aa98-9306e9bb977c" />

below is the sample upgrade result:
https://github.com/alaahong/fastexcel-legacy-demo/commit/d0e6abf8a80f10db2cce36d137a6729ff1f52302


## What's changed?

- Supports both legacy namespaces: cn.idev.excel.* and org.apache.fesod.excel.*
- Implements a three-phase migration process for gradual updates
- Includes comprehensive documentation for developers

## Checklist

- [X] I have read the [Contributor Guide](https://fesod.apache.org/community/contribution/).
- [X] I have written the necessary doc or comment.
- [X] I have added the necessary unit tests and all cases have passed.
