### PR TITLE
refactor: manage password handling in Excel processing

### DIFF
--- a/fesod-sheet/src/main/java/org/apache/fesod/sheet/analysis/ExcelAnalyserImpl.java
+++ b/fesod-sheet/src/main/java/org/apache/fesod/sheet/analysis/ExcelAnalyserImpl.java
@@ -150,10 +150,6 @@ public class ExcelAnalyserImpl implements ExcelAnalyser {
                         poifsFileSystem.close();
                     }
                 }
-                // Set the user password for processing encrypted Excel files
-                if (readWorkbook.getPassword() != null) {
-                    Biff8EncryptionKey.setCurrentUserPassword(readWorkbook.getPassword());
-                }
                 XlsReadContext xlsReadContext = new DefaultXlsReadContext(readWorkbook, ExcelTypeEnum.XLS);
                 xlsReadContext.xlsReadWorkbookHolder().setPoifsFileSystem(poifsFileSystem);
                 analysisContext = xlsReadContext;

--- a/fesod-sheet/src/main/java/org/apache/fesod/sheet/analysis/v03/XlsSaxAnalyser.java
+++ b/fesod-sheet/src/main/java/org/apache/fesod/sheet/analysis/v03/XlsSaxAnalyser.java
@@ -85,6 +85,7 @@ import org.apache.poi.hssf.record.Record;
 import org.apache.poi.hssf.record.SSTRecord;
 import org.apache.poi.hssf.record.StringRecord;
 import org.apache.poi.hssf.record.TextObjectRecord;
+import org.apache.poi.hssf.record.crypto.Biff8EncryptionKey;
 
 /**
  * A text extractor for Excel files.
@@ -150,7 +151,12 @@ public class XlsSaxAnalyser implements HSSFListener, ExcelReadExecutor {
     public List<ReadSheet> sheetList() {
         try {
             if (xlsReadContext.readWorkbookHolder().getActualSheetDataList() == null) {
-                new XlsListSheetListener(xlsReadContext).execute();
+                try {
+                    setCurrentUserPassword();
+                    new XlsListSheetListener(xlsReadContext).execute();
+                } finally {
+                    clearCurrentUserPassword();
+                }
             }
         } catch (ExcelAnalysisStopException e) {
             if (log.isDebugEnabled()) {
@@ -185,6 +191,7 @@ public class XlsSaxAnalyser implements HSSFListener, ExcelReadExecutor {
         HSSFRequest request = new HSSFRequest();
         request.addListenerForAllRecords(xlsReadWorkbookHolder.getFormatTrackingHSSFListener());
         try {
+            setCurrentUserPassword();
             factory.processWorkbookEvents(request, xlsReadWorkbookHolder.getPoifsFileSystem());
         } catch (OldExcelFormatException e) {
             // POI reports very old BIFF (e.g., BIFF2) formats via OldExcelFormatException. Treat as benign:
@@ -204,10 +211,25 @@ public class XlsSaxAnalyser implements HSSFListener, ExcelReadExecutor {
             throw e;
         } catch (IOException e) {
             throw new ExcelAnalysisException(e);
+        } finally {
+            clearCurrentUserPassword();
         }
 
         // There are some special xls that do not have the terminator "[EOF]", so an additional
         xlsReadContext.analysisEventProcessor().endSheet(xlsReadContext);
+    }
+
+    private void setCurrentUserPassword() {
+        String password = xlsReadContext.readWorkbookHolder().getPassword();
+        if (password != null) {
+            Biff8EncryptionKey.setCurrentUserPassword(password);
+        }
+    }
+
+    private void clearCurrentUserPassword() {
+        if (xlsReadContext.readWorkbookHolder().getPassword() != null) {
+            Biff8EncryptionKey.setCurrentUserPassword(null);
+        }
     }
 
     protected boolean isOldExcelFormat(Throwable t) {

--- a/fesod-sheet/src/main/java/org/apache/fesod/sheet/util/WorkBookUtil.java
+++ b/fesod-sheet/src/main/java/org/apache/fesod/sheet/util/WorkBookUtil.java
@@ -93,8 +93,12 @@ public class WorkBookUtil {
                 writeWorkbookHolder.setCachedWorkbook(hssfWorkbook);
                 writeWorkbookHolder.setWorkbook(hssfWorkbook);
                 if (writeWorkbookHolder.getPassword() != null) {
-                    Biff8EncryptionKey.setCurrentUserPassword(writeWorkbookHolder.getPassword());
-                    hssfWorkbook.writeProtectWorkbook(writeWorkbookHolder.getPassword(), StringUtils.EMPTY);
+                    try {
+                        Biff8EncryptionKey.setCurrentUserPassword(writeWorkbookHolder.getPassword());
+                        hssfWorkbook.writeProtectWorkbook(writeWorkbookHolder.getPassword(), StringUtils.EMPTY);
+                    } finally {
+                        Biff8EncryptionKey.setCurrentUserPassword(null);
+                    }
                 }
                 return;
             case CSV:

--- a/fesod-sheet/src/test/java/org/apache/fesod/sheet/encrypt/EncryptDataTest.java
+++ b/fesod-sheet/src/test/java/org/apache/fesod/sheet/encrypt/EncryptDataTest.java
@@ -36,6 +36,7 @@ import org.apache.fesod.sheet.simple.SimpleData;
 import org.apache.fesod.sheet.support.ExcelTypeEnum;
 import org.apache.fesod.sheet.util.TestFileUtil;
 import org.apache.fesod.sheet.write.builder.ExcelWriterBuilder;
+import org.apache.poi.hssf.record.crypto.Biff8EncryptionKey;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.MethodOrderer;
@@ -126,7 +127,9 @@ public class EncryptDataTest {
         }
 
         excelWriterBuilder.sheet().doWrite(data());
+        Assertions.assertNull(Biff8EncryptionKey.getCurrentUserPassword());
         List<EncryptData> dataList = readerBuilder.sheet().doReadSync();
+        Assertions.assertNull(Biff8EncryptionKey.getCurrentUserPassword());
         Assertions.assertEquals(10, dataList.size());
         Assertions.assertNotNull(dataList.get(0).getName());
     }

--- a/fesod-sheet/src/test/java/org/apache/fesod/sheet/util/WorkBookUtilTest.java
+++ b/fesod-sheet/src/test/java/org/apache/fesod/sheet/util/WorkBookUtilTest.java
@@ -228,6 +228,7 @@ class WorkBookUtilTest {
 
         // Verify
         Mockito.verify(writeWorkbookHolder).setWorkbook(Mockito.any(HSSFWorkbook.class));
+        Assertions.assertNull(Biff8EncryptionKey.getCurrentUserPassword());
     }
 
     @Test


### PR DESCRIPTION
## Purpose of the pull request

Improve the lifecycle handling of POI encryption context in XLS read/write paths.

## What's changed?

- Scope encryption context setup to the XLS operations that require it.
- Clear the context in `finally` after XLS sheet listing, parsing, and write protection.
- Add regression assertions to verify the context is cleared after encrypted read/write flows.

## Checklist

- [X] I have read the [Contributor Guide](https://fesod.apache.org/community/contribution/).
- [X] I have written the necessary doc or comment.
- [X] I have added the necessary unit tests and all cases have passed.