### PR TITLE
fix: CsvCell crashes on java.sql.Date/Time due to unsupported toInstant()

### DIFF
--- a/fesod-sheet/src/main/java/org/apache/fesod/sheet/metadata/csv/CsvCell.java
+++ b/fesod-sheet/src/main/java/org/apache/fesod/sheet/metadata/csv/CsvCell.java
@@ -164,7 +164,13 @@ public class CsvCell extends CellBase {
         if (value == null) {
             return;
         }
-        this.dateValue = LocalDateTime.ofInstant(value.toInstant(), ZoneId.systemDefault());
+        if (value instanceof java.sql.Date) {
+            this.dateValue = ((java.sql.Date) value).toLocalDate().atStartOfDay();
+        } else if (value instanceof java.sql.Time) {
+            this.dateValue = ((java.sql.Time) value).toLocalTime().atDate(java.time.LocalDate.of(1970, 1, 1));
+        } else {
+            this.dateValue = LocalDateTime.ofInstant(value.toInstant(), ZoneId.systemDefault());
+        }
         this.cellType = CellType.NUMERIC;
         this.numericCellType = NumericCellTypeEnum.DATE;
     }

--- a/fesod-sheet/src/main/java/org/apache/fesod/sheet/metadata/csv/CsvCell.java
+++ b/fesod-sheet/src/main/java/org/apache/fesod/sheet/metadata/csv/CsvCell.java
@@ -36,6 +36,7 @@ import lombok.Getter;
 import lombok.Setter;
 import org.apache.fesod.sheet.enums.NumericCellTypeEnum;
 import org.apache.fesod.sheet.metadata.data.FormulaData;
+import org.apache.fesod.sheet.util.DateUtils;
 import org.apache.poi.ss.SpreadsheetVersion;
 import org.apache.poi.ss.usermodel.CellBase;
 import org.apache.poi.ss.usermodel.CellStyle;
@@ -167,7 +168,7 @@ public class CsvCell extends CellBase {
         if (value instanceof java.sql.Date) {
             this.dateValue = ((java.sql.Date) value).toLocalDate().atStartOfDay();
         } else if (value instanceof java.sql.Time) {
-            this.dateValue = ((java.sql.Time) value).toLocalTime().atDate(java.time.LocalDate.of(1970, 1, 1));
+            this.dateValue = ((java.sql.Time) value).toLocalTime().atDate(DateUtils.EPOCH);
         } else {
             this.dateValue = LocalDateTime.ofInstant(value.toInstant(), ZoneId.systemDefault());
         }

--- a/fesod-sheet/src/main/java/org/apache/fesod/sheet/metadata/data/WriteCellData.java
+++ b/fesod-sheet/src/main/java/org/apache/fesod/sheet/metadata/data/WriteCellData.java
@@ -36,6 +36,7 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.apache.fesod.common.util.ListUtils;
 import org.apache.fesod.sheet.enums.CellDataTypeEnum;
+import org.apache.fesod.sheet.util.DateUtils;
 import org.apache.fesod.sheet.write.metadata.style.WriteCellStyle;
 import org.apache.poi.ss.usermodel.CellStyle;
 
@@ -172,7 +173,7 @@ public class WriteCellData<T> extends CellData<T> {
         if (dateValue instanceof java.sql.Date) {
             this.dateValue = ((java.sql.Date) dateValue).toLocalDate().atStartOfDay();
         } else if (dateValue instanceof java.sql.Time) {
-            this.dateValue = ((java.sql.Time) dateValue).toLocalTime().atDate(java.time.LocalDate.of(1970, 1, 1));
+            this.dateValue = ((java.sql.Time) dateValue).toLocalTime().atDate(DateUtils.EPOCH);
         } else {
             this.dateValue = LocalDateTime.ofInstant(dateValue.toInstant(), ZoneId.systemDefault());
         }

--- a/fesod-sheet/src/main/java/org/apache/fesod/sheet/util/DateUtils.java
+++ b/fesod-sheet/src/main/java/org/apache/fesod/sheet/util/DateUtils.java
@@ -87,6 +87,12 @@ public class DateUtils {
     // for format which start with "年" or "月" or "日" or "时" or "分" or "秒" could be a Chinese date
     private static final Pattern date_ptrn6 = Pattern.compile("(年|月|日|时|分|秒)+");
 
+    /**
+     * The epoch date (1970-01-01) used as the date component when converting
+     * {@code java.sql.Time} to {@code LocalDateTime}.
+     */
+    public static final LocalDate EPOCH = LocalDate.of(1970, 1, 1);
+
     public static final String DATE_FORMAT_10 = "yyyy-MM-dd";
     public static final String DATE_FORMAT_14 = "yyyyMMddHHmmss";
     public static final String DATE_FORMAT_16 = "yyyy-MM-dd HH:mm";

--- a/fesod-sheet/src/test/java/org/apache/fesod/sheet/format/CsvRowTest.java
+++ b/fesod-sheet/src/test/java/org/apache/fesod/sheet/format/CsvRowTest.java
@@ -20,10 +20,13 @@
 package org.apache.fesod.sheet.format;
 
 import java.io.File;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Calendar;
 import java.util.List;
 import org.apache.fesod.sheet.FastExcel;
+import org.apache.fesod.sheet.metadata.csv.CsvCell;
 import org.apache.fesod.sheet.metadata.csv.CsvRow;
 import org.apache.fesod.sheet.metadata.csv.CsvSheet;
 import org.apache.fesod.sheet.metadata.csv.CsvWorkbook;
@@ -118,6 +121,47 @@ public class CsvRowTest {
                 .registerWriteHandler(new AssertCsvHeadDataWriteHandler(head(), data()))
                 .csv()
                 .doWrite(modelData());
+    }
+
+    /**
+     * Verifies that {@link CsvCell} handles {@link java.sql.Date} the same way as
+     * {@link org.apache.fesod.sheet.metadata.data.WriteCellData}: the date is extracted
+     * via {@code toLocalDate().atStartOfDay()}, stripping any time component that may
+     * exist in the underlying milliseconds (common when JDBC drivers create
+     * {@code java.sql.Date} from a {@code java.util.Date} with time info).
+     */
+    @Test
+    void testCsvCellSqlDateConversion() {
+        // Create a java.sql.Date from a java.util.Date that has a time component
+        java.util.Date utilDate = new java.util.Date(2023 - 1900, Calendar.JUNE, 15, 23, 30, 0);
+        java.sql.Date sqlDate = new java.sql.Date(utilDate.getTime());
+
+        Cell cell = csvRow.createCell(0, CellType.NUMERIC);
+        cell.setCellValue(sqlDate);
+
+        LocalDateTime dateValue = ((CsvCell) cell).getLocalDateTimeCellValue();
+        // java.sql.Date is date-only: time component must be stripped to midnight
+        Assertions.assertEquals(LocalDateTime.of(2023, 6, 15, 0, 0, 0), dateValue);
+    }
+
+    /**
+     * Verifies that {@link CsvCell} handles {@link java.sql.Time} the same way as
+     * {@link org.apache.fesod.sheet.metadata.data.WriteCellData}: the time is extracted
+     * via {@code toLocalTime().atDate(LocalDate.of(1970, 1, 1))}, stripping any date
+     * component that may exist in the underlying milliseconds.
+     */
+    @Test
+    void testCsvCellSqlTimeConversion() {
+        // Create a java.sql.Time from a java.util.Date that has a date component
+        java.util.Date utilDate = new java.util.Date(2023 - 1900, Calendar.JUNE, 15, 12, 30, 45);
+        java.sql.Time sqlTime = new java.sql.Time(utilDate.getTime());
+
+        Cell cell = csvRow.createCell(0, CellType.NUMERIC);
+        cell.setCellValue(sqlTime);
+
+        LocalDateTime dateValue = ((CsvCell) cell).getLocalDateTimeCellValue();
+        // java.sql.Time is time-only: date component must be normalized to 1970-01-01
+        Assertions.assertEquals(LocalDateTime.of(1970, 1, 1, 12, 30, 45), dateValue);
     }
 
     private static List<SimpleCsvData> modelData() {

--- a/fesod-sheet/src/test/java/org/apache/fesod/sheet/format/CsvRowTest.java
+++ b/fesod-sheet/src/test/java/org/apache/fesod/sheet/format/CsvRowTest.java
@@ -20,6 +20,9 @@
 package org.apache.fesod.sheet.format;
 
 import java.io.File;
+import java.io.FileWriter;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -162,6 +165,46 @@ public class CsvRowTest {
         LocalDateTime dateValue = ((CsvCell) cell).getLocalDateTimeCellValue();
         // java.sql.Time is time-only: date component must be normalized to 1970-01-01
         Assertions.assertEquals(LocalDateTime.of(1970, 1, 1, 12, 30, 45), dateValue);
+    }
+
+    /**
+     * Real-file integration test: writes a physical CSV file containing
+     * {@code java.sql.Date} and {@code java.sql.Time} values via the
+     * {@link CsvCell} API, then reads the file back to verify the output.
+     * <p>
+     * Without the fix, {@code CsvCell.setCellValueImpl(Date)} calls
+     * {@code value.toInstant()} which throws {@code UnsupportedOperationException}
+     * on Java 9+ for {@code java.sql.Date}/{@code java.sql.Time}.
+     */
+    @Test
+    void csvWrite_withSqlDateAndTime_producesCorrectFile() throws Exception {
+        File csvFile = new File(tempDir, "sql-date-test.csv");
+
+        try (FileWriter writer = new FileWriter(csvFile)) {
+            CsvWorkbook workbook = new CsvWorkbook(
+                    writer, null, false, false, StandardCharsets.UTF_8, false);
+            CsvSheet sheet = (CsvSheet) workbook.createSheet();
+            CsvRow row = (CsvRow) sheet.createRow(0);
+
+            // java.sql.Date — without fix: UnsupportedOperationException
+            Cell dateCell = row.createCell(0, CellType.NUMERIC);
+            dateCell.setCellValue(java.sql.Date.valueOf("2024-01-15"));
+
+            // java.sql.Time — without fix: UnsupportedOperationException
+            Cell timeCell = row.createCell(1, CellType.NUMERIC);
+            timeCell.setCellValue(java.sql.Time.valueOf("12:30:45"));
+
+            sheet.close();
+        }
+
+        // Read file back and verify date/time strings
+        List<String> lines = Files.readAllLines(csvFile.toPath(), StandardCharsets.UTF_8);
+        Assertions.assertEquals(1, lines.size());
+        String line = lines.get(0);
+        Assertions.assertTrue(line.contains("2024-01-15"),
+                "CSV should contain date 2024-01-15, got: " + line);
+        Assertions.assertTrue(line.contains("12:30:45"),
+                "CSV should contain time 12:30:45, got: " + line);
     }
 
     private static List<SimpleCsvData> modelData() {

--- a/fesod-sheet/src/test/java/org/apache/fesod/sheet/format/CsvRowTest.java
+++ b/fesod-sheet/src/test/java/org/apache/fesod/sheet/format/CsvRowTest.java
@@ -33,6 +33,7 @@ import org.apache.fesod.sheet.metadata.csv.CsvRow;
 import org.apache.fesod.sheet.metadata.csv.CsvSheet;
 import org.apache.fesod.sheet.metadata.csv.CsvWorkbook;
 import org.apache.fesod.sheet.testkit.Tags;
+import org.apache.fesod.sheet.util.DateUtils;
 import org.apache.poi.ss.usermodel.Cell;
 import org.apache.poi.ss.usermodel.CellType;
 import org.junit.jupiter.api.Assertions;
@@ -144,14 +145,14 @@ public class CsvRowTest {
         cell.setCellValue(sqlDate);
 
         LocalDateTime dateValue = ((CsvCell) cell).getLocalDateTimeCellValue();
-        // java.sql.Date is date-only: time component must be stripped to midnight
-        Assertions.assertEquals(LocalDateTime.of(2023, 6, 15, 0, 0, 0), dateValue);
+        // java.sql.Date is date-only: derive expected value from sqlDate itself to avoid timezone sensitivity
+        Assertions.assertEquals(sqlDate.toLocalDate().atStartOfDay(), dateValue);
     }
 
     /**
      * Verifies that {@link CsvCell} handles {@link java.sql.Time} the same way as
      * {@link org.apache.fesod.sheet.metadata.data.WriteCellData}: the time is extracted
-     * via {@code toLocalTime().atDate(LocalDate.of(1970, 1, 1))}, stripping any date
+     * via {@code toLocalTime().atDate(DateUtils.EPOCH)}, stripping any date
      * component that may exist in the underlying milliseconds.
      */
     @Test
@@ -166,8 +167,8 @@ public class CsvRowTest {
         cell.setCellValue(sqlTime);
 
         LocalDateTime dateValue = ((CsvCell) cell).getLocalDateTimeCellValue();
-        // java.sql.Time is time-only: date component must be normalized to 1970-01-01
-        Assertions.assertEquals(LocalDateTime.of(1970, 1, 1, 12, 30, 45), dateValue);
+        // java.sql.Time is time-only: derive expected value from sqlTime itself to avoid timezone sensitivity
+        Assertions.assertEquals(sqlTime.toLocalTime().atDate(DateUtils.EPOCH), dateValue);
     }
 
     /**

--- a/fesod-sheet/src/test/java/org/apache/fesod/sheet/format/CsvRowTest.java
+++ b/fesod-sheet/src/test/java/org/apache/fesod/sheet/format/CsvRowTest.java
@@ -20,7 +20,6 @@
 package org.apache.fesod.sheet.format;
 
 import java.io.File;
-import java.io.FileWriter;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.time.LocalDateTime;
@@ -136,8 +135,10 @@ public class CsvRowTest {
     @Test
     void testCsvCellSqlDateConversion() {
         // Create a java.sql.Date from a java.util.Date that has a time component
-        java.util.Date utilDate = new java.util.Date(2023 - 1900, Calendar.JUNE, 15, 23, 30, 0);
-        java.sql.Date sqlDate = new java.sql.Date(utilDate.getTime());
+        Calendar cal = Calendar.getInstance();
+        cal.set(2023, Calendar.JUNE, 15, 23, 30, 0);
+        cal.set(Calendar.MILLISECOND, 0);
+        java.sql.Date sqlDate = new java.sql.Date(cal.getTimeInMillis());
 
         Cell cell = csvRow.createCell(0, CellType.NUMERIC);
         cell.setCellValue(sqlDate);
@@ -156,8 +157,10 @@ public class CsvRowTest {
     @Test
     void testCsvCellSqlTimeConversion() {
         // Create a java.sql.Time from a java.util.Date that has a date component
-        java.util.Date utilDate = new java.util.Date(2023 - 1900, Calendar.JUNE, 15, 12, 30, 45);
-        java.sql.Time sqlTime = new java.sql.Time(utilDate.getTime());
+        Calendar cal = Calendar.getInstance();
+        cal.set(2023, Calendar.JUNE, 15, 12, 30, 45);
+        cal.set(Calendar.MILLISECOND, 0);
+        java.sql.Time sqlTime = new java.sql.Time(cal.getTimeInMillis());
 
         Cell cell = csvRow.createCell(0, CellType.NUMERIC);
         cell.setCellValue(sqlTime);
@@ -180,7 +183,7 @@ public class CsvRowTest {
     void csvWrite_withSqlDateAndTime_producesCorrectFile() throws Exception {
         File csvFile = new File(tempDir, "sql-date-test.csv");
 
-        try (FileWriter writer = new FileWriter(csvFile)) {
+        try (java.io.Writer writer = Files.newBufferedWriter(csvFile.toPath(), StandardCharsets.UTF_8)) {
             CsvWorkbook workbook = new CsvWorkbook(writer, null, false, false, StandardCharsets.UTF_8, false);
             CsvSheet sheet = (CsvSheet) workbook.createSheet();
             CsvRow row = (CsvRow) sheet.createRow(0);

--- a/fesod-sheet/src/test/java/org/apache/fesod/sheet/format/CsvRowTest.java
+++ b/fesod-sheet/src/test/java/org/apache/fesod/sheet/format/CsvRowTest.java
@@ -181,8 +181,7 @@ public class CsvRowTest {
         File csvFile = new File(tempDir, "sql-date-test.csv");
 
         try (FileWriter writer = new FileWriter(csvFile)) {
-            CsvWorkbook workbook = new CsvWorkbook(
-                    writer, null, false, false, StandardCharsets.UTF_8, false);
+            CsvWorkbook workbook = new CsvWorkbook(writer, null, false, false, StandardCharsets.UTF_8, false);
             CsvSheet sheet = (CsvSheet) workbook.createSheet();
             CsvRow row = (CsvRow) sheet.createRow(0);
 
@@ -201,10 +200,8 @@ public class CsvRowTest {
         List<String> lines = Files.readAllLines(csvFile.toPath(), StandardCharsets.UTF_8);
         Assertions.assertEquals(1, lines.size());
         String line = lines.get(0);
-        Assertions.assertTrue(line.contains("2024-01-15"),
-                "CSV should contain date 2024-01-15, got: " + line);
-        Assertions.assertTrue(line.contains("12:30:45"),
-                "CSV should contain time 12:30:45, got: " + line);
+        Assertions.assertTrue(line.contains("2024-01-15"), "CSV should contain date 2024-01-15, got: " + line);
+        Assertions.assertTrue(line.contains("12:30:45"), "CSV should contain time 12:30:45, got: " + line);
     }
 
     private static List<SimpleCsvData> modelData() {


### PR DESCRIPTION
<!--
Thanks very much for contributing to Apache Fesod (Incubating)! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

Closed: #ISSUE
Related: #ISSUE

-->

## Purpose of the pull request

The SQL date type fix in #912  was only applied to WriteCellData, not
to CsvCell.setCellValueImpl(Date). The old code calls value.toInstant()
unconditionally, which throws UnsupportedOperationException for
java.sql.Date and java.sql.Time on Java 9+ (these types override
toInstant() to throw because they represent date-only/time-only values).

Fix: Add the same instanceof checks as WriteCellData - use toLocalDate()
.atStartOfDay() for java.sql.Date and toLocalTime().atDate(...) for
java.sql.Time, falling back to toInstant() for regular java.util.Date.

Before Change
<img width="1030" height="276" alt="image" src="https://github.com/user-attachments/assets/037f8db2-456f-4f52-9617-455002d38cef" />


## What's changed?

CsvCell

## Checklist

- [X] I have read the [Contributor Guide](https://fesod.apache.org/community/contribution/).
- [X] I have written the necessary doc or comment.
- [X] I have added the necessary unit tests and all cases have passed.
