### PR TITLE
chore: bump DavidAnson/markdownlint-cli2-action from 21.0.0 to 22.0.0

### DIFF
--- a/.github/workflows/ci-docs.yml
+++ b/.github/workflows/ci-docs.yml
@@ -57,7 +57,7 @@ jobs:
         run: pnpm build
 
       - name: Lint markdown files
-        uses: DavidAnson/markdownlint-cli2-action@992badcdf24e3b8eb7e87ff9287fe931bcb00c6e
+        uses: DavidAnson/markdownlint-cli2-action@07035fd053f7be764496c0f8d8f9f41f98305101
         with:
           globs: 'website/**/*.md'
           config: 'website/.markdownlint-cli2.jsonc'


### PR DESCRIPTION
## Purpose of the pull request

Closed: #862 

## What's changed?

bump DavidAnson/markdownlint-cli2-action from 21.0.0 to 22.0.0

https://github.com/apache/infrastructure-actions/blob/9960dc7775cc92db3e40479d784213af9577c614/actions.yml#L82-L87

## Checklist

- [x] I have read the [Contributor Guide](https://fesod.apache.org/community/contribution/).
- [x] I have written the necessary doc or comment.
- [x] I have added the necessary unit tests and all cases have passed.
