### PR TITLE
docs: update download page for release 2.0.2-incubating

### DIFF
--- a/website/docs/download.md
+++ b/website/docs/download.md
@@ -20,67 +20,36 @@ title: 'Download'
 - limitations under the License.
 -->
 
-Here is the Apache Fesod (Incubating) official download page. Apache Fesod provides source releases that can be
-downloaded from the ASF distribution site. Binary artifacts are available through Maven Central.
+# Download Apache Fesod (Incubating)
 
-# How to Use Apache Fesod (Incubating)
+Here is the Apache Fesod (Incubating) official download page. Apache Fesod provides source releases that can be downloaded from the ASF distribution site. Binary artifacts are available through Maven Central.
 
-## Using Maven Central (Recommended)
+## The Latest Stable Release
 
-For most users, simply add the dependency to your project:
+|     Version      |    Date    | Download                                                                                                                                                                                                                                                                                                                                                                                                  |                                 Release Notes                                  |
+|:----------------:|:----------:|:----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|:------------------------------------------------------------------------------:|
+| 2.0.2-incubating | 2026-05-30 | [apache-fesod-2.0.2-incubating-src.tar.gz](https://www.apache.org/dyn/closer.lua/incubator/fesod/2.0.2-incubating/apache-fesod-2.0.2-incubating-src.tar.gz ) ([asc](https://downloads.apache.org/incubator/fesod/2.0.2-incubating/apache-fesod-2.0.2-incubating-src.tar.gz.asc), [sha512](https://downloads.apache.org/incubator/fesod/2.0.2-incubating/apache-fesod-2.0.2-incubating-src.tar.gz.sha512)) | [Release Notes](https://github.com/apache/fesod/releases/tag/2.0.2-incubating) |
 
-:::tip
+## All Archived Releases
 
-```xml
-<dependency>
-    <groupId>org.apache.fesod</groupId>
-    <artifactId>fesod-sheet</artifactId>
-    <version>2.0.1-incubating</version>
-</dependency>
-```
+|     Version      |    Date    | Download                                                                                                                                                                                                                                                                                                                                                                                                  |                                 Release Notes                                  |
+|:----------------:|:----------:|:----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|:------------------------------------------------------------------------------:|
+| 2.0.1-incubating | 2026-02-11 | [apache-fesod-2.0.1-incubating-src.tar.gz](https://www.apache.org/dyn/closer.lua/incubator/fesod/2.0.1-incubating/apache-fesod-2.0.1-incubating-src.tar.gz ) ([asc](https://downloads.apache.org/incubator/fesod/2.0.1-incubating/apache-fesod-2.0.1-incubating-src.tar.gz.asc), [sha512](https://downloads.apache.org/incubator/fesod/2.0.1-incubating/apache-fesod-2.0.1-incubating-src.tar.gz.sha512)) | [Release Notes](https://github.com/apache/fesod/releases/tag/2.0.1-incubating) |
+| 2.0.0-incubating | 2026-01-24 | NA(Not Available)                                                                                                                                                                                                                                                                                                                                                                                         |                               NA(Not Available)                                |
 
-:::
+For older releases, please check the [archive](https://archive.apache.org/dist/incubator/fesod/).
 
-## Available Modules
+For non-Apache releases, please check the [non-apache releases](https://repo1.maven.org/maven2/cn/idev/excel/fastexcel/).
 
-- **fesod-sheet** - Core module for Excel/CSV processing (recommended for most users)
-- **fesod-common** - Common utilities (automatically included with fesod-sheet)
-- **fesod-shaded** - Shaded dependencies to avoid conflicts (automatically included with fesod-sheet)
+## Verifying Apache Releases
 
-# Apache Source Releases
+Before use, please refer to this [official guide](https://www.apache.org/info/verification.html) to verify all Apache release versions, including the integrity and authenticity of source code releases.
 
-## The Latest Release
+### Download Verification Files
 
-|     Version      |    Date    |                                                                                                                                                    Source Download                                                                                                                                                    |                                 Release Notes                                  |
-|:----------------:|:----------:|:---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------:|:------------------------------------------------------------------------------:|
-| 2.0.1-incubating | 2026-02-11 | [Source](https://downloads.apache.org/incubator/fesod/2.0.1-incubating/) ([asc](https://downloads.apache.org/incubator/fesod/2.0.1-incubating/apache-fesod-2.0.1-incubating-src.tar.gz.asc), [sha512](https://downloads.apache.org/incubator/fesod/2.0.1-incubating/apache-fesod-2.0.1-incubating-src.tar.gz.sha512)) | [Release Notes](https://github.com/apache/fesod/releases/tag/2.0.1-incubating) |
-| 2.0.0-incubating | 2026-01-24 |                                                                                                                                                   NA(Not Available)                                                                                                                                                   |                               NA(Not Available)                                |
+Download the [project release KEYS](https://downloads.apache.org/incubator/fesod/KEYS) file containing the public keys used for signing releases.
 
-# Previous Releases (Non-Apache)
-
-## All archived releases
-
-| Version |    Date    |                                                                                                                                                Download                                                                                                                                                |                        Release notes                        |
-|:-------:|:----------:|:------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------:|:-----------------------------------------------------------:|
-|  1.3.0  | 2025-08-23 | [fastexcel-1.3.0.jar](https://repo1.maven.org/maven2/cn/idev/excel/fastexcel/1.3.0/fastexcel-1.3.0.jar) ( [asc](https://repo1.maven.org/maven2/cn/idev/excel/fastexcel/1.3.0/fastexcel-1.3.0.jar.asc) \| [sha](https://repo1.maven.org/maven2/cn/idev/excel/fastexcel/1.3.0/fastexcel-1.3.0.jar.sha1)) | [notes](https://github.com/apache/fesod/releases/tag/1.3.0) |
-
-| Version |    Date    |                                                                                                                                                Download                                                                                                                                                |                        Release notes                        |
-|:-------:|:----------:|:------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------:|:-----------------------------------------------------------:|
-|  1.2.0  | 2025-04-14 | [fastexcel-1.2.0.jar](https://repo1.maven.org/maven2/cn/idev/excel/fastexcel/1.2.0/fastexcel-1.2.0.jar) ( [asc](https://repo1.maven.org/maven2/cn/idev/excel/fastexcel/1.2.0/fastexcel-1.2.0.jar.asc) \| [sha](https://repo1.maven.org/maven2/cn/idev/excel/fastexcel/1.2.0/fastexcel-1.2.0.jar.sha1)) | [notes](https://github.com/apache/fesod/releases/tag/1.2.0) |
-|  1.1.0  | 2025-01-14 | [fastexcel-1.1.0.jar](https://repo1.maven.org/maven2/cn/idev/excel/fastexcel/1.1.0/fastexcel-1.1.0.jar) ( [asc](https://repo1.maven.org/maven2/cn/idev/excel/fastexcel/1.1.0/fastexcel-1.1.0.jar.asc) \| [sha](https://repo1.maven.org/maven2/cn/idev/excel/fastexcel/1.1.0/fastexcel-1.1.0.jar.sha1)) | [notes](https://github.com/apache/fesod/releases/tag/1.1.0) |
-|  1.0.0  | 2024-12-05 | [fastexcel-1.0.0.jar](https://repo1.maven.org/maven2/cn/idev/excel/fastexcel/1.0.0/fastexcel-1.0.0.jar) ( [asc](https://repo1.maven.org/maven2/cn/idev/excel/fastexcel/1.0.0/fastexcel-1.0.0.jar.asc) \| [sha](https://repo1.maven.org/maven2/cn/idev/excel/fastexcel/1.0.0/fastexcel-1.0.0.jar.sha1)) | [notes](https://github.com/apache/fesod/releases/tag/1.0.0) |
-
-# Verifying Apache Releases
-
-All Apache releases must be verified before use. Follow these steps to verify the integrity and authenticity of the
-source release:
-
-## Download Verification Files
-
-Download the [KEYS](https://downloads.apache.org/incubator/fesod/KEYS) file containing the public keys used for signing
-releases.
-
-## Verify Signature
+### Verify Signature
 
 1. Import the KEYS file to your GPG keyring:
 
@@ -92,20 +61,20 @@ releases.
 
 3. Verify the GPG signature:
 
+    ```bash
+    gpg --verify apache-fesod-X.X.X-incubating-src.tar.gz.asc apache-fesod-X.X.X-incubating-src.tar.gz
+    ```
+
+### Verify Checksum
+
+Verify the `SHA-512` checksum:
+
 ```bash
-gpg --verify apache-fesod-2.0.1-incubating-src.tar.gz.asc apache-fesod-2.0.1-incubating-src.tar.gz
-```
-
-## Verify Checksum
-
-Verify the SHA-512 checksum:
-
-```bash
-shasum -a 512 -c apache-fesod-2.0.1-incubating-src.tar.gz.sha512
+shasum -a 512 -c apache-fesod-X.X.X-incubating-src.tar.gz.sha512
 ```
 
 Or on Linux:
 
 ```bash
-sha512sum -c apache-fesod-2.0.1-incubating-src.tar.gz.sha512
+sha512sum -c apache-fesod-X.X.X-incubating-src.tar.gz.sha512
 ```

--- a/website/docs/migration/from-fastexcel.md
+++ b/website/docs/migration/from-fastexcel.md
@@ -58,7 +58,7 @@ Replace your existing dependency with Apache Fesod (Incubating):
 | Source                          | GroupId          | ArtifactId  | Version           |
 |---------------------------------|------------------|-------------|-------------------|
 | **cn.idev FastExcel**           | cn.idev.excel    | fastexcel   | 1.3.0             |
-| **Apache Fesod (Incubating)** ✅ | org.apache.fesod | fesod-sheet | 2.0.1-incubating+ |
+| **Apache Fesod (Incubating)** ✅ | org.apache.fesod | fesod-sheet | 2.0.2-incubating+ |
 
 **Maven:**
 
@@ -78,7 +78,7 @@ After:
 <dependency>
     <groupId>org.apache.fesod</groupId>
     <artifactId>fesod-sheet</artifactId>
-    <version>2.0.1-incubating</version>
+    <version>2.0.2-incubating</version>
 </dependency>
 ```
 
@@ -93,7 +93,7 @@ implementation 'cn.idev.excel:fastexcel:1.3.0'
 After:
 
 ```gradle
-implementation 'org.apache.fesod:fesod-sheet:2.0.1-incubating'
+implementation 'org.apache.fesod:fesod-sheet:2.0.2-incubating'
 ```
 
 > **Note**: The `fesod-sheet` module is the core module for Excel/CSV processing. It automatically includes the necessary dependencies (`fesod-common` and `fesod-shaded`).

--- a/website/docs/quickstart/guide.md
+++ b/website/docs/quickstart/guide.md
@@ -29,6 +29,7 @@ Incubating) library:
 
 | Version          | JDK Version Support Range | Notes                    |
 |------------------|---------------------------|--------------------------|
+| 2.0.2-incubating | JDK8 - JDK25              | Apache Incubator release |
 | 2.0.1-incubating | JDK8 - JDK25              | Apache Incubator release |
 | 2.0.0-incubating | JDK8 - JDK25              | NA(not available)        |
 | 1.3.x            | JDK8 - JDK25              | Non-Apache release       |
@@ -66,7 +67,7 @@ If you are using Maven for project building, add the following configuration in 
 <dependency>
     <groupId>org.apache.fesod</groupId>
     <artifactId>fesod-sheet</artifactId>
-    <version>2.0.1-incubating</version>
+    <version>2.0.2-incubating</version>
 </dependency>
 ```
 
@@ -76,6 +77,6 @@ If you are using Gradle for project building, add the following configuration in
 
 ```gradle
 dependencies {
-    implementation 'org.apache.fesod:fesod-sheet:2.0.1-incubating'
+    implementation 'org.apache.fesod:fesod-sheet:2.0.2-incubating'
 }
 ```

--- a/website/i18n/zh-cn/docusaurus-plugin-content-docs/current/download.md
+++ b/website/i18n/zh-cn/docusaurus-plugin-content-docs/current/download.md
@@ -3,65 +3,37 @@ id: 'download'
 title: '下载'
 ---
 
-这是 Apache Fesod (Incubating) 的官方下载页面。Apache Fesod 提供可从 ASF 发布站点下载的源码发布。二进制构件可通过 Maven
+# 下载 Apache Fesod (Incubating)
+
+这是 Apache Fesod (Incubating) 的官方下载页面。提供可从 ASF 发布站点下载的源码发布。二进制构件可通过 Maven
 中央仓库获取。
-
-# 如何使用 Apache Fesod (Incubating)
-
-## 使用 Maven 中央仓库（推荐）
-
-对于大多数用户，只需在项目里添加以下依赖：
-
-:::tip
-
-```xml
-<dependency>
-    <groupId>org.apache.fesod</groupId>
-    <artifactId>fesod-sheet</artifactId>
-    <version>2.0.1-incubating</version>
-</dependency>
-```
-
-:::
-
-## 可用模块
-
-- **fesod-sheet** - Excel/CSV 处理的核心模块（推荐大多数用户使用）
-- **fesod-common** - 公共工具类（会随 fesod-sheet 自动引入）
-- **fesod-shaded** - 隔离的依赖以避免冲突（会随 fesod-sheet 自动引入）
-
-# Apache 源码发布
 
 ## 最新版本
 
-|        版本        |    发布日期    |                                                                                                                                                       源码下载                                                                                                                                                        |                                 版本说明                                  |
-|:----------------:|:----------:|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------:|:---------------------------------------------------------------------:|
-| 2.0.1-incubating | 2026-02-11 | [源码](https://downloads.apache.org/incubator/fesod/2.0.1-incubating/) ([asc](https://downloads.apache.org/incubator/fesod/2.0.1-incubating/apache-fesod-2.0.1-incubating-src.tar.gz.asc), [sha512](https://downloads.apache.org/incubator/fesod/2.0.1-incubating/apache-fesod-2.0.1-incubating-src.tar.gz.sha512)) | [版本说明](https://github.com/apache/fesod/releases/tag/2.0.1-incubating) |
-| 2.0.0-incubating | 2026-01-24 |                                                                                                                                                      NA(无效)                                                                                                                                                       |                                NA(无效)                                 |
+|        版本        |    发布日期    | 下载                                                                                                                                                                                                                                                                                                                                                                                                        |                                 版本说明                                  |
+|:----------------:|:----------:|:----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|:---------------------------------------------------------------------:|
+| 2.0.2-incubating | 2026-05-30 | [apache-fesod-2.0.2-incubating-src.tar.gz](https://www.apache.org/dyn/closer.lua/incubator/fesod/2.0.2-incubating/apache-fesod-2.0.2-incubating-src.tar.gz ) ([asc](https://downloads.apache.org/incubator/fesod/2.0.2-incubating/apache-fesod-2.0.2-incubating-src.tar.gz.asc), [sha512](https://downloads.apache.org/incubator/fesod/2.0.2-incubating/apache-fesod-2.0.2-incubating-src.tar.gz.sha512)) | [版本说明](https://github.com/apache/fesod/releases/tag/2.0.2-incubating) |
 
-# 发布版本（非 Apache 版本）
+## 归档版本
 
-## 历史版本
+|     版本      |    发布日期    | 下载                                                                                                                                                                                                                                                                                                                                                                                                  |                                 版本说明                                  |
+|:----------------:|:----------:|:----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|:------------------------------------------------------------------------------:|
+| 2.0.1-incubating | 2026-02-11 | [apache-fesod-2.0.1-incubating-src.tar.gz](https://www.apache.org/dyn/closer.lua/incubator/fesod/2.0.1-incubating/apache-fesod-2.0.1-incubating-src.tar.gz ) ([asc](https://downloads.apache.org/incubator/fesod/2.0.1-incubating/apache-fesod-2.0.1-incubating-src.tar.gz.asc), [sha512](https://downloads.apache.org/incubator/fesod/2.0.1-incubating/apache-fesod-2.0.1-incubating-src.tar.gz.sha512)) | [版本说明](https://github.com/apache/fesod/releases/tag/2.0.1-incubating) |
+| 2.0.0-incubating | 2026-01-24 | NA(Not Available)                                                                                                                                                                                                                                                                                                                                                                                         |                               NA(Not Available)                                |
 
-|  版本   |    发布日期    |                                                                                                                                                  下载地址                                                                                                                                                  |                            版本说明                             |
-|:-----:|:----------:|:------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------:|:-----------------------------------------------------------:|
-| 1.3.0 | 2025-08-23 | [fastexcel-1.3.0.jar](https://repo1.maven.org/maven2/cn/idev/excel/fastexcel/1.3.0/fastexcel-1.3.0.jar) ( [asc](https://repo1.maven.org/maven2/cn/idev/excel/fastexcel/1.3.0/fastexcel-1.3.0.jar.asc) \| [sha](https://repo1.maven.org/maven2/cn/idev/excel/fastexcel/1.3.0/fastexcel-1.3.0.jar.sha1)) | [notes](https://github.com/apache/fesod/releases/tag/1.3.0) |
+在这里查看所有历史已归档版本: [archive](https://archive.apache.org/dist/incubator/fesod/).
 
-|  版本   |    发布日期    |                                                                                                                                                  下载地址                                                                                                                                                  |                            版本说明                             |
-|:-----:|:----------:|:------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------:|:-----------------------------------------------------------:|
-| 1.2.0 | 2025-04-14 | [fastexcel-1.2.0.jar](https://repo1.maven.org/maven2/cn/idev/excel/fastexcel/1.2.0/fastexcel-1.2.0.jar) ( [asc](https://repo1.maven.org/maven2/cn/idev/excel/fastexcel/1.2.0/fastexcel-1.2.0.jar.asc) \| [sha](https://repo1.maven.org/maven2/cn/idev/excel/fastexcel/1.2.0/fastexcel-1.2.0.jar.sha1)) | [notes](https://github.com/apache/fesod/releases/tag/1.2.0) |
-| 1.1.0 | 2025-01-14 | [fastexcel-1.1.0.jar](https://repo1.maven.org/maven2/cn/idev/excel/fastexcel/1.1.0/fastexcel-1.1.0.jar) ( [asc](https://repo1.maven.org/maven2/cn/idev/excel/fastexcel/1.1.0/fastexcel-1.1.0.jar.asc) \| [sha](https://repo1.maven.org/maven2/cn/idev/excel/fastexcel/1.1.0/fastexcel-1.1.0.jar.sha1)) | [notes](https://github.com/apache/fesod/releases/tag/1.1.0) |
-| 1.0.0 | 2024-12-05 | [fastexcel-1.0.0.jar](https://repo1.maven.org/maven2/cn/idev/excel/fastexcel/1.0.0/fastexcel-1.0.0.jar) ( [asc](https://repo1.maven.org/maven2/cn/idev/excel/fastexcel/1.0.0/fastexcel-1.0.0.jar.asc) \| [sha](https://repo1.maven.org/maven2/cn/idev/excel/fastexcel/1.0.0/fastexcel-1.0.0.jar.sha1)) | [notes](https://github.com/apache/fesod/releases/tag/1.0.0) |
+在这里查看所有 non-Apache 版本: [non-apache releases](https://repo1.maven.org/maven2/cn/idev/excel/fastexcel/).
 
-# 验证 Apache 发布版本
+## 验证 Apache 发布版本
 
-在使用前必须验证所有 Apache 发布版本。请按以下步骤验证源码发布的完整性和真实性：
+在使用前，请参考这份[官方指南](https://www.apache.org/info/verification.html)验证所有 Apache 发布版本，包括验证源码发布的完整性和真实性。
 
-## 下载验证文件
+### 下载验证文件
 
 下载包含用于签署发布版本的公钥的 [KEYS](https://downloads.apache.org/incubator/fesod/KEYS) 文件。
 
-## 验证签名
+### 验证签名
 
 1. 将 KEYS 文件导入您的 GPG 密钥环：
 
@@ -73,20 +45,20 @@ title: '下载'
 
 3. 验证 GPG 签名：
 
-```bash
-gpg --verify apache-fesod-2.0.1-incubating-src.tar.gz.asc apache-fesod-2.0.1-incubating-src.tar.gz
-```
+   ```bash
+   gpg --verify apache-fesod-X.X.X-incubating-src.tar.gz.asc apache-fesod-X.X.X-incubating-src.tar.gz
+   ```
 
-## 验证校验和
+### 验证校验和
 
 验证 SHA-512 校验和：
 
 ```bash
-shasum -a 512 -c apache-fesod-2.0.1-incubating-src.tar.gz.sha512
+shasum -a 512 -c apache-fesod-X.X.X-incubating-src.tar.gz.sha512
 ```
 
 或在 Linux 上：
 
 ```bash
-sha512sum -c apache-fesod-2.0.1-incubating-src.tar.gz.sha512
+sha512sum -c apache-fesod-X.X.X-incubating-src.tar.gz.sha512
 ```

--- a/website/i18n/zh-cn/docusaurus-plugin-content-docs/current/migration/from-fastexcel.md
+++ b/website/i18n/zh-cn/docusaurus-plugin-content-docs/current/migration/from-fastexcel.md
@@ -41,7 +41,7 @@ keywords: [fesod, 迁移, fastexcel, apache, excel, 升级]
 | 来源                              | GroupId          | ArtifactId  | 版本                |
 |---------------------------------|------------------|-------------|-------------------|
 | **cn.idev FastExcel**           | cn.idev.excel    | fastexcel   | 1.3.0             |
-| **Apache Fesod (Incubating)** ✅ | org.apache.fesod | fesod-sheet | 2.0.1-incubating+ |
+| **Apache Fesod (Incubating)** ✅ | org.apache.fesod | fesod-sheet | 2.0.2-incubating+ |
 
 **Maven 配置：**
 
@@ -61,7 +61,7 @@ keywords: [fesod, 迁移, fastexcel, apache, excel, 升级]
 <dependency>
     <groupId>org.apache.fesod</groupId>
     <artifactId>fesod-sheet</artifactId>
-    <version>2.0.1-incubating</version>
+    <version>2.0.2-incubating</version>
 </dependency>
 ```
 
@@ -76,7 +76,7 @@ implementation 'cn.idev.excel:fastexcel:1.3.0'
 修改后：
 
 ```gradle
-implementation 'org.apache.fesod:fesod-sheet:2.0.1-incubating'
+implementation 'org.apache.fesod:fesod-sheet:2.0.2-incubating'
 ```
 
 > **注意**: `fesod-sheet` 模块是 Excel/CSV 处理的核心模块。它会自动引入必要的依赖（`fesod-common` 和 `fesod-shaded`）。

--- a/website/i18n/zh-cn/docusaurus-plugin-content-docs/current/quickstart/guide.md
+++ b/website/i18n/zh-cn/docusaurus-plugin-content-docs/current/quickstart/guide.md
@@ -11,6 +11,7 @@ title: '指南'
 
 | 版本               | jdk版本支持范围    | 备注           |
 |------------------|--------------|--------------|
+| 2.0.2-incubating | jdk8 - jdk25 | Apache 孵化器版本 |
 | 2.0.1-incubating | jdk8 - jdk25 | Apache 孵化器版本 |
 | 2.0.0-incubating | jdk8 - jdk25 | NA(无效)       |
 | 1.3.x            | jdk8 - jdk25 | 非 Apache 版本  |
@@ -45,7 +46,7 @@ Apache Fesod(Incubating) 使用了以下核心依赖：
 <dependency>
     <groupId>org.apache.fesod</groupId>
     <artifactId>fesod-sheet</artifactId>
-    <version>2.0.1-incubating</version>
+    <version>2.0.2-incubating</version>
 </dependency>
 ```
 
@@ -55,6 +56,6 @@ Apache Fesod(Incubating) 使用了以下核心依赖：
 
 ```gradle
 dependencies {
-    implementation 'org.apache.fesod:fesod-sheet:2.0.1-incubating'
+    implementation 'org.apache.fesod:fesod-sheet:2.0.2-incubating'
 }
 ```


### PR DESCRIPTION

## Purpose of the pull request

Update the download page for release 2.0.2-incubating, and review the relevant content on the download page to ensure that it complies with [ASF policy](https://infra.apache.org/release-download-pages.html) when this version is released.

## What's changed?

- Use the `closer.lua` utility to fix the download link.
- Add the link to the archived version.
- Remove the non-apache version information.

The results of the md-lint inspection are as follows:
```bash
> website@1.0.0 md-lint /Users/deleiguo/WorkSpace/gitrepo/deleiguo/fesod/website
> markdownlint-cli2 --config ./.markdownlint-cli2.jsonc "./**/*.md" "#node_modules"

markdownlint-cli2 v0.20.0 (markdownlint v0.40.0)
Finding: ./**/*.md !node_modules website/**/*.md !**/node_modules/** !**/target/** !**/dist/**
Linting: 119 file(s)
Summary: 0 error(s)
```

## Checklist

- [x] I have read the [Contributor Guide](https://fesod.apache.org/community/contribution/).
- [x] I have written the necessary doc or comment.
- [x] I have added the necessary unit tests and all cases have passed.
