### PR TITLE
fix: reset cached batch in PageReadListener between sheets to avoid duplicate rows

### DIFF
--- a/fesod-sheet/src/main/java/org/apache/fesod/sheet/read/listener/PageReadListener.java
+++ b/fesod-sheet/src/main/java/org/apache/fesod/sheet/read/listener/PageReadListener.java
@@ -77,6 +77,7 @@ public class PageReadListener<T> implements ReadListener<T> {
     public void doAfterAllAnalysed(AnalysisContext context) {
         if (CollectionUtils.isNotEmpty(cachedDataList)) {
             consumer.accept(cachedDataList);
+            cachedDataList = ListUtils.newArrayListWithExpectedSize(batchCount);
         }
     }
 }

--- a/fesod-sheet/src/test/java/org/apache/fesod/sheet/core/SimpleDataTest.java
+++ b/fesod-sheet/src/test/java/org/apache/fesod/sheet/core/SimpleDataTest.java
@@ -26,8 +26,12 @@
 package org.apache.fesod.sheet.core;
 
 import java.io.File;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
+import org.apache.fesod.sheet.ExcelWriter;
 import org.apache.fesod.sheet.FesodSheet;
 import org.apache.fesod.sheet.read.listener.PageReadListener;
 import org.apache.fesod.sheet.testkit.Tags;
@@ -113,5 +117,34 @@ public class SimpleDataTest extends AbstractExcelTest {
                                 5))
                 .sheet()
                 .doRead();
+    }
+
+    @Test
+    void pageReadListenerMultipleSheets07() throws Exception {
+        File file = createTempFile(ExcelFormat.XLSX);
+        try (ExcelWriter excelWriter = FesodSheet.write(file, SimpleData.class).build()) {
+            excelWriter.write(
+                    TestDataBuilder.simpleData(3, "First"),
+                    FesodSheet.writerSheet(0, "sheet0").build());
+            excelWriter.write(
+                    TestDataBuilder.simpleData(4, "Second"),
+                    FesodSheet.writerSheet(1, "sheet1").build());
+        }
+
+        List<SimpleData> allData = new ArrayList<>();
+        FesodSheet.read(file, SimpleData.class, new PageReadListener<SimpleData>(allData::addAll, 5))
+                .doReadAll();
+
+        // Each row must be delivered exactly once, even when a sheet ends with a partially filled batch
+        Assertions.assertEquals(
+                Arrays.asList(
+                        "FirstName0",
+                        "FirstName1",
+                        "FirstName2",
+                        "SecondName0",
+                        "SecondName1",
+                        "SecondName2",
+                        "SecondName3"),
+                allData.stream().map(SimpleData::getName).collect(Collectors.toList()));
     }
 }


### PR DESCRIPTION
## Purpose of the pull request

Closed: #960

`PageReadListener` re-delivers the previous sheet's leftover rows when a single listener reads multiple sheets (`doReadAll()`) with a batch size greater than 1, so the consumer processes those rows twice.

## What's changed?

`doAfterAllAnalysed` flushes the partially filled batch at the end of each sheet, but kept the delivered rows in `cachedDataList`. Since `DefaultAnalysisEventProcessor.endSheet` invokes `doAfterAllAnalysed` after every sheet and the same listener instance serves all sheets, the next sheet kept appending to the already-delivered list and re-emitted its rows as soon as the batch filled up.

The fix is a one-line reset of `cachedDataList` after the end-of-sheet flush, mirroring what `invoke` already does after delivering a full batch.

Regression test: `SimpleDataTest.pageReadListenerMultipleSheets07` writes a two-sheet workbook (3 + 4 rows), reads all sheets with batch size 5, and asserts the exact delivered sequence. On current `main` it fails with sheet0's three rows delivered twice (10 deliveries instead of 7):

```
expected: <[FirstName0, FirstName1, FirstName2, SecondName0, SecondName1, SecondName2, SecondName3]>
 but was: <[FirstName0, FirstName1, FirstName2, FirstName0, FirstName1, FirstName2, SecondName0, SecondName1, SecondName2, SecondName3]>
```

## Checklist

- [x] I have read the [Contributor Guide](https://fesod.apache.org/community/contribution/).
- [x] I have written the necessary doc or comment.
- [x] I have added the necessary unit tests and all cases have passed.
