### PR TITLE
fix: remove redundant buffer copy in IoUtils.toByteArray(InputStream)

### DIFF
--- a/fesod-common/src/main/java/org/apache/fesod/common/util/IoUtils.java
+++ b/fesod-common/src/main/java/org/apache/fesod/common/util/IoUtils.java
@@ -53,12 +53,8 @@ public class IoUtils {
      */
     public static byte[] toByteArray(final InputStream input) throws IOException {
         final ByteArrayOutputStream output = new ByteArrayOutputStream();
-        try {
-            copy(input, output);
-            return output.toByteArray();
-        } finally {
-            output.toByteArray();
-        }
+        copy(input, output);
+        return output.toByteArray();
     }
 
     /**


### PR DESCRIPTION
## Purpose of the pull request

Closed: #952

## What's changed?

`IoUtils.toByteArray(InputStream)` had a `finally` block calling `output.toByteArray()` and discarding the result. `ByteArrayOutputStream.toByteArray()` allocates a full copy of the internal buffer, so every call allocated the payload twice - a leftover from translating commons-io's try-with-resources version, where the `finally` would have been `output.close()` (a no-op for `ByteArrayOutputStream`).

This removes the `try`/`finally` entirely.

### Testing

No behaviour change. Existing `IoUtilsTest` (7 cases) passes unchanged.

## Checklist

- [x] I have read the [Contributor Guide](https://fesod.apache.org/community/contribution/).
- [x] I have written the necessary doc or comment.
- [x] I have added the necessary unit tests and all cases have passed.
