### PR TITLE
feat: add support for column index limit in ReadSheet

### DIFF
--- a/fesod-sheet/src/main/java/org/apache/fesod/sheet/FesodSheet.java
+++ b/fesod-sheet/src/main/java/org/apache/fesod/sheet/FesodSheet.java
@@ -338,9 +338,12 @@ public class FesodSheet {
      * @param columnIndexes Specific columns to read (e.g., [0, 2] for Column A and C).
      * @return Excel sheet reader builder.
      */
-    public static ExcelReaderSheetBuilder readSheet(Integer sheetNo, java.util.List<Integer> columnIndexes) {
+    public static ExcelReaderSheetBuilder readSheetWithColumns(
+            Integer sheetNo, String sheetName, Integer numRows, List<Integer> columnIndexes) {
         return new ExcelReaderSheetBuilder()
                 .sheetNoIfNotNull(sheetNo)
+                .sheetNameIfNotNull(sheetName)
+                .numRowsIfNotNull(numRows)
                 .includeColumnIndexes(columnIndexes);
     }
 }

--- a/fesod-sheet/src/main/java/org/apache/fesod/sheet/FesodSheet.java
+++ b/fesod-sheet/src/main/java/org/apache/fesod/sheet/FesodSheet.java
@@ -22,6 +22,7 @@ package org.apache.fesod.sheet;
 import java.io.File;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.util.List;
 import org.apache.fesod.sheet.read.builder.ExcelReaderBuilder;
 import org.apache.fesod.sheet.read.builder.ExcelReaderSheetBuilder;
 import org.apache.fesod.sheet.read.listener.ReadListener;

--- a/fesod-sheet/src/main/java/org/apache/fesod/sheet/FesodSheet.java
+++ b/fesod-sheet/src/main/java/org/apache/fesod/sheet/FesodSheet.java
@@ -330,4 +330,17 @@ public class FesodSheet {
                 .sheetNameIfNotNull(sheetName)
                 .numRowsIfNotNull(numRows);
     }
+
+    /**
+     * Build excel the 'readSheet' targeting specific column indexes.
+     *
+     * @param sheetNo       Index of sheet, 0 base.
+     * @param columnIndexes Specific columns to read (e.g., [0, 2] for Column A and C).
+     * @return Excel sheet reader builder.
+     */
+    public static ExcelReaderSheetBuilder readSheet(Integer sheetNo, java.util.List<Integer> columnIndexes) {
+        return new ExcelReaderSheetBuilder()
+                .sheetNoIfNotNull(sheetNo)
+                .includeColumnIndexes(columnIndexes);
+    }
 }

--- a/fesod-sheet/src/main/java/org/apache/fesod/sheet/analysis/v07/handlers/CellTagHandler.java
+++ b/fesod-sheet/src/main/java/org/apache/fesod/sheet/analysis/v07/handlers/CellTagHandler.java
@@ -26,6 +26,7 @@
 package org.apache.fesod.sheet.analysis.v07.handlers;
 
 import java.math.BigDecimal;
+import java.util.List;
 import org.apache.fesod.common.util.BooleanUtils;
 import org.apache.fesod.common.util.PositionUtils;
 import org.apache.fesod.common.util.StringUtils;
@@ -134,7 +135,7 @@ public class CellTagHandler extends AbstractXlsxTagHandler {
         tempCellData.checkEmpty();
         tempCellData.setRowIndex(xlsxReadSheetHolder.getRowIndex());
         tempCellData.setColumnIndex(xlsxReadSheetHolder.getColumnIndex());
-        java.util.List<Integer> includeColumnIndexes = null;
+        List<Integer> includeColumnIndexes = null;
         if (xlsxReadContext.readSheetHolder() != null
                 && xlsxReadContext.readSheetHolder().getReadSheet() != null) {
             includeColumnIndexes =
@@ -142,18 +143,14 @@ public class CellTagHandler extends AbstractXlsxTagHandler {
         }
 
         if (includeColumnIndexes == null) {
-            // Default behavior: Keep raw Excel column index
             xlsxReadSheetHolder.getCellMap().put(xlsxReadSheetHolder.getColumnIndex(), tempCellData);
         } else {
             int targetIndex = includeColumnIndexes.indexOf(xlsxReadSheetHolder.getColumnIndex());
             if (targetIndex != -1) {
-                // If it's a target column, rewrite the cell's internal index and pack it sequentially!
+                // If it's a target column, rewrite the cell's internal index and pack it sequentially
                 tempCellData.setColumnIndex(targetIndex);
                 xlsxReadSheetHolder.getCellMap().put(targetIndex, tempCellData);
             }
-            // If targetIndex is -1, it's skipped entirely, leaving your map size at exactly 2
         }
-        // --- FILTER & REMAP LOGIC END ---
-        // xlsxReadSheetHolder.getCellMap().put(xlsxReadSheetHolder.getColumnIndex(), tempCellData);
     }
 }

--- a/fesod-sheet/src/main/java/org/apache/fesod/sheet/analysis/v07/handlers/CellTagHandler.java
+++ b/fesod-sheet/src/main/java/org/apache/fesod/sheet/analysis/v07/handlers/CellTagHandler.java
@@ -82,6 +82,25 @@ public class CellTagHandler extends AbstractXlsxTagHandler {
     public void endElement(XlsxReadContext xlsxReadContext, String name) {
         XlsxReadSheetHolder xlsxReadSheetHolder = xlsxReadContext.xlsxReadSheetHolder();
         ReadCellData<?> tempCellData = xlsxReadSheetHolder.getTempCellData();
+        int targetColumnIndex = 0;
+
+        List<Integer> includeColumnIndexes = null;
+        includeColumnIndexes = xlsxReadContext.readSheetHolder().getReadSheet().getColumnIndexes();
+
+        if (includeColumnIndexes == null) {
+            targetColumnIndex = xlsxReadSheetHolder.getColumnIndex();
+            // xlsxReadSheetHolder.getCellMap().put(xlsxReadSheetHolder.getColumnIndex(), tempCellData);
+        } else {
+            targetColumnIndex = includeColumnIndexes.indexOf(xlsxReadSheetHolder.getColumnIndex());
+            if (targetColumnIndex != -1) {
+                // If it's a target column, rewrite the cell's internal index and pack it sequentially
+                tempCellData.setColumnIndex(targetColumnIndex);
+                // xlsxReadSheetHolder.getCellMap().put(targetIndex, tempCellData);
+            } else {
+                return;
+            }
+        }
+
         StringBuilder tempData = xlsxReadSheetHolder.getTempData();
         String tempDataString = tempData.toString();
         CellDataTypeEnum oldType = tempCellData.getType();
@@ -131,26 +150,9 @@ public class CellTagHandler extends AbstractXlsxTagHandler {
                 tempCellData.setStringValue(tempCellData.getStringValue().trim());
             }
         }
-
         tempCellData.checkEmpty();
         tempCellData.setRowIndex(xlsxReadSheetHolder.getRowIndex());
         tempCellData.setColumnIndex(xlsxReadSheetHolder.getColumnIndex());
-        List<Integer> includeColumnIndexes = null;
-        if (xlsxReadContext.readSheetHolder() != null
-                && xlsxReadContext.readSheetHolder().getReadSheet() != null) {
-            includeColumnIndexes =
-                    xlsxReadContext.readSheetHolder().getReadSheet().getColumnIndexes();
-        }
-
-        if (includeColumnIndexes == null) {
-            xlsxReadSheetHolder.getCellMap().put(xlsxReadSheetHolder.getColumnIndex(), tempCellData);
-        } else {
-            int targetIndex = includeColumnIndexes.indexOf(xlsxReadSheetHolder.getColumnIndex());
-            if (targetIndex != -1) {
-                // If it's a target column, rewrite the cell's internal index and pack it sequentially
-                tempCellData.setColumnIndex(targetIndex);
-                xlsxReadSheetHolder.getCellMap().put(targetIndex, tempCellData);
-            }
-        }
+        xlsxReadSheetHolder.getCellMap().put(targetColumnIndex, tempCellData);
     }
 }

--- a/fesod-sheet/src/main/java/org/apache/fesod/sheet/analysis/v07/handlers/CellTagHandler.java
+++ b/fesod-sheet/src/main/java/org/apache/fesod/sheet/analysis/v07/handlers/CellTagHandler.java
@@ -84,18 +84,17 @@ public class CellTagHandler extends AbstractXlsxTagHandler {
         ReadCellData<?> tempCellData = xlsxReadSheetHolder.getTempCellData();
         int targetColumnIndex = 0;
 
-        List<Integer> includeColumnIndexes = null;
-        includeColumnIndexes = xlsxReadContext.readSheetHolder().getReadSheet().getColumnIndexes();
+        List<Integer> includeColumnIndexes =
+                xlsxReadContext.readSheetHolder().getReadSheet().getColumnIndexes();
 
         if (includeColumnIndexes == null) {
             targetColumnIndex = xlsxReadSheetHolder.getColumnIndex();
-            // xlsxReadSheetHolder.getCellMap().put(xlsxReadSheetHolder.getColumnIndex(), tempCellData);
+            tempCellData.setColumnIndex(xlsxReadSheetHolder.getColumnIndex());
         } else {
             targetColumnIndex = includeColumnIndexes.indexOf(xlsxReadSheetHolder.getColumnIndex());
             if (targetColumnIndex != -1) {
                 // If it's a target column, rewrite the cell's internal index and pack it sequentially
                 tempCellData.setColumnIndex(targetColumnIndex);
-                // xlsxReadSheetHolder.getCellMap().put(targetIndex, tempCellData);
             } else {
                 return;
             }
@@ -152,7 +151,6 @@ public class CellTagHandler extends AbstractXlsxTagHandler {
         }
         tempCellData.checkEmpty();
         tempCellData.setRowIndex(xlsxReadSheetHolder.getRowIndex());
-        tempCellData.setColumnIndex(xlsxReadSheetHolder.getColumnIndex());
         xlsxReadSheetHolder.getCellMap().put(targetColumnIndex, tempCellData);
     }
 }

--- a/fesod-sheet/src/main/java/org/apache/fesod/sheet/analysis/v07/handlers/CellTagHandler.java
+++ b/fesod-sheet/src/main/java/org/apache/fesod/sheet/analysis/v07/handlers/CellTagHandler.java
@@ -149,7 +149,7 @@ public class CellTagHandler extends AbstractXlsxTagHandler {
         }
         tempCellData.checkEmpty();
         tempCellData.setRowIndex(xlsxReadSheetHolder.getRowIndex());
-        tempCellData.setColumnIndex(xlsxReadSheetHolder.getColumnIndex());
+        tempCellData.setColumnIndex(targetColumnIndex);
         xlsxReadSheetHolder.getCellMap().put(targetColumnIndex, tempCellData);
     }
 }

--- a/fesod-sheet/src/main/java/org/apache/fesod/sheet/analysis/v07/handlers/CellTagHandler.java
+++ b/fesod-sheet/src/main/java/org/apache/fesod/sheet/analysis/v07/handlers/CellTagHandler.java
@@ -134,6 +134,26 @@ public class CellTagHandler extends AbstractXlsxTagHandler {
         tempCellData.checkEmpty();
         tempCellData.setRowIndex(xlsxReadSheetHolder.getRowIndex());
         tempCellData.setColumnIndex(xlsxReadSheetHolder.getColumnIndex());
-        xlsxReadSheetHolder.getCellMap().put(xlsxReadSheetHolder.getColumnIndex(), tempCellData);
+        java.util.List<Integer> includeColumnIndexes = null;
+        if (xlsxReadContext.readSheetHolder() != null
+                && xlsxReadContext.readSheetHolder().getReadSheet() != null) {
+            includeColumnIndexes =
+                    xlsxReadContext.readSheetHolder().getReadSheet().getColumnIndexes();
+        }
+
+        if (includeColumnIndexes == null) {
+            // Default behavior: Keep raw Excel column index
+            xlsxReadSheetHolder.getCellMap().put(xlsxReadSheetHolder.getColumnIndex(), tempCellData);
+        } else {
+            int targetIndex = includeColumnIndexes.indexOf(xlsxReadSheetHolder.getColumnIndex());
+            if (targetIndex != -1) {
+                // If it's a target column, rewrite the cell's internal index and pack it sequentially!
+                tempCellData.setColumnIndex(targetIndex);
+                xlsxReadSheetHolder.getCellMap().put(targetIndex, tempCellData);
+            }
+            // If targetIndex is -1, it's skipped entirely, leaving your map size at exactly 2
+        }
+        // --- FILTER & REMAP LOGIC END ---
+        // xlsxReadSheetHolder.getCellMap().put(xlsxReadSheetHolder.getColumnIndex(), tempCellData);
     }
 }

--- a/fesod-sheet/src/main/java/org/apache/fesod/sheet/analysis/v07/handlers/CellTagHandler.java
+++ b/fesod-sheet/src/main/java/org/apache/fesod/sheet/analysis/v07/handlers/CellTagHandler.java
@@ -89,13 +89,11 @@ public class CellTagHandler extends AbstractXlsxTagHandler {
 
         if (includeColumnIndexes == null) {
             targetColumnIndex = xlsxReadSheetHolder.getColumnIndex();
-            tempCellData.setColumnIndex(xlsxReadSheetHolder.getColumnIndex());
         } else {
+            // if it's a target column, rewrite the cell's internal index
             targetColumnIndex = includeColumnIndexes.indexOf(xlsxReadSheetHolder.getColumnIndex());
-            if (targetColumnIndex != -1) {
-                // If it's a target column, rewrite the cell's internal index and pack it sequentially
-                tempCellData.setColumnIndex(targetColumnIndex);
-            } else {
+            if (targetColumnIndex < 0) {
+
                 return;
             }
         }
@@ -151,6 +149,7 @@ public class CellTagHandler extends AbstractXlsxTagHandler {
         }
         tempCellData.checkEmpty();
         tempCellData.setRowIndex(xlsxReadSheetHolder.getRowIndex());
+        tempCellData.setColumnIndex(xlsxReadSheetHolder.getColumnIndex());
         xlsxReadSheetHolder.getCellMap().put(targetColumnIndex, tempCellData);
     }
 }

--- a/fesod-sheet/src/main/java/org/apache/fesod/sheet/read/builder/ExcelReaderSheetBuilder.java
+++ b/fesod-sheet/src/main/java/org/apache/fesod/sheet/read/builder/ExcelReaderSheetBuilder.java
@@ -119,13 +119,13 @@ public class ExcelReaderSheetBuilder extends AbstractExcelReaderParameterBuilder
      * @return
      */
     public ExcelReaderSheetBuilder includeColumnIndexes(List<Integer> columnIndexes) {
-        readSheet.setIncludeColumnIndexes(columnIndexes);
+        readSheet.setColumnIndexes(columnIndexes);
         return this;
     }
 
     public ExcelReaderSheetBuilder includeColumnIndexesIfNotNull(List<Integer> columnIndexes) {
         if (Objects.nonNull(columnIndexes)) {
-            readSheet.setIncludeColumnIndexes(columnIndexes);
+            readSheet.setColumnIndexes(columnIndexes);
         }
         return this;
     }

--- a/fesod-sheet/src/main/java/org/apache/fesod/sheet/read/builder/ExcelReaderSheetBuilder.java
+++ b/fesod-sheet/src/main/java/org/apache/fesod/sheet/read/builder/ExcelReaderSheetBuilder.java
@@ -113,6 +113,23 @@ public class ExcelReaderSheetBuilder extends AbstractExcelReaderParameterBuilder
     }
 
     /**
+     * Specific columns to read
+     *
+     * @param columnIndexes
+     * @return
+     */
+    public ExcelReaderSheetBuilder includeColumnIndexes(List<Integer> columnIndexes) {
+        readSheet.setIncludeColumnIndexes(columnIndexes);
+        return this;
+    }
+
+    public ExcelReaderSheetBuilder includeColumnIndexesIfNotNull(List<Integer> columnIndexes) {
+        if (Objects.nonNull(columnIndexes)) {
+            readSheet.setIncludeColumnIndexes(columnIndexes);
+        }
+        return this;
+    }
+    /**
      * Sax read
      */
     public void doRead() {

--- a/fesod-sheet/src/main/java/org/apache/fesod/sheet/read/metadata/ReadSheet.java
+++ b/fesod-sheet/src/main/java/org/apache/fesod/sheet/read/metadata/ReadSheet.java
@@ -25,8 +25,8 @@
 
 package org.apache.fesod.sheet.read.metadata;
 
-import lombok.EqualsAndHashCode;
 import java.util.List;
+import lombok.EqualsAndHashCode;
 
 /**
  * Read sheet
@@ -121,8 +121,8 @@ public class ReadSheet extends ReadBasicParameter {
         return this.includeColumnIndexes;
     }
 
-    public void setIncludeColumnIndexes(java.util.List<Integer> includeColumnIndexes) {
-        this.includeColumnIndexes = columnIndexes;
+    public void setIncludeColumnIndexes(List<Integer> includeColumnIndexes) {
+        this.includeColumnIndexes = includeColumnIndexes;
     }
 
     public void copyBasicParameter(ReadSheet other) {

--- a/fesod-sheet/src/main/java/org/apache/fesod/sheet/read/metadata/ReadSheet.java
+++ b/fesod-sheet/src/main/java/org/apache/fesod/sheet/read/metadata/ReadSheet.java
@@ -26,6 +26,7 @@
 package org.apache.fesod.sheet.read.metadata;
 
 import lombok.EqualsAndHashCode;
+import java.util.List;
 
 /**
  * Read sheet
@@ -53,6 +54,11 @@ public class ReadSheet extends ReadBasicParameter {
      * The number of rows to read, the default is all, start with 0.
      */
     public Integer numRows;
+
+    /**
+     * Specific columns to read (0-based indexes)
+     */
+    private java.util.List<Integer> includeColumnIndexes;
 
     public ReadSheet() {}
 
@@ -111,6 +117,14 @@ public class ReadSheet extends ReadBasicParameter {
         this.sheetVeryHidden = sheetVeryHidden;
     }
 
+    public List<Integer> getIncludeColumnIndexes() {
+        return this.includeColumnIndexes;
+    }
+
+    public void setIncludeColumnIndexes(java.util.List<Integer> includeColumnIndexes) {
+        this.includeColumnIndexes = columnIndexes;
+    }
+
     public void copyBasicParameter(ReadSheet other) {
         if (other == null) {
             return;
@@ -126,6 +140,7 @@ public class ReadSheet extends ReadBasicParameter {
         this.setNumRows(other.getNumRows());
         this.setHidden(other.isHidden());
         this.setVeryHidden(other.isVeryHidden());
+        this.setIncludeColumnIndexes(other.getIncludeColumnIndexes());
     }
 
     @Override

--- a/fesod-sheet/src/main/java/org/apache/fesod/sheet/read/metadata/ReadSheet.java
+++ b/fesod-sheet/src/main/java/org/apache/fesod/sheet/read/metadata/ReadSheet.java
@@ -58,7 +58,7 @@ public class ReadSheet extends ReadBasicParameter {
     /**
      * Specific columns to read (0-based indexes)
      */
-    private java.util.List<Integer> includeColumnIndexes;
+    private List<Integer> columnIndexes;
 
     public ReadSheet() {}
 
@@ -75,6 +75,13 @@ public class ReadSheet extends ReadBasicParameter {
         this.sheetNo = sheetNo;
         this.sheetName = sheetName;
         this.numRows = numRows;
+    }
+
+    public ReadSheet(Integer sheetNo, String sheetName, Integer numRows, Integer numCols) {
+        this.sheetNo = sheetNo;
+        this.sheetName = sheetName;
+        this.numRows = numRows;
+        this.columnIndexes = columnIndexes;
     }
 
     public Integer getSheetNo() {
@@ -117,12 +124,12 @@ public class ReadSheet extends ReadBasicParameter {
         this.sheetVeryHidden = sheetVeryHidden;
     }
 
-    public List<Integer> getIncludeColumnIndexes() {
-        return this.includeColumnIndexes;
+    public List<Integer> getColumnIndexes() {
+        return this.columnIndexes;
     }
 
-    public void setIncludeColumnIndexes(List<Integer> includeColumnIndexes) {
-        this.includeColumnIndexes = includeColumnIndexes;
+    public void setColumnIndexes(List<Integer> columnIndexes) {
+        this.columnIndexes = columnIndexes;
     }
 
     public void copyBasicParameter(ReadSheet other) {
@@ -140,7 +147,7 @@ public class ReadSheet extends ReadBasicParameter {
         this.setNumRows(other.getNumRows());
         this.setHidden(other.isHidden());
         this.setVeryHidden(other.isVeryHidden());
-        this.setIncludeColumnIndexes(other.getIncludeColumnIndexes());
+        this.setColumnIndexes(other.getColumnIndexes());
     }
 
     @Override

--- a/fesod-sheet/src/main/java/org/apache/fesod/sheet/read/metadata/ReadSheet.java
+++ b/fesod-sheet/src/main/java/org/apache/fesod/sheet/read/metadata/ReadSheet.java
@@ -77,11 +77,11 @@ public class ReadSheet extends ReadBasicParameter {
         this.numRows = numRows;
     }
 
-    public ReadSheet(Integer sheetNo, String sheetName, Integer numRows, Integer numCols) {
+    public ReadSheet(Integer sheetNo, String sheetName, Integer numRows, List<Integer> numCols) {
         this.sheetNo = sheetNo;
         this.sheetName = sheetName;
         this.numRows = numRows;
-        this.columnIndexes = columnIndexes;
+        this.columnIndexes = numCols;
     }
 
     public Integer getSheetNo() {

--- a/fesod-sheet/src/main/java/org/apache/fesod/sheet/read/metadata/ReadWorkbook.java
+++ b/fesod-sheet/src/main/java/org/apache/fesod/sheet/read/metadata/ReadWorkbook.java
@@ -145,6 +145,11 @@ public class ReadWorkbook extends ReadBasicParameter {
     private Integer numRows;
 
     /**
+     * The number of columns to read, the default is all, start with 0.
+     */
+    private Integer numColumns;
+
+    /**
      * Ignore hidden sheet.
      */
     private Boolean ignoreHiddenSheet;

--- a/fesod-sheet/src/main/java/org/apache/fesod/sheet/read/metadata/ReadWorkbook.java
+++ b/fesod-sheet/src/main/java/org/apache/fesod/sheet/read/metadata/ReadWorkbook.java
@@ -28,6 +28,7 @@ package org.apache.fesod.sheet.read.metadata;
 import java.io.File;
 import java.io.InputStream;
 import java.nio.charset.Charset;
+import java.util.List;
 import java.util.Set;
 import javax.xml.parsers.SAXParserFactory;
 import lombok.EqualsAndHashCode;
@@ -145,9 +146,9 @@ public class ReadWorkbook extends ReadBasicParameter {
     private Integer numRows;
 
     /**
-     * The number of columns to read, the default is all, start with 0.
+     * The indexes of columns to read, the default is all, start with 0.
      */
-    private Integer numColumns;
+    private List<Integer> numColumns;
 
     /**
      * Ignore hidden sheet.

--- a/fesod-sheet/src/main/java/org/apache/fesod/sheet/read/metadata/ReadWorkbook.java
+++ b/fesod-sheet/src/main/java/org/apache/fesod/sheet/read/metadata/ReadWorkbook.java
@@ -28,7 +28,6 @@ package org.apache.fesod.sheet.read.metadata;
 import java.io.File;
 import java.io.InputStream;
 import java.nio.charset.Charset;
-import java.util.List;
 import java.util.Set;
 import javax.xml.parsers.SAXParserFactory;
 import lombok.EqualsAndHashCode;
@@ -144,11 +143,6 @@ public class ReadWorkbook extends ReadBasicParameter {
      * The number of rows to read, the default is all, start with 0.
      */
     private Integer numRows;
-
-    /**
-     * The indexes of columns to read, the default is all, start with 0.
-     */
-    private List<Integer> numColumns;
 
     /**
      * Ignore hidden sheet.

--- a/fesod-sheet/src/test/java/org/apache/fesod/sheet/FesodSheetTest.java
+++ b/fesod-sheet/src/test/java/org/apache/fesod/sheet/FesodSheetTest.java
@@ -24,8 +24,10 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.lang.reflect.Method;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import org.apache.fesod.sheet.read.builder.ExcelReaderBuilder;
 import org.apache.fesod.sheet.read.builder.ExcelReaderSheetBuilder;
 import org.apache.fesod.sheet.read.listener.ReadListener;
@@ -253,18 +255,36 @@ class FesodSheetTest {
     @Test
     void testReadSheet_withColumnIndexes_shouldConfigureAll() {
 
+        java.util.List<java.util.List<String>> head = new java.util.ArrayList<>();
+        head.add(new ArrayList<>(Arrays.asList("ID")));
+        head.add(new ArrayList<>(Arrays.asList("Name")));
+        head.add(new ArrayList<>(Arrays.asList("Age")));
+        head.add(new ArrayList<>(Arrays.asList("Gender")));
+
+        List<List<Object>> dataList = new ArrayList<>();
+        dataList.add(Arrays.asList("1", "Alice", "30", "Female"));
+
+        FesodSheet.write(tempFile).head(head).sheet("Sheet1").doWrite(dataList);
+
         List<Integer> targetColumns = Arrays.asList(0, 2);
 
-        ExcelReaderSheetBuilder builder = FesodSheet.readSheetWithColumns(1, "DataSheet", 100, targetColumns);
-
-        Assertions.assertNotNull(builder, "Builder should not be null");
-
+        ExcelReaderSheetBuilder builder = FesodSheet.readSheetWithColumns(0, "Sheet1", 100, targetColumns);
         ReadSheet configuredSheet = builder.build();
-        Assertions.assertNotNull(configuredSheet, "The internal ReadSheet should be created");
+        List<Map<Integer, String>> readResults =
+                FesodSheet.read(tempFile).sheet(configuredSheet).doReadSync();
 
+        // builder tests
+        Assertions.assertNotNull(builder, "Builder should not be null");
+        Assertions.assertNotNull(configuredSheet, "The internal ReadSheet should be created");
         Assertions.assertEquals(1, configuredSheet.getSheetNo());
-        Assertions.assertEquals("DataSheet", configuredSheet.getSheetName());
+        Assertions.assertEquals("Sheet1", configuredSheet.getSheetName());
         Assertions.assertEquals(100, configuredSheet.getNumRows());
         Assertions.assertEquals(targetColumns, configuredSheet.getIncludeColumnIndexes());
+        // data related tests
+        Assertions.assertNotNull(readResults);
+        Map<Integer, String> parsedRow = readResults.get(0);
+        Assertions.assertEquals("1", parsedRow.get(0));
+        Assertions.assertEquals("Alice", parsedRow.get(1));
+        Assertions.assertEquals("30", parsedRow.get(2));
     }
 }

--- a/fesod-sheet/src/test/java/org/apache/fesod/sheet/FesodSheetTest.java
+++ b/fesod-sheet/src/test/java/org/apache/fesod/sheet/FesodSheetTest.java
@@ -24,6 +24,8 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.lang.reflect.Method;
 import java.nio.file.Path;
+import java.util.List;
+import java.util.Arrays;
 import org.apache.fesod.sheet.read.builder.ExcelReaderBuilder;
 import org.apache.fesod.sheet.read.builder.ExcelReaderSheetBuilder;
 import org.apache.fesod.sheet.read.listener.ReadListener;
@@ -246,5 +248,21 @@ class FesodSheetTest {
     void testReadSheet_withAllParams_shouldReturnBuilder() {
         ExcelReaderSheetBuilder builder = FesodSheet.readSheet(0, "DataSheet", 100);
         Assertions.assertNotNull(builder);
+    }
+
+    @Test
+    void testReadSheet_withColumnIndexes_shouldConfigureAll() {
+
+        List<Integer> targetColumns = Arrays.asList(0, 2);
+
+        ExcelReaderSheetBuilder builder = FesodSheet.readSheet(1, targetColumns);
+
+        Assertions.assertNotNull(builder, "Builder should not be null");
+
+        ReadSheet configuredSheet = builder.build();
+        Assertions.assertNotNull(configuredSheet, "The internal ReadSheet should be created");
+
+        Assertions.assertEquals(1, configuredSheet.getSheetNo());
+        Assertions.assertEquals(targetColumns, configuredSheet.getIncludeColumnIndexes());
     }
 }

--- a/fesod-sheet/src/test/java/org/apache/fesod/sheet/FesodSheetTest.java
+++ b/fesod-sheet/src/test/java/org/apache/fesod/sheet/FesodSheetTest.java
@@ -282,11 +282,12 @@ class FesodSheetTest {
         Assertions.assertEquals(0, configuredSheet.getSheetNo());
         Assertions.assertEquals("Sheet1", configuredSheet.getSheetName());
         Assertions.assertEquals(100, configuredSheet.getNumRows());
-        Assertions.assertEquals(targetColumns, configuredSheet.getIncludeColumnIndexes());
+        Assertions.assertEquals(targetColumns, configuredSheet.getColumnIndexes());
         // data related tests
         Assertions.assertNotNull(readResults);
         Map<Integer, String> parsedRow = readResults.get(0);
+        Assertions.assertEquals(2, parsedRow.size());
         Assertions.assertEquals("1", parsedRow.get(0));
-        Assertions.assertEquals("Alice", parsedRow.get(1));
+        Assertions.assertEquals("30", parsedRow.get(1));
     }
 }

--- a/fesod-sheet/src/test/java/org/apache/fesod/sheet/FesodSheetTest.java
+++ b/fesod-sheet/src/test/java/org/apache/fesod/sheet/FesodSheetTest.java
@@ -24,8 +24,8 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.lang.reflect.Method;
 import java.nio.file.Path;
-import java.util.List;
 import java.util.Arrays;
+import java.util.List;
 import org.apache.fesod.sheet.read.builder.ExcelReaderBuilder;
 import org.apache.fesod.sheet.read.builder.ExcelReaderSheetBuilder;
 import org.apache.fesod.sheet.read.listener.ReadListener;
@@ -255,7 +255,7 @@ class FesodSheetTest {
 
         List<Integer> targetColumns = Arrays.asList(0, 2);
 
-        ExcelReaderSheetBuilder builder = FesodSheet.readSheet(1, targetColumns);
+        ExcelReaderSheetBuilder builder = FesodSheet.readSheetWithColumns(1, "DataSheet", 100, targetColumns);
 
         Assertions.assertNotNull(builder, "Builder should not be null");
 
@@ -263,6 +263,8 @@ class FesodSheetTest {
         Assertions.assertNotNull(configuredSheet, "The internal ReadSheet should be created");
 
         Assertions.assertEquals(1, configuredSheet.getSheetNo());
+        Assertions.assertEquals("DataSheet", configuredSheet.getSheetName());
+        Assertions.assertEquals(100, configuredSheet.getNumRows());
         Assertions.assertEquals(targetColumns, configuredSheet.getIncludeColumnIndexes());
     }
 }

--- a/fesod-sheet/src/test/java/org/apache/fesod/sheet/FesodSheetTest.java
+++ b/fesod-sheet/src/test/java/org/apache/fesod/sheet/FesodSheetTest.java
@@ -279,15 +279,14 @@ class FesodSheetTest {
         // builder tests
         Assertions.assertNotNull(builder, "Builder should not be null");
         Assertions.assertNotNull(configuredSheet, "The internal ReadSheet should be created");
-        Assertions.assertEquals(1, configuredSheet.getSheetNo());
+        Assertions.assertEquals(0, configuredSheet.getSheetNo());
         Assertions.assertEquals("Sheet1", configuredSheet.getSheetName());
         Assertions.assertEquals(100, configuredSheet.getNumRows());
         Assertions.assertEquals(targetColumns, configuredSheet.getIncludeColumnIndexes());
         // data related tests
         Assertions.assertNotNull(readResults);
         Map<Integer, String> parsedRow = readResults.get(0);
-        Assertions.assertEquals("1", parsedRow.get(0));
-        Assertions.assertEquals("Alice", parsedRow.get(1));
-        Assertions.assertEquals("30", parsedRow.get(2));
+        Assertions.assertEquals(0, parsedRow.get(0));
+        Assertions.assertEquals(100, parsedRow.get(1));
     }
 }

--- a/fesod-sheet/src/test/java/org/apache/fesod/sheet/FesodSheetTest.java
+++ b/fesod-sheet/src/test/java/org/apache/fesod/sheet/FesodSheetTest.java
@@ -32,6 +32,7 @@ import org.apache.fesod.sheet.read.builder.ExcelReaderBuilder;
 import org.apache.fesod.sheet.read.builder.ExcelReaderSheetBuilder;
 import org.apache.fesod.sheet.read.listener.ReadListener;
 import org.apache.fesod.sheet.read.metadata.ReadWorkbook;
+import org.apache.fesod.sheet.read.metadata.ReadSheet;
 import org.apache.fesod.sheet.testkit.Tags;
 import org.apache.fesod.sheet.write.builder.ExcelWriterBuilder;
 import org.apache.fesod.sheet.write.builder.ExcelWriterSheetBuilder;

--- a/fesod-sheet/src/test/java/org/apache/fesod/sheet/FesodSheetTest.java
+++ b/fesod-sheet/src/test/java/org/apache/fesod/sheet/FesodSheetTest.java
@@ -256,7 +256,7 @@ class FesodSheetTest {
     @Test
     void testReadSheet_withColumnIndexes_shouldConfigureAll() {
 
-        java.util.List<java.util.List<String>> head = new java.util.ArrayList<>();
+        List<List<String>> head = new ArrayList<>();
         head.add(new ArrayList<>(Arrays.asList("ID")));
         head.add(new ArrayList<>(Arrays.asList("Name")));
         head.add(new ArrayList<>(Arrays.asList("Age")));
@@ -287,6 +287,6 @@ class FesodSheetTest {
         Assertions.assertNotNull(readResults);
         Map<Integer, String> parsedRow = readResults.get(0);
         Assertions.assertEquals("1", parsedRow.get(0));
-        Assertions.assertEquals("30", parsedRow.get(1));
+        Assertions.assertEquals("Alice", parsedRow.get(1));
     }
 }

--- a/fesod-sheet/src/test/java/org/apache/fesod/sheet/FesodSheetTest.java
+++ b/fesod-sheet/src/test/java/org/apache/fesod/sheet/FesodSheetTest.java
@@ -31,8 +31,8 @@ import java.util.Map;
 import org.apache.fesod.sheet.read.builder.ExcelReaderBuilder;
 import org.apache.fesod.sheet.read.builder.ExcelReaderSheetBuilder;
 import org.apache.fesod.sheet.read.listener.ReadListener;
-import org.apache.fesod.sheet.read.metadata.ReadWorkbook;
 import org.apache.fesod.sheet.read.metadata.ReadSheet;
+import org.apache.fesod.sheet.read.metadata.ReadWorkbook;
 import org.apache.fesod.sheet.testkit.Tags;
 import org.apache.fesod.sheet.write.builder.ExcelWriterBuilder;
 import org.apache.fesod.sheet.write.builder.ExcelWriterSheetBuilder;
@@ -271,8 +271,10 @@ class FesodSheetTest {
 
         ExcelReaderSheetBuilder builder = FesodSheet.readSheetWithColumns(0, "Sheet1", 100, targetColumns);
         ReadSheet configuredSheet = builder.build();
-        List<Map<Integer, String>> readResults =
-                FesodSheet.read(tempFile).sheet(configuredSheet).doReadSync();
+        List<Map<Integer, String>> readResults = FesodSheet.read(tempFile)
+                .sheet(0)
+                .includeColumnIndexes(targetColumns)
+                .doReadSync();
 
         // builder tests
         Assertions.assertNotNull(builder, "Builder should not be null");

--- a/fesod-sheet/src/test/java/org/apache/fesod/sheet/FesodSheetTest.java
+++ b/fesod-sheet/src/test/java/org/apache/fesod/sheet/FesodSheetTest.java
@@ -286,7 +286,7 @@ class FesodSheetTest {
         // data related tests
         Assertions.assertNotNull(readResults);
         Map<Integer, String> parsedRow = readResults.get(0);
-        Assertions.assertEquals(0, parsedRow.get(0));
-        Assertions.assertEquals(100, parsedRow.get(1));
+        Assertions.assertEquals("1", parsedRow.get(0));
+        Assertions.assertEquals("30", parsedRow.get(1));
     }
 }


### PR DESCRIPTION
## Purpose of the pull request

Related: #950

## What's changed?

- Added support for column-based reading.
- **Currently xlsx only**; xls support will be added later.

**Column filtering behavior: `CellTagHandler#endElement`**

When `includeColumnIndexes != null`:

-  Only process target columns
-  Rewrite target columns’ internal indexes to consecutive (0-based)

When `includeColumnIndexes == null`:

-  Keep the original behavior

### API Usage Example

```java
// data
┌────────────┬─────────────┬────────────┬─────────────┐
│     NO     │     Name    │     Age    │   Password  │
├────────────┼─────────────┼────────────┼─────────────┤
│     1      │    Jackson  │     22     │    123456   │
└────────────┴─────────────┴────────────┴─────────────┘

List<Map<Integer, String>> results = FesodSheet.read(pathname)
		.excelType(ExcelTypeEnum.XLSX)
		.sheet()
		.includeColumnIndexes(Arrays.asList(1, 3))
		.doReadSync();

Map<Integer, String> data = results.get(0);

assertEquals(2, data.size());
assertEquals("Jackson", data.get(0));
assertEquals("123456", data.get(1));
```

## Checklist

- [x] I have read the [Contributor Guide](https://fesod.apache.org/community/contribution/).
- [x] I have written the necessary doc or comment.
- [x] I have added the necessary unit tests and all cases have passed.