### PR TITLE
Fix custom converters not being inherited from parent write holders

### DIFF
--- a/fesod-sheet/src/main/java/org/apache/fesod/sheet/write/metadata/holder/AbstractWriteHolder.java
+++ b/fesod-sheet/src/main/java/org/apache/fesod/sheet/write/metadata/holder/AbstractWriteHolder.java
@@ -130,6 +130,11 @@ public abstract class AbstractWriteHolder extends AbstractHolder implements Writ
     private Boolean orderByIncludeColumn;
 
     /**
+     * Custom converters for this holder
+     */
+    private List<Converter<?>> customConverterList;
+
+    /**
      * Write handler
      */
     private List<WriteHandler> writeHandlerList;
@@ -261,12 +266,22 @@ public abstract class AbstractWriteHolder extends AbstractHolder implements Writ
 
         // Set converterMap
         if (parentAbstractWriteHolder == null) {
-            setConverterMap(DefaultConverterLoader.loadDefaultWriteConverter());
+            setConverterMap(new HashMap<>(DefaultConverterLoader.loadDefaultWriteConverter()));
         } else {
             setConverterMap(new HashMap<>(parentAbstractWriteHolder.getConverterMap()));
+            if (CollectionUtils.isNotEmpty(parentAbstractWriteHolder.getCustomConverterList())) {
+                for (Converter<?> converter : parentAbstractWriteHolder.getCustomConverterList()) {
+                    getConverterMap()
+                            .put(
+                                    ConverterKeyBuild.buildKey(
+                                            converter.supportJavaTypeKey(), converter.supportExcelTypeKey()),
+                                    converter);
+                }
+            }
         }
         if (writeBasicParameter.getCustomConverterList() != null
                 && !writeBasicParameter.getCustomConverterList().isEmpty()) {
+            this.customConverterList = writeBasicParameter.getCustomConverterList();
             for (Converter<?> converter : writeBasicParameter.getCustomConverterList()) {
                 getConverterMap()
                         .put(

--- a/fesod-sheet/src/test/java/org/apache/fesod/sheet/converter/CustomConverterTest.java
+++ b/fesod-sheet/src/test/java/org/apache/fesod/sheet/converter/CustomConverterTest.java
@@ -103,7 +103,7 @@ public class CustomConverterTest {
     }
 
     @Test
-    void t06GlobalConverterWriteWithoutAnnotation() throws Exception {
+    void t06GlobalConverterWriteWithoutFieldLevelConverter() throws Exception {
         FesodSheet.write(converterCsvFile14)
                 .registerConverter(new TimestampStringConverter())
                 .sheet()

--- a/fesod-sheet/src/test/java/org/apache/fesod/sheet/converter/CustomConverterTest.java
+++ b/fesod-sheet/src/test/java/org/apache/fesod/sheet/converter/CustomConverterTest.java
@@ -30,6 +30,7 @@ import org.apache.fesod.sheet.converters.Converter;
 import org.apache.fesod.sheet.converters.ConverterKeyBuild;
 import org.apache.fesod.sheet.util.TestFileUtil;
 import org.apache.fesod.sheet.write.builder.ExcelWriterSheetBuilder;
+import org.apache.fesod.sheet.write.metadata.holder.WriteSheetHolder;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.MethodOrderer;
@@ -42,12 +43,16 @@ public class CustomConverterTest {
     private static File converterCsvFile10;
     private static File converterExcelFile11;
     private static File converterExcelFile12;
+    private static File converterExcelFile13;
+    private static File converterCsvFile14;
 
     @BeforeAll
     static void init() {
         converterCsvFile10 = TestFileUtil.createNewFile("converter10.csv");
         converterExcelFile11 = TestFileUtil.createNewFile("converter11.xls");
         converterExcelFile12 = TestFileUtil.createNewFile("converter12.xlsx");
+        converterExcelFile13 = TestFileUtil.createNewFile("converter13.xlsx");
+        converterCsvFile14 = TestFileUtil.createNewFile("converter14.csv");
     }
 
     @Test
@@ -83,12 +88,42 @@ public class CustomConverterTest {
         writeFile(converterExcelFile12);
     }
 
+    @Test
+    void t05GlobalConverterInSheetHolder() throws Exception {
+        TimestampStringConverter timestampStringConverter = new TimestampStringConverter();
+        ExcelWriter excelWriter = FesodSheet.write(converterExcelFile13)
+                .registerConverter(timestampStringConverter)
+                .build();
+        excelWriter.write(data(), new ExcelWriterSheetBuilder().sheetNo(0).build());
+        WriteSheetHolder sheetHolder = excelWriter.writeContext().writeSheetHolder();
+        Map<ConverterKeyBuild.ConverterKey, Converter<?>> sheetConverterMap = sheetHolder.converterMap();
+        excelWriter.finish();
+        Assertions.assertTrue(sheetConverterMap.containsKey(ConverterKeyBuild.buildKey(
+                timestampStringConverter.supportJavaTypeKey(), timestampStringConverter.supportExcelTypeKey())));
+    }
+
+    @Test
+    void t06GlobalConverterWriteWithoutAnnotation() throws Exception {
+        FesodSheet.write(converterCsvFile14)
+                .registerConverter(new TimestampStringConverter())
+                .sheet()
+                .doWrite(globalData());
+    }
+
     private void writeFile(File file) throws Exception {
         FesodSheet.write(file)
                 .registerConverter(new TimestampNumberConverter())
                 .registerConverter(new TimestampStringConverter())
                 .sheet()
                 .doWrite(data());
+    }
+
+    private List<GlobalConverterWriteData> globalData() throws Exception {
+        List<GlobalConverterWriteData> list = new ArrayList<>();
+        GlobalConverterWriteData writeData = new GlobalConverterWriteData();
+        writeData.setTimestampData(Timestamp.valueOf("2020-01-01 01:00:00"));
+        list.add(writeData);
+        return list;
     }
 
     private List<CustomConverterWriteData> data() throws Exception {

--- a/fesod-sheet/src/test/java/org/apache/fesod/sheet/converter/GlobalConverterWriteData.java
+++ b/fesod-sheet/src/test/java/org/apache/fesod/sheet/converter/GlobalConverterWriteData.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.fesod.sheet.converter;
+
+import java.sql.Timestamp;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+import org.apache.fesod.sheet.annotation.ExcelProperty;
+
+@Getter
+@Setter
+@EqualsAndHashCode
+public class GlobalConverterWriteData {
+    @ExcelProperty("时间戳-字符串")
+    private Timestamp timestampData;
+}


### PR DESCRIPTION
## Purpose

Closes #648

## What's changed?

The global custom converters weren't being inherited by child write holders. The parent holder wasn't storing which custom converters it had, so there was nothing to pass down when initializing child holders. Added a `customConverterList` field to track custom converters and updated the initialization logic to apply inherited converters when building the converter map. Also added a test to verify the behavior works correctly.

## Checklist

- [x] Read Contributor Guide
- [x] Documentation/comments added
- [x] Unit tests with passing cases