### PR TITLE
dependency: upgrade assertj-core to 3.27.7 to fix XXE vulnerability

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -111,7 +111,7 @@
         <junit.version>5.13.4</junit.version>
         <mockito.version>4.11.0</mockito.version>
         <jazzer.junit.version>0.25.1</jazzer.junit.version>
-        <assertj.version>3.25.3</assertj.version>
+        <assertj.version>3.27.7</assertj.version>
         <surefire.jvm.args>-Xmx2g -Xms2g -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8</surefire.jvm.args>
         <surefire.jdk9plus.args></surefire.jdk9plus.args>
         <argLine></argLine>


### PR DESCRIPTION
## Summary

Upgrade \assertj-core\ from \3.25.3\ to \3.27.7\ to resolve the Dependabot security alert [#101](https://github.com/apache/fesod/security/dependabot/101).

## Vulnerability

assertj-core versions prior to 3.27.7 are vulnerable to XML External Entity (XXE) injection when parsing XML assertions. This could allow an attacker to read arbitrary files, cause denial of service, or perform SSRF attacks when assertj processes untrusted XML input.

## Changes

- \pom.xml\: Updated \assertj.version\ property from \3.25.3\ to \3.27.7\

## Verification

- **Build**: \mvn clean install -DskipTests\ passes on all modules
- **Tests**: All 412 unit tests pass (\mvn test -pl fesod-sheet -Dtest.groups=unit -Dtest.excludedGroups=fuzz\)
- **Spotless**: \mvn spotless:check\ passes — no formatting issues

## Related

- Fixes: https://github.com/apache/fesod/security/dependabot/101