### PR TITLE
test: cover field-level converter precedence

### DIFF
--- a/fesod-sheet/src/test/java/org/apache/fesod/sheet/converter/CustomConverterTest.java
+++ b/fesod-sheet/src/test/java/org/apache/fesod/sheet/converter/CustomConverterTest.java
@@ -20,14 +20,21 @@
 package org.apache.fesod.sheet.converter;
 
 import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import org.apache.fesod.sheet.ExcelWriter;
 import org.apache.fesod.sheet.FesodSheet;
+import org.apache.fesod.sheet.annotation.ExcelProperty;
 import org.apache.fesod.sheet.converters.Converter;
 import org.apache.fesod.sheet.converters.ConverterKeyBuild;
+import org.apache.fesod.sheet.enums.CellDataTypeEnum;
+import org.apache.fesod.sheet.metadata.GlobalConfiguration;
+import org.apache.fesod.sheet.metadata.data.WriteCellData;
+import org.apache.fesod.sheet.metadata.property.ExcelContentProperty;
 import org.apache.fesod.sheet.util.TestFileUtil;
 import org.apache.fesod.sheet.write.builder.ExcelWriterSheetBuilder;
 import org.apache.fesod.sheet.write.metadata.holder.WriteSheetHolder;
@@ -45,6 +52,7 @@ public class CustomConverterTest {
     private static File converterExcelFile12;
     private static File converterExcelFile13;
     private static File converterCsvFile14;
+    private static File converterCsvFile15;
 
     @BeforeAll
     static void init() {
@@ -53,6 +61,7 @@ public class CustomConverterTest {
         converterExcelFile12 = TestFileUtil.createNewFile("converter12.xlsx");
         converterExcelFile13 = TestFileUtil.createNewFile("converter13.xlsx");
         converterCsvFile14 = TestFileUtil.createNewFile("converter14.csv");
+        converterCsvFile15 = TestFileUtil.createNewFile("converter15.csv");
     }
 
     @Test
@@ -110,6 +119,23 @@ public class CustomConverterTest {
                 .doWrite(globalData());
     }
 
+    @Test
+    void t07FieldLevelConverterTakesPrecedenceOverRegisteredConverter() throws Exception {
+        FieldLevelConverterWriteData writeData = new FieldLevelConverterWriteData();
+        writeData.setFieldValue("value");
+        writeData.setRegisteredValue("value");
+        List<FieldLevelConverterWriteData> list = new ArrayList<>();
+        list.add(writeData);
+
+        FesodSheet.write(converterCsvFile15, FieldLevelConverterWriteData.class)
+                .registerConverter(new RegisteredStringConverter())
+                .sheet()
+                .doWrite(list);
+
+        String csvContent = new String(Files.readAllBytes(converterCsvFile15.toPath()), StandardCharsets.UTF_8);
+        Assertions.assertTrue(csvContent.contains("field:value,registered:value"));
+    }
+
     private void writeFile(File file) throws Exception {
         FesodSheet.write(file)
                 .registerConverter(new TimestampNumberConverter())
@@ -133,5 +159,65 @@ public class CustomConverterTest {
         writeData.setTimestampNumberData(Timestamp.valueOf("2020-12-01 12:12:12"));
         list.add(writeData);
         return list;
+    }
+
+    public static class FieldLevelConverterWriteData {
+        @ExcelProperty(value = "fieldValue", converter = FieldLevelStringConverter.class)
+        private String fieldValue;
+
+        @ExcelProperty("registeredValue")
+        private String registeredValue;
+
+        public String getFieldValue() {
+            return fieldValue;
+        }
+
+        public void setFieldValue(String fieldValue) {
+            this.fieldValue = fieldValue;
+        }
+
+        public String getRegisteredValue() {
+            return registeredValue;
+        }
+
+        public void setRegisteredValue(String registeredValue) {
+            this.registeredValue = registeredValue;
+        }
+    }
+
+    public static class FieldLevelStringConverter implements Converter<String> {
+        @Override
+        public Class<?> supportJavaTypeKey() {
+            return String.class;
+        }
+
+        @Override
+        public CellDataTypeEnum supportExcelTypeKey() {
+            return CellDataTypeEnum.STRING;
+        }
+
+        @Override
+        public WriteCellData<?> convertToExcelData(
+                String value, ExcelContentProperty contentProperty, GlobalConfiguration globalConfiguration) {
+            return new WriteCellData<>("field:" + value);
+        }
+    }
+
+    public static class RegisteredStringConverter implements Converter<String> {
+        @Override
+        public Class<?> supportJavaTypeKey() {
+            return String.class;
+        }
+
+        @Override
+        public CellDataTypeEnum supportExcelTypeKey() {
+            return CellDataTypeEnum.STRING;
+        }
+
+        @Override
+        public WriteCellData<?> convertToExcelData(
+                String value, ExcelContentProperty contentProperty, GlobalConfiguration globalConfiguration) {
+            return new WriteCellData<>("registered:" + value);
+        }
     }
 }


### PR DESCRIPTION
<!--
Thanks very much for contributing to Apache Fesod (Incubating)! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

Closed: #ISSUE
Related: #ISSUE

-->

## Purpose of the pull request

<!-- Describe the purpose of this pull request. For example: Closed: #ISSUE-->

I've added test coverage for converter precedence when both a field-level converter and a registered converter could apply to the same Java type.

The behavior I wanted to lock down is that a converter declared directly on a field with `@ExcelProperty(converter = ...)` should take precedence over a converter registered through `registerConverter(...)`.


## What's changed?

<!--- Describe the change below, including rationale and design decisions -->

Added a regression test in `CustomConverterTest` for this case.

The test writes a CSV with two `String` fields. One field has a field-level converter declared with `@ExcelProperty`, and the other field has no field-level converter, so it should use the registered `String` converter.

The expected output contains both converted values: `field:value,registered:value`.

This verifies the registered converter is actually active for the unannotated field and the field-level converter still takes precedence for the annotated field.

This is useful because users may register a general converter as a default behavior, while still expecting field-specific converters to override it for special cases.

Tested with `fesod-sheet -Dmaven.test.skip=false -Dtest=CustomConverterTest test`.

Result: `Tests run: 7, Failures: 0, Errors: 0, Skipped: 0`.

## Checklist

- [x] I have read the [Contributor Guide](https://fesod.apache.org/community/contribution/).
- [x] I have written the necessary doc or comment.
- [x] I have added the necessary unit tests and all cases have passed.
