### PR TITLE
fix: XLS BIFF8 encryption not applied due to premature password clearing

### DIFF
--- a/fesod-sheet/src/main/java/org/apache/fesod/sheet/util/WorkBookUtil.java
+++ b/fesod-sheet/src/main/java/org/apache/fesod/sheet/util/WorkBookUtil.java
@@ -93,12 +93,8 @@ public class WorkBookUtil {
                 writeWorkbookHolder.setCachedWorkbook(hssfWorkbook);
                 writeWorkbookHolder.setWorkbook(hssfWorkbook);
                 if (writeWorkbookHolder.getPassword() != null) {
-                    try {
-                        Biff8EncryptionKey.setCurrentUserPassword(writeWorkbookHolder.getPassword());
-                        hssfWorkbook.writeProtectWorkbook(writeWorkbookHolder.getPassword(), StringUtils.EMPTY);
-                    } finally {
-                        Biff8EncryptionKey.setCurrentUserPassword(null);
-                    }
+                    Biff8EncryptionKey.setCurrentUserPassword(writeWorkbookHolder.getPassword());
+                    hssfWorkbook.writeProtectWorkbook(writeWorkbookHolder.getPassword(), StringUtils.EMPTY);
                 }
                 return;
             case CSV:

--- a/fesod-sheet/src/main/java/org/apache/fesod/sheet/util/WorkBookUtil.java
+++ b/fesod-sheet/src/main/java/org/apache/fesod/sheet/util/WorkBookUtil.java
@@ -92,7 +92,7 @@ public class WorkBookUtil {
                 }
                 writeWorkbookHolder.setCachedWorkbook(hssfWorkbook);
                 writeWorkbookHolder.setWorkbook(hssfWorkbook);
-                if (writeWorkbookHolder.getPassword() != null) {
+                if (!StringUtils.isEmpty(writeWorkbookHolder.getPassword())) {
                     Biff8EncryptionKey.setCurrentUserPassword(writeWorkbookHolder.getPassword());
                     hssfWorkbook.writeProtectWorkbook(writeWorkbookHolder.getPassword(), StringUtils.EMPTY);
                 }

--- a/fesod-sheet/src/test/java/org/apache/fesod/sheet/readwrite/EncryptDataTest.java
+++ b/fesod-sheet/src/test/java/org/apache/fesod/sheet/readwrite/EncryptDataTest.java
@@ -39,6 +39,7 @@ import org.apache.fesod.sheet.testkit.listeners.CollectingReadListener;
 import org.apache.fesod.sheet.testkit.models.SimpleData;
 import org.apache.fesod.sheet.testkit.params.ExcelFormatSource;
 import org.apache.fesod.sheet.write.builder.ExcelWriterBuilder;
+import org.apache.poi.EncryptedDocumentException;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -123,11 +124,11 @@ public class EncryptDataTest extends AbstractExcelTest {
                 .doWrite(TestDataBuilder.simpleData(10));
 
         // Reading without the password must fail because the content is BIFF8-encrypted
-        Assertions.assertThrows(
-                Exception.class, () -> FesodSheet.read(file, SimpleData.class, new CollectingReadListener<SimpleData>())
-                        .excelType(ExcelTypeEnum.XLS)
-                        .sheet()
-                        .doReadSync());
+        Assertions.assertThrows(EncryptedDocumentException.class, () -> FesodSheet.read(
+                        file, SimpleData.class, new CollectingReadListener<SimpleData>())
+                .excelType(ExcelTypeEnum.XLS)
+                .sheet()
+                .doReadSync());
 
         // Reading with the correct password must succeed
         List<SimpleData> dataList = FesodSheet.read(file, SimpleData.class, new CollectingReadListener<SimpleData>())

--- a/fesod-sheet/src/test/java/org/apache/fesod/sheet/readwrite/EncryptDataTest.java
+++ b/fesod-sheet/src/test/java/org/apache/fesod/sheet/readwrite/EncryptDataTest.java
@@ -41,6 +41,7 @@ import org.apache.fesod.sheet.testkit.params.ExcelFormatSource;
 import org.apache.fesod.sheet.write.builder.ExcelWriterBuilder;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 
 /**
@@ -103,5 +104,38 @@ public class EncryptDataTest extends AbstractExcelTest {
         List<SimpleData> dataList = readerBuilder.sheet().doReadSync();
         Assertions.assertEquals(10, dataList.size());
         Assertions.assertNotNull(dataList.get(0).getName());
+    }
+
+    /**
+     * Verifies that an XLS file written with a password is actually encrypted at the BIFF8 record level,
+     * not merely flagged as write-protected. Without the correct password, reading the file content
+     * must fail.
+     */
+    @Test
+    void xlsPasswordWrite_isActuallyEncrypted() throws Exception {
+        File file = createTempFile("enc-verify", ExcelFormat.XLS);
+
+        // Write an encrypted XLS file
+        FesodSheet.write(file, SimpleData.class)
+                .excelType(ExcelTypeEnum.XLS)
+                .password(PASSWORD)
+                .sheet()
+                .doWrite(TestDataBuilder.simpleData(10));
+
+        // Reading without the password must fail because the content is BIFF8-encrypted
+        Assertions.assertThrows(
+                Exception.class,
+                () -> FesodSheet.read(file, SimpleData.class, new CollectingReadListener<SimpleData>())
+                        .excelType(ExcelTypeEnum.XLS)
+                        .sheet()
+                        .doReadSync());
+
+        // Reading with the correct password must succeed
+        List<SimpleData> dataList = FesodSheet.read(file, SimpleData.class, new CollectingReadListener<SimpleData>())
+                .excelType(ExcelTypeEnum.XLS)
+                .password(PASSWORD)
+                .sheet()
+                .doReadSync();
+        Assertions.assertEquals(10, dataList.size());
     }
 }

--- a/fesod-sheet/src/test/java/org/apache/fesod/sheet/readwrite/EncryptDataTest.java
+++ b/fesod-sheet/src/test/java/org/apache/fesod/sheet/readwrite/EncryptDataTest.java
@@ -124,8 +124,7 @@ public class EncryptDataTest extends AbstractExcelTest {
 
         // Reading without the password must fail because the content is BIFF8-encrypted
         Assertions.assertThrows(
-                Exception.class,
-                () -> FesodSheet.read(file, SimpleData.class, new CollectingReadListener<SimpleData>())
+                Exception.class, () -> FesodSheet.read(file, SimpleData.class, new CollectingReadListener<SimpleData>())
                         .excelType(ExcelTypeEnum.XLS)
                         .sheet()
                         .doReadSync());

--- a/fesod-sheet/src/test/java/org/apache/fesod/sheet/util/WorkBookUtilTest.java
+++ b/fesod-sheet/src/test/java/org/apache/fesod/sheet/util/WorkBookUtilTest.java
@@ -231,7 +231,10 @@ class WorkBookUtilTest {
 
         // Verify
         Mockito.verify(writeWorkbookHolder).setWorkbook(Mockito.any(HSSFWorkbook.class));
-        Assertions.assertNull(Biff8EncryptionKey.getCurrentUserPassword());
+        // The BIFF8 encryption password must remain set after createWorkBook() so that
+        // workbook.write() (called later in WriteContextImpl.finish()) can apply encryption.
+        // WriteContextImpl.clearEncrypt03() clears it after writing completes.
+        Assertions.assertEquals("123456", Biff8EncryptionKey.getCurrentUserPassword());
     }
 
     @Test


### PR DESCRIPTION


<!--
Thanks very much for contributing to Apache Fesod (Incubating)! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

Closed: #ISSUE
Related: #ISSUE

-->

## Purpose of the pull request

The refactor in 7fe23f0 added a finally block in WorkBookUtil.createWorkBook() that clears the Biff8EncryptionKey ThreadLocal immediately after setting it. However, workbook.write() (which applies BIFF8 encryption) runs later in WriteContextImpl.finish(). At that point the password is already null, so the file content is never encrypted - only a write-protection flag is set.

Below two files, XLSX can protect the content, but xls only provide write permission protection.
[sample-xls-password-buggy.xls](https://github.com/user-attachments/files/30159464/sample-xls-password-buggy.xls)
<img width="149" height="96" alt="image" src="https://github.com/user-attachments/assets/1fba1a95-67a6-42b9-a153-3c639512b07b" /> 

[sample-xlsx-password-encrypted.xlsx](https://github.com/user-attachments/files/30159465/sample-xlsx-password-encrypted.xlsx)
<img width="159" height="83" alt="image" src="https://github.com/user-attachments/assets/53d04ab3-b661-4b07-9867-f3df06facc39" />


Since code fixed, it also protect the content as below
<img width="155" height="84" alt="image" src="https://github.com/user-attachments/assets/c0bbf3c6-dca4-4f3d-a016-df9435feba67" />


## What's changed?


Fix: Remove the premature clearing. The password is correctly cleared by WriteContextImpl.clearEncrypt03() after workbook.write() completes.

Tests:
- Update WorkBookUtilTest to verify password remains set after createWorkBook()
- Add EncryptDataTest.xlsPasswordWrite_isActuallyEncrypted to verify that reading an encrypted XLS without a password fails


## Checklist

- [X] I have read the [Contributor Guide](https://fesod.apache.org/community/contribution/).
- [X] I have written the necessary doc or comment.
- [X] I have added the necessary unit tests and all cases have passed.
