### PR TITLE
feat: cache date and number formatters

### DIFF
--- a/fesod-common/src/main/java/org/apache/fesod/common/util/MapUtils.java
+++ b/fesod-common/src/main/java/org/apache/fesod/common/util/MapUtils.java
@@ -27,11 +27,43 @@ package org.apache.fesod.common.util;
 
 import java.util.HashMap;
 import java.util.LinkedHashMap;
+import java.util.Map;
 import java.util.TreeMap;
 
 public class MapUtils {
 
     private MapUtils() {}
+
+    /**
+     * A {@link LinkedHashMap} bounded to {@code maxEntries}, evicting the eldest entry on overflow (FIFO). Insertion
+     * order keeps {@link #get} non-mutating on hot paths.
+     */
+    private static final class BoundedLinkedHashMap<K, V> extends LinkedHashMap<K, V> {
+        private static final long serialVersionUID = 1L;
+
+        private final int maxEntries;
+
+        private BoundedLinkedHashMap(int maxEntries) {
+            super(capacity(maxEntries), 0.75f, false);
+            this.maxEntries = maxEntries;
+        }
+
+        @Override
+        protected boolean removeEldestEntry(Map.Entry<K, V> eldest) {
+            return size() > maxEntries;
+        }
+    }
+
+    /**
+     * Creates an empty {@code Map} that retains at most {@code maxEntries} entries, evicting the eldest on overflow.
+     * Handy for thread-local caches keyed by an unbounded input set.
+     *
+     * @param maxEntries the maximum number of entries to retain; must be positive
+     * @return a new, empty bounded {@code Map}
+     */
+    public static <K, V> Map<K, V> newBoundedMap(int maxEntries) {
+        return new BoundedLinkedHashMap<>(maxEntries);
+    }
 
     /**
      * Creates a <i>mutable</i>, empty {@code HashMap} instance.

--- a/fesod-sheet/src/main/java/org/apache/fesod/sheet/analysis/ExcelAnalyserImpl.java
+++ b/fesod-sheet/src/main/java/org/apache/fesod/sheet/analysis/ExcelAnalyserImpl.java
@@ -53,6 +53,7 @@ import org.apache.fesod.sheet.util.ClassUtils;
 import org.apache.fesod.sheet.util.DateUtils;
 import org.apache.fesod.sheet.util.FileUtils;
 import org.apache.fesod.sheet.util.NumberDataFormatterUtils;
+import org.apache.fesod.sheet.util.NumberUtils;
 import org.apache.poi.hssf.OldExcelFormatException;
 import org.apache.poi.hssf.record.crypto.Biff8EncryptionKey;
 import org.apache.poi.poifs.crypt.Decryptor;
@@ -292,6 +293,7 @@ public class ExcelAnalyserImpl implements ExcelAnalyser {
      */
     private void removeThreadLocalCache() {
         NumberDataFormatterUtils.removeThreadLocalCache();
+        NumberUtils.removeThreadLocalCache();
         DateUtils.removeThreadLocalCache();
         ClassUtils.removeThreadLocalCache();
     }

--- a/fesod-sheet/src/main/java/org/apache/fesod/sheet/context/WriteContextImpl.java
+++ b/fesod-sheet/src/main/java/org/apache/fesod/sheet/context/WriteContextImpl.java
@@ -45,6 +45,7 @@ import org.apache.fesod.sheet.util.ClassUtils;
 import org.apache.fesod.sheet.util.DateUtils;
 import org.apache.fesod.sheet.util.FileUtils;
 import org.apache.fesod.sheet.util.NumberDataFormatterUtils;
+import org.apache.fesod.sheet.util.NumberUtils;
 import org.apache.fesod.sheet.util.WorkBookUtil;
 import org.apache.fesod.sheet.util.WriteHandlerUtils;
 import org.apache.fesod.sheet.write.handler.context.CellWriteHandlerContext;
@@ -561,6 +562,7 @@ public class WriteContextImpl implements WriteContext {
      */
     private void removeThreadLocalCache() {
         NumberDataFormatterUtils.removeThreadLocalCache();
+        NumberUtils.removeThreadLocalCache();
         DateUtils.removeThreadLocalCache();
         ClassUtils.removeThreadLocalCache();
     }

--- a/fesod-sheet/src/main/java/org/apache/fesod/sheet/util/DateUtils.java
+++ b/fesod-sheet/src/main/java/org/apache/fesod/sheet/util/DateUtils.java
@@ -49,6 +49,11 @@ import org.apache.poi.util.LocaleUtil;
  * Date utils
  */
 public class DateUtils {
+
+    private static final int MAX_LOCALE_CACHE_SIZE = 8;
+
+    private static final int MAX_FORMAT_CACHE_SIZE = 64;
+
     /**
      * Is a cache of dates
      */
@@ -57,12 +62,12 @@ public class DateUtils {
      * Is a cache of dates
      */
     private static final ThreadLocal<Map<String, SimpleDateFormat>> DATE_FORMAT_THREAD_LOCAL = new ThreadLocal<>();
+
     /**
-     * Is a cache of {@link DateTimeFormatter}, keyed by the resolved locale and pattern. Thread-local (rather than a
-     * shared static map) so it is bounded by thread lifetime and cleared by {@link #removeThreadLocalCache()}, matching
-     * {@link #DATE_FORMAT_THREAD_LOCAL}.
+     * Bounded cache of {@link DateTimeFormatter}, nested by resolved locale then pattern. Both levels evict FIFO, and
+     * the whole cache is cleared by {@link #removeThreadLocalCache()}.
      */
-    private static final ThreadLocal<Map<String, DateTimeFormatter>> DATE_TIME_FORMATTER_THREAD_LOCAL =
+    private static final ThreadLocal<Map<Locale, Map<String, DateTimeFormatter>>> DATE_TIME_FORMATTER_THREAD_LOCAL =
             new ThreadLocal<>();
 
     /**
@@ -296,20 +301,21 @@ public class DateUtils {
     }
 
     private static DateTimeFormatter getCacheDateTimeFormat(String dateFormat, Locale locale) {
-        // Resolve null to the default FORMAT locale (matching DateTimeFormatter.ofPattern(String)) so the resolved
-        // locale can be part of the cache key. Keying on the raw argument would let null collide with Locale.ROOT
-        // (both stringify to ""), returning a formatter built for the wrong locale.
         Locale actualLocale = locale == null ? Locale.getDefault(Locale.Category.FORMAT) : locale;
-        String key = actualLocale.toString() + '\n' + dateFormat;
-        Map<String, DateTimeFormatter> formatterMap = DATE_TIME_FORMATTER_THREAD_LOCAL.get();
-        if (formatterMap == null) {
-            formatterMap = new HashMap<>();
-            DATE_TIME_FORMATTER_THREAD_LOCAL.set(formatterMap);
+        Map<Locale, Map<String, DateTimeFormatter>> localeCache = DATE_TIME_FORMATTER_THREAD_LOCAL.get();
+        if (localeCache == null) {
+            localeCache = MapUtils.newBoundedMap(MAX_LOCALE_CACHE_SIZE);
+            DATE_TIME_FORMATTER_THREAD_LOCAL.set(localeCache);
         }
-        DateTimeFormatter formatter = formatterMap.get(key);
+        Map<String, DateTimeFormatter> formatCache = localeCache.get(actualLocale);
+        if (formatCache == null) {
+            formatCache = MapUtils.newBoundedMap(MAX_FORMAT_CACHE_SIZE);
+            localeCache.put(actualLocale, formatCache);
+        }
+        DateTimeFormatter formatter = formatCache.get(dateFormat);
         if (formatter == null) {
             formatter = DateTimeFormatter.ofPattern(dateFormat, actualLocale);
-            formatterMap.put(key, formatter);
+            formatCache.put(dateFormat, formatter);
         }
         return formatter;
     }

--- a/fesod-sheet/src/main/java/org/apache/fesod/sheet/util/DateUtils.java
+++ b/fesod-sheet/src/main/java/org/apache/fesod/sheet/util/DateUtils.java
@@ -57,6 +57,13 @@ public class DateUtils {
      * Is a cache of dates
      */
     private static final ThreadLocal<Map<String, SimpleDateFormat>> DATE_FORMAT_THREAD_LOCAL = new ThreadLocal<>();
+    /**
+     * Is a cache of {@link DateTimeFormatter}, keyed by the resolved locale and pattern. Thread-local (rather than a
+     * shared static map) so it is bounded by thread lifetime and cleared by {@link #removeThreadLocalCache()}, matching
+     * {@link #DATE_FORMAT_THREAD_LOCAL}.
+     */
+    private static final ThreadLocal<Map<String, DateTimeFormatter>> DATE_TIME_FORMATTER_THREAD_LOCAL =
+            new ThreadLocal<>();
 
     /**
      * The following patterns are used in {@link #isADateFormat(Short, String)}
@@ -126,11 +133,7 @@ public class DateUtils {
         if (StringUtils.isEmpty(dateFormat)) {
             dateFormat = switchDateFormat(dateString);
         }
-        if (local == null) {
-            return LocalDateTime.parse(dateString, DateTimeFormatter.ofPattern(dateFormat));
-        } else {
-            return LocalDateTime.parse(dateString, DateTimeFormatter.ofPattern(dateFormat, local));
-        }
+        return LocalDateTime.parse(dateString, getCacheDateTimeFormat(dateFormat, local));
     }
 
     /**
@@ -145,11 +148,7 @@ public class DateUtils {
         if (StringUtils.isEmpty(dateFormat)) {
             dateFormat = switchDateFormat(dateString);
         }
-        if (local == null) {
-            return LocalDate.parse(dateString, DateTimeFormatter.ofPattern(dateFormat));
-        } else {
-            return LocalDate.parse(dateString, DateTimeFormatter.ofPattern(dateFormat, local));
-        }
+        return LocalDate.parse(dateString, getCacheDateTimeFormat(dateFormat, local));
     }
 
     /**
@@ -238,11 +237,7 @@ public class DateUtils {
         if (StringUtils.isEmpty(dateFormat)) {
             dateFormat = defaultDateFormat;
         }
-        if (local == null) {
-            return date.format(DateTimeFormatter.ofPattern(dateFormat));
-        } else {
-            return date.format(DateTimeFormatter.ofPattern(dateFormat, local));
-        }
+        return date.format(getCacheDateTimeFormat(dateFormat, local));
     }
 
     /**
@@ -270,11 +265,7 @@ public class DateUtils {
         if (StringUtils.isEmpty(dateFormat)) {
             dateFormat = defaultLocalDateFormat;
         }
-        if (local == null) {
-            return date.format(DateTimeFormatter.ofPattern(dateFormat));
-        } else {
-            return date.format(DateTimeFormatter.ofPattern(dateFormat, local));
-        }
+        return date.format(getCacheDateTimeFormat(dateFormat, local));
     }
 
     /**
@@ -302,6 +293,25 @@ public class DateUtils {
         LocalDateTime localDateTime =
                 DateUtil.getLocalDateTime(date.doubleValue(), BooleanUtils.isTrue(use1904windowing), true);
         return format(localDateTime, dateFormat);
+    }
+
+    private static DateTimeFormatter getCacheDateTimeFormat(String dateFormat, Locale locale) {
+        // Resolve null to the default FORMAT locale (matching DateTimeFormatter.ofPattern(String)) so the resolved
+        // locale can be part of the cache key. Keying on the raw argument would let null collide with Locale.ROOT
+        // (both stringify to ""), returning a formatter built for the wrong locale.
+        Locale actualLocale = locale == null ? Locale.getDefault(Locale.Category.FORMAT) : locale;
+        String key = actualLocale.toString() + '\n' + dateFormat;
+        Map<String, DateTimeFormatter> formatterMap = DATE_TIME_FORMATTER_THREAD_LOCAL.get();
+        if (formatterMap == null) {
+            formatterMap = new HashMap<>();
+            DATE_TIME_FORMATTER_THREAD_LOCAL.set(formatterMap);
+        }
+        DateTimeFormatter formatter = formatterMap.get(key);
+        if (formatter == null) {
+            formatter = DateTimeFormatter.ofPattern(dateFormat, actualLocale);
+            formatterMap.put(key, formatter);
+        }
+        return formatter;
     }
 
     private static DateFormat getCacheDateFormat(String dateFormat) {
@@ -573,5 +583,6 @@ public class DateUtils {
     public static void removeThreadLocalCache() {
         DATE_THREAD_LOCAL.remove();
         DATE_FORMAT_THREAD_LOCAL.remove();
+        DATE_TIME_FORMATTER_THREAD_LOCAL.remove();
     }
 }

--- a/fesod-sheet/src/main/java/org/apache/fesod/sheet/util/NumberUtils.java
+++ b/fesod-sheet/src/main/java/org/apache/fesod/sheet/util/NumberUtils.java
@@ -30,9 +30,9 @@ import java.math.RoundingMode;
 import java.text.DecimalFormat;
 import java.text.DecimalFormatSymbols;
 import java.text.ParseException;
-import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
+import org.apache.fesod.common.util.MapUtils;
 import org.apache.fesod.common.util.StringUtils;
 import org.apache.fesod.sheet.metadata.data.WriteCellData;
 import org.apache.fesod.sheet.metadata.property.ExcelContentProperty;
@@ -43,14 +43,17 @@ import org.apache.fesod.sheet.metadata.property.ExcelContentProperty;
  *
  */
 public class NumberUtils {
+
+    private static final int MAX_LOCALE_CACHE_SIZE = 4;
+
+    private static final int MAX_FORMAT_CACHE_SIZE = 64;
+
     /**
-     * Is a cache of {@link DecimalFormat}, keyed by the default FORMAT locale and pattern. {@link DecimalFormat} is not
-     * thread-safe, so the cache is thread-local, like {@code DateUtils.DATE_FORMAT_THREAD_LOCAL}. The locale is part of
-     * the key (and used to build the symbols) because {@link DecimalFormat} snapshots the locale symbols at
-     * construction time; keying on the pattern alone would keep formatting with a stale locale after the default
-     * changes.
+     * Bounded cache of {@link DecimalFormat}, nested by default FORMAT locale then pattern. {@link DecimalFormat} is
+     * not thread-safe, so it is thread-local; both levels evict FIFO to keep long-lived threads bounded.
      */
-    private static final ThreadLocal<Map<String, DecimalFormat>> DECIMAL_FORMAT_THREAD_LOCAL = new ThreadLocal<>();
+    private static final ThreadLocal<Map<Locale, Map<String, DecimalFormat>>> DECIMAL_FORMAT_THREAD_LOCAL =
+            new ThreadLocal<>();
 
     private NumberUtils() {}
 
@@ -230,18 +233,24 @@ public class NumberUtils {
 
     private static DecimalFormat getCacheDecimalFormat(String format, RoundingMode roundingMode) {
         Locale locale = Locale.getDefault(Locale.Category.FORMAT);
-        String key = locale.toString() + '\n' + format;
-        Map<String, DecimalFormat> decimalFormatMap = DECIMAL_FORMAT_THREAD_LOCAL.get();
-        if (decimalFormatMap == null) {
-            decimalFormatMap = new HashMap<>();
-            DECIMAL_FORMAT_THREAD_LOCAL.set(decimalFormatMap);
+        Map<Locale, Map<String, DecimalFormat>> localeCache = DECIMAL_FORMAT_THREAD_LOCAL.get();
+        if (localeCache == null) {
+            localeCache = MapUtils.newBoundedMap(MAX_LOCALE_CACHE_SIZE);
+            DECIMAL_FORMAT_THREAD_LOCAL.set(localeCache);
         }
-        DecimalFormat decimalFormat = decimalFormatMap.get(key);
+        Map<String, DecimalFormat> formatCache = localeCache.get(locale);
+        if (formatCache == null) {
+            formatCache = MapUtils.newBoundedMap(MAX_FORMAT_CACHE_SIZE);
+            localeCache.put(locale, formatCache);
+        }
+        DecimalFormat decimalFormat = formatCache.get(format);
         if (decimalFormat == null) {
             decimalFormat = new DecimalFormat(format, DecimalFormatSymbols.getInstance(locale));
-            decimalFormatMap.put(key, decimalFormat);
+            formatCache.put(format, decimalFormat);
         }
-        decimalFormat.setRoundingMode(roundingMode);
+        if (decimalFormat.getRoundingMode() != roundingMode) {
+            decimalFormat.setRoundingMode(roundingMode);
+        }
         return decimalFormat;
     }
 

--- a/fesod-sheet/src/main/java/org/apache/fesod/sheet/util/NumberUtils.java
+++ b/fesod-sheet/src/main/java/org/apache/fesod/sheet/util/NumberUtils.java
@@ -28,7 +28,11 @@ package org.apache.fesod.sheet.util;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
 import java.text.ParseException;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
 import org.apache.fesod.common.util.StringUtils;
 import org.apache.fesod.sheet.metadata.data.WriteCellData;
 import org.apache.fesod.sheet.metadata.property.ExcelContentProperty;
@@ -39,6 +43,15 @@ import org.apache.fesod.sheet.metadata.property.ExcelContentProperty;
  *
  */
 public class NumberUtils {
+    /**
+     * Is a cache of {@link DecimalFormat}, keyed by the default FORMAT locale and pattern. {@link DecimalFormat} is not
+     * thread-safe, so the cache is thread-local, like {@code DateUtils.DATE_FORMAT_THREAD_LOCAL}. The locale is part of
+     * the key (and used to build the symbols) because {@link DecimalFormat} snapshots the locale symbols at
+     * construction time; keying on the pattern alone would keep formatting with a stale locale after the default
+     * changes.
+     */
+    private static final ThreadLocal<Map<String, DecimalFormat>> DECIMAL_FORMAT_THREAD_LOCAL = new ThreadLocal<>();
+
     private NumberUtils() {}
 
     /**
@@ -60,9 +73,7 @@ public class NumberUtils {
         }
         String format = contentProperty.getNumberFormatProperty().getFormat();
         RoundingMode roundingMode = contentProperty.getNumberFormatProperty().getRoundingMode();
-        DecimalFormat decimalFormat = new DecimalFormat(format);
-        decimalFormat.setRoundingMode(roundingMode);
-        return decimalFormat.format(num);
+        return getCacheDecimalFormat(format, roundingMode).format(num);
     }
 
     /**
@@ -212,9 +223,29 @@ public class NumberUtils {
     private static Number parse(String string, ExcelContentProperty contentProperty) throws ParseException {
         String format = contentProperty.getNumberFormatProperty().getFormat();
         RoundingMode roundingMode = contentProperty.getNumberFormatProperty().getRoundingMode();
-        DecimalFormat decimalFormat = new DecimalFormat(format);
-        decimalFormat.setRoundingMode(roundingMode);
+        DecimalFormat decimalFormat = getCacheDecimalFormat(format, roundingMode);
         decimalFormat.setParseBigDecimal(true);
         return decimalFormat.parse(string);
+    }
+
+    private static DecimalFormat getCacheDecimalFormat(String format, RoundingMode roundingMode) {
+        Locale locale = Locale.getDefault(Locale.Category.FORMAT);
+        String key = locale.toString() + '\n' + format;
+        Map<String, DecimalFormat> decimalFormatMap = DECIMAL_FORMAT_THREAD_LOCAL.get();
+        if (decimalFormatMap == null) {
+            decimalFormatMap = new HashMap<>();
+            DECIMAL_FORMAT_THREAD_LOCAL.set(decimalFormatMap);
+        }
+        DecimalFormat decimalFormat = decimalFormatMap.get(key);
+        if (decimalFormat == null) {
+            decimalFormat = new DecimalFormat(format, DecimalFormatSymbols.getInstance(locale));
+            decimalFormatMap.put(key, decimalFormat);
+        }
+        decimalFormat.setRoundingMode(roundingMode);
+        return decimalFormat;
+    }
+
+    public static void removeThreadLocalCache() {
+        DECIMAL_FORMAT_THREAD_LOCAL.remove();
     }
 }

--- a/fesod-sheet/src/test/java/org/apache/fesod/sheet/util/DateUtilsTest.java
+++ b/fesod-sheet/src/test/java/org/apache/fesod/sheet/util/DateUtilsTest.java
@@ -36,6 +36,8 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.ResourceLock;
+import org.junit.jupiter.api.parallel.Resources;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -195,6 +197,7 @@ class DateUtilsTest {
     }
 
     @Test
+    @ResourceLock(Resources.LOCALE)
     void test_dateTimeFormatterCache_distinguishesRootFromDefaultLocale() {
         Locale originalLocale = Locale.getDefault(Locale.Category.FORMAT);
         try {
@@ -214,6 +217,7 @@ class DateUtilsTest {
     }
 
     @Test
+    @ResourceLock(Resources.LOCALE)
     void test_dateTimeFormatterCache_tracksDefaultFormatLocaleChanges() {
         Locale originalLocale = Locale.getDefault(Locale.Category.FORMAT);
         try {
@@ -231,6 +235,36 @@ class DateUtilsTest {
         } finally {
             Locale.setDefault(Locale.Category.FORMAT, originalLocale);
         }
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void test_dateTimeFormatterCache_isBounded() throws NoSuchFieldException, IllegalAccessException {
+        int localeCap = readIntConstant("MAX_LOCALE_CACHE_SIZE");
+        int formatCap = readIntConstant("MAX_FORMAT_CACHE_SIZE");
+        LocalDate date = LocalDate.of(2026, 7, 13);
+
+        for (int i = 0; i <= formatCap; i++) {
+            DateUtils.format(date, "yyyy-MM-dd'" + i + "'", Locale.US);
+        }
+
+        Field field = DateUtils.class.getDeclaredField("DATE_TIME_FORMATTER_THREAD_LOCAL");
+        field.setAccessible(true);
+        ThreadLocal<Map<Locale, Map<String, DateTimeFormatter>>> threadLocal =
+                (ThreadLocal<Map<Locale, Map<String, DateTimeFormatter>>>) field.get(null);
+        Map<Locale, Map<String, DateTimeFormatter>> localeCache = threadLocal.get();
+        Assertions.assertEquals(formatCap, localeCache.get(Locale.US).size());
+
+        for (int i = 0; i < localeCap + 2; i++) {
+            DateUtils.format(date, "yyyy-MM-dd", new Locale("en", "X" + i));
+        }
+        Assertions.assertEquals(localeCap, localeCache.size());
+    }
+
+    private static int readIntConstant(String name) throws NoSuchFieldException, IllegalAccessException {
+        Field field = DateUtils.class.getDeclaredField(name);
+        field.setAccessible(true);
+        return field.getInt(null);
     }
 
     @Test

--- a/fesod-sheet/src/test/java/org/apache/fesod/sheet/util/DateUtilsTest.java
+++ b/fesod-sheet/src/test/java/org/apache/fesod/sheet/util/DateUtilsTest.java
@@ -195,6 +195,45 @@ class DateUtilsTest {
     }
 
     @Test
+    void test_dateTimeFormatterCache_distinguishesRootFromDefaultLocale() {
+        Locale originalLocale = Locale.getDefault(Locale.Category.FORMAT);
+        try {
+            Locale.setDefault(Locale.Category.FORMAT, Locale.FRANCE);
+            LocalDate date = LocalDate.of(2026, 7, 13);
+            String format = "MMMM";
+
+            String rootResult = DateUtils.format(date, format, Locale.ROOT);
+            String defaultResult = DateUtils.format(date, format, null);
+
+            Assertions.assertEquals(date.format(DateTimeFormatter.ofPattern(format, Locale.ROOT)), rootResult);
+            Assertions.assertEquals(date.format(DateTimeFormatter.ofPattern(format, Locale.FRANCE)), defaultResult);
+            Assertions.assertNotEquals(rootResult, defaultResult);
+        } finally {
+            Locale.setDefault(Locale.Category.FORMAT, originalLocale);
+        }
+    }
+
+    @Test
+    void test_dateTimeFormatterCache_tracksDefaultFormatLocaleChanges() {
+        Locale originalLocale = Locale.getDefault(Locale.Category.FORMAT);
+        try {
+            LocalDate date = LocalDate.of(2026, 7, 13);
+            String format = "MMMM";
+
+            Locale.setDefault(Locale.Category.FORMAT, Locale.FRANCE);
+            String franceResult = DateUtils.format(date, format, null);
+            Locale.setDefault(Locale.Category.FORMAT, Locale.US);
+            String usResult = DateUtils.format(date, format, null);
+
+            Assertions.assertEquals(date.format(DateTimeFormatter.ofPattern(format, Locale.FRANCE)), franceResult);
+            Assertions.assertEquals(date.format(DateTimeFormatter.ofPattern(format, Locale.US)), usResult);
+            Assertions.assertNotEquals(franceResult, usResult);
+        } finally {
+            Locale.setDefault(Locale.Category.FORMAT, originalLocale);
+        }
+    }
+
+    @Test
     void test_format_BigDecimal() {
         // 43831 = 2020-01-01
         BigDecimal excelDate = new BigDecimal("43831.5");
@@ -355,19 +394,24 @@ class DateUtilsTest {
     @Test
     void test_removeThreadLocalCache() throws NoSuchFieldException, IllegalAccessException {
         DateUtils.format(new Date(), "yyyy-MM-dd");
+        DateUtils.format(LocalDate.of(2026, 7, 13), "MMMM", Locale.US);
         DateUtils.isADateFormat((short) 100, "yyyy-MM-dd");
 
         Field f1 = DateUtils.class.getDeclaredField("DATE_THREAD_LOCAL");
         Field f2 = DateUtils.class.getDeclaredField("DATE_FORMAT_THREAD_LOCAL");
+        Field f3 = DateUtils.class.getDeclaredField("DATE_TIME_FORMATTER_THREAD_LOCAL");
         f1.setAccessible(true);
         f2.setAccessible(true);
+        f3.setAccessible(true);
 
         Assertions.assertNotNull(((ThreadLocal<?>) f1.get(null)).get());
         Assertions.assertNotNull(((ThreadLocal<?>) f2.get(null)).get());
+        Assertions.assertNotNull(((ThreadLocal<?>) f3.get(null)).get());
 
         DateUtils.removeThreadLocalCache();
 
         Assertions.assertNull(((ThreadLocal<?>) f1.get(null)).get());
         Assertions.assertNull(((ThreadLocal<?>) f2.get(null)).get());
+        Assertions.assertNull(((ThreadLocal<?>) f3.get(null)).get());
     }
 }

--- a/fesod-sheet/src/test/java/org/apache/fesod/sheet/util/NumberUtilsTest.java
+++ b/fesod-sheet/src/test/java/org/apache/fesod/sheet/util/NumberUtilsTest.java
@@ -29,6 +29,7 @@ import java.text.DecimalFormatSymbols;
 import java.text.ParseException;
 import java.util.Collections;
 import java.util.Locale;
+import java.util.Map;
 import org.apache.fesod.sheet.FesodSheet;
 import org.apache.fesod.sheet.metadata.data.WriteCellData;
 import org.apache.fesod.sheet.metadata.property.ExcelContentProperty;
@@ -40,6 +41,8 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.api.parallel.ResourceLock;
+import org.junit.jupiter.api.parallel.Resources;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -93,6 +96,7 @@ class NumberUtilsTest {
     }
 
     @Test
+    @ResourceLock(Resources.LOCALE)
     void test_formatCache_tracksDefaultFormatLocaleChanges() {
         Locale originalLocale = Locale.getDefault(Locale.Category.FORMAT);
         try {
@@ -114,6 +118,46 @@ class NumberUtilsTest {
         } finally {
             Locale.setDefault(Locale.Category.FORMAT, originalLocale);
         }
+    }
+
+    @Test
+    @ResourceLock(Resources.LOCALE)
+    @SuppressWarnings("unchecked")
+    void test_formatCache_isBounded() throws NoSuchFieldException, IllegalAccessException {
+        int localeCap = readIntConstant("MAX_LOCALE_CACHE_SIZE");
+        int formatCap = readIntConstant("MAX_FORMAT_CACHE_SIZE");
+        Locale originalLocale = Locale.getDefault(Locale.Category.FORMAT);
+        try {
+            Locale.setDefault(Locale.Category.FORMAT, Locale.US);
+            ExcelContentProperty property = new ExcelContentProperty();
+            StringBuilder format = new StringBuilder("0.");
+            for (int i = 0; i <= formatCap; i++) {
+                format.append('0');
+                property.setNumberFormatProperty(new NumberFormatProperty(format.toString(), RoundingMode.HALF_UP));
+                NumberUtils.format(1234.5, property);
+            }
+
+            Field field = NumberUtils.class.getDeclaredField("DECIMAL_FORMAT_THREAD_LOCAL");
+            field.setAccessible(true);
+            ThreadLocal<Map<Locale, Map<String, DecimalFormat>>> threadLocal =
+                    (ThreadLocal<Map<Locale, Map<String, DecimalFormat>>>) field.get(null);
+            Map<Locale, Map<String, DecimalFormat>> localeCache = threadLocal.get();
+            Assertions.assertEquals(formatCap, localeCache.get(Locale.US).size());
+
+            for (int i = 0; i < localeCap + 2; i++) {
+                Locale.setDefault(Locale.Category.FORMAT, new Locale("en", "X" + i));
+                NumberUtils.format(1234.5, property);
+            }
+            Assertions.assertEquals(localeCap, localeCache.size());
+        } finally {
+            Locale.setDefault(Locale.Category.FORMAT, originalLocale);
+        }
+    }
+
+    private static int readIntConstant(String name) throws NoSuchFieldException, IllegalAccessException {
+        Field field = NumberUtils.class.getDeclaredField(name);
+        field.setAccessible(true);
+        return field.getInt(null);
     }
 
     @Test

--- a/fesod-sheet/src/test/java/org/apache/fesod/sheet/util/NumberUtilsTest.java
+++ b/fesod-sheet/src/test/java/org/apache/fesod/sheet/util/NumberUtilsTest.java
@@ -19,17 +19,27 @@
 
 package org.apache.fesod.sheet.util;
 
+import java.io.File;
+import java.lang.reflect.Field;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
+import java.nio.file.Path;
+import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
 import java.text.ParseException;
+import java.util.Collections;
+import java.util.Locale;
+import org.apache.fesod.sheet.FesodSheet;
 import org.apache.fesod.sheet.metadata.data.WriteCellData;
 import org.apache.fesod.sheet.metadata.property.ExcelContentProperty;
 import org.apache.fesod.sheet.metadata.property.NumberFormatProperty;
 import org.apache.fesod.sheet.testkit.Tags;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -46,6 +56,11 @@ class NumberUtilsTest {
 
     @Mock
     private NumberFormatProperty numberFormatProperty;
+
+    @AfterEach
+    void tearDown() {
+        NumberUtils.removeThreadLocalCache();
+    }
 
     @Test
     void test_format_noFormat_BigDecimal() {
@@ -75,6 +90,30 @@ class NumberUtilsTest {
         String result = NumberUtils.format(123.451, contentProperty);
 
         Assertions.assertEquals("123.46", result);
+    }
+
+    @Test
+    void test_formatCache_tracksDefaultFormatLocaleChanges() {
+        Locale originalLocale = Locale.getDefault(Locale.Category.FORMAT);
+        try {
+            String format = "#,##0.00";
+            ExcelContentProperty property = new ExcelContentProperty();
+            property.setNumberFormatProperty(new NumberFormatProperty(format, RoundingMode.HALF_UP));
+
+            Locale.setDefault(Locale.Category.FORMAT, Locale.FRANCE);
+            String franceResult = NumberUtils.format(1234.5, property);
+            Locale.setDefault(Locale.Category.FORMAT, Locale.US);
+            String usResult = NumberUtils.format(1234.5, property);
+
+            Assertions.assertEquals(
+                    new DecimalFormat(format, DecimalFormatSymbols.getInstance(Locale.FRANCE)).format(1234.5),
+                    franceResult);
+            Assertions.assertEquals(
+                    new DecimalFormat(format, DecimalFormatSymbols.getInstance(Locale.US)).format(1234.5), usResult);
+            Assertions.assertNotEquals(franceResult, usResult);
+        } finally {
+            Locale.setDefault(Locale.Category.FORMAT, originalLocale);
+        }
     }
 
     @Test
@@ -269,5 +308,42 @@ class NumberUtilsTest {
         Assertions.assertThrows(ParseException.class, () -> {
             NumberUtils.parseInteger("not_a_number", contentProperty);
         });
+    }
+
+    @Test
+    void test_removeThreadLocalCache() throws NoSuchFieldException, IllegalAccessException {
+        ExcelContentProperty property = new ExcelContentProperty();
+        property.setNumberFormatProperty(new NumberFormatProperty("#,##0.00", RoundingMode.HALF_UP));
+        NumberUtils.format(1234.5, property);
+
+        Field field = NumberUtils.class.getDeclaredField("DECIMAL_FORMAT_THREAD_LOCAL");
+        field.setAccessible(true);
+        ThreadLocal<?> threadLocal = (ThreadLocal<?>) field.get(null);
+        Assertions.assertNotNull(threadLocal.get());
+
+        NumberUtils.removeThreadLocalCache();
+
+        Assertions.assertNull(threadLocal.get());
+    }
+
+    @Test
+    void test_readAndWriteFinishRemoveThreadLocalCache(@TempDir Path tempDir)
+            throws NoSuchFieldException, IllegalAccessException {
+        Field field = NumberUtils.class.getDeclaredField("DECIMAL_FORMAT_THREAD_LOCAL");
+        field.setAccessible(true);
+        ThreadLocal<?> threadLocal = (ThreadLocal<?>) field.get(null);
+        ExcelContentProperty property = new ExcelContentProperty();
+        property.setNumberFormatProperty(new NumberFormatProperty("#,##0.00", RoundingMode.HALF_UP));
+        File file = tempDir.resolve("thread-local-cache.xlsx").toFile();
+
+        NumberUtils.format(1234.5, property);
+        Assertions.assertNotNull(threadLocal.get());
+        FesodSheet.write(file).sheet().doWrite(Collections.singletonList(Collections.singletonList("value")));
+        Assertions.assertNull(threadLocal.get());
+
+        NumberUtils.format(1234.5, property);
+        Assertions.assertNotNull(threadLocal.get());
+        FesodSheet.read(file).sheet().doReadSync();
+        Assertions.assertNull(threadLocal.get());
     }
 }


### PR DESCRIPTION
## Purpose of the pull request

DateUtils and NumberUtils rebuilt a formatter on every cell. This PR caches them per thread, keyed by locale + pattern, so a formatter is built once and reused.

The java.util.Date path in the very same class was already cached; the java.time and DecimalFormat paths just never got the same treatment. This PR closes that gap.

## What's changed?

Both caches are ThreadLocal (not a shared static map) so they are bounded by thread lifetime and released by the existing cleanup, consistent with the sibling DATE_FORMAT_THREAD_LOCAL.

1. DateUtils — new DATE_TIME_FORMATTER_THREAD_LOCAL cache; all 8 sites resolve through getCacheDateTimeFormat(pattern, locale). Cleared in the existing removeThreadLocalCache().
2. NumberUtils — new DECIMAL_FORMAT_THREAD_LOCAL cache via getCacheDecimalFormat(pattern, roundingMode), plus a new removeThreadLocalCache() wired into the read/write finish paths (WriteContextImpl, ExcelAnalyserImpl).

## Benchmark

``` mardown
Per cell (JMH 1.37, -prof gc, 2 forks; allocation deterministic ±0.001 B/op)

┌──────────────┬─────────────┬────────────┬─────────────┬──────────────┬─────────────┬─────────┐
│  Benchmark   │ Time before │ Time after │   Time Δ    │ Alloc before │ Alloc after │ Alloc Δ │
├──────────────┼─────────────┼────────────┼─────────────┼──────────────┼─────────────┼─────────┤
│ dateFormat   │    422.8 ns │   205.4 ns │        −51% │        776 B │       396 B │    −49% │
├──────────────┼─────────────┼────────────┼─────────────┼──────────────┼─────────────┼─────────┤
│ dateParse    │    680.0 ns │   631.1 ns │        −7%  │       1272 B │       880 B │    −31% │
├──────────────┼─────────────┼────────────┼─────────────┼──────────────┼─────────────┼─────────┤
│ numberFormat │    905.2 ns │   749.4 ns │        −17% │       1656 B │       480 B │    −71% │
├──────────────┼─────────────┼────────────┼─────────────┼──────────────┼─────────────┼─────────┤
│ numberParse  │    492.8 ns │   277.0 ns │        −44% │       1568 B │       376 B │    −76% │
└──────────────┴─────────────┴────────────┴─────────────┴──────────────┴─────────────┴─────────┘

End-to-end (500000-row CSV, median of 3)

┌───────┬───────────────────┬──────────┬──────────┬──────┐
│ Phase │      Metric       │  Before  │  After   │  Δ   │
├───────┼───────────────────┼──────────┼──────────┼──────┤
│ Write │ Thread allocation │ 2,386 MB │ 1,593 MB │ −33% │
├───────┼───────────────────┼──────────┼──────────┼──────┤
│ Read  │ Thread allocation │ 1,960 MB │ 1,279 MB │ −35% │
└───────┴───────────────────┴──────────┴──────────┴──────┘
```

## Checklist

- [x] I have read the [Contributor Guide](https://fesod.apache.org/community/contribution/).
- [ ] I have written the necessary doc or comment.
- [x] I have added the necessary unit tests and all cases have passed.