### PR TITLE
fix: copy default read converter map to isolate per-reader custom converters

### DIFF
--- a/fesod-sheet/src/main/java/org/apache/fesod/sheet/converters/DefaultConverterLoader.java
+++ b/fesod-sheet/src/main/java/org/apache/fesod/sheet/converters/DefaultConverterLoader.java
@@ -25,6 +25,8 @@
 
 package org.apache.fesod.sheet.converters;
 
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 import org.apache.fesod.common.util.MapUtils;
 import org.apache.fesod.sheet.converters.ConverterKeyBuild.ConverterKey;
@@ -139,6 +141,7 @@ public class DefaultConverterLoader {
         putAllConverter(new StringNumberConverter());
         putAllConverter(new StringStringConverter());
         putAllConverter(new StringErrorConverter());
+        allConverter = Collections.unmodifiableMap(allConverter);
     }
 
     private static void initDefaultWriteConverter() {
@@ -176,6 +179,7 @@ public class DefaultConverterLoader {
         putWriteStringConverter(new LongStringConverter());
         putWriteStringConverter(new ShortStringConverter());
         putWriteStringConverter(new StringStringConverter());
+        defaultWriteConverter = Collections.unmodifiableMap(defaultWriteConverter);
     }
 
     /**
@@ -185,6 +189,15 @@ public class DefaultConverterLoader {
      */
     public static Map<ConverterKey, Converter<?>> loadDefaultWriteConverter() {
         return defaultWriteConverter;
+    }
+
+    /**
+     * Copy default write converter
+     *
+     * @return
+     */
+    public static Map<ConverterKey, Converter<?>> copyDefaultWriteConverter() {
+        return new HashMap<>(loadDefaultWriteConverter());
     }
 
     private static void putWriteConverter(Converter<?> converter) {
@@ -206,12 +219,30 @@ public class DefaultConverterLoader {
     }
 
     /**
+     * Copy default read converter
+     *
+     * @return
+     */
+    public static Map<ConverterKey, Converter<?>> copyDefaultReadConverter() {
+        return new HashMap<>(loadDefaultReadConverter());
+    }
+
+    /**
      * Load all converter
      *
      * @return
      */
     public static Map<ConverterKey, Converter<?>> loadAllConverter() {
         return allConverter;
+    }
+
+    /**
+     * Copy all converter
+     *
+     * @return
+     */
+    public static Map<ConverterKey, Converter<?>> copyAllConverter() {
+        return new HashMap<>(loadAllConverter());
     }
 
     private static void putAllConverter(Converter<?> converter) {

--- a/fesod-sheet/src/main/java/org/apache/fesod/sheet/read/metadata/holder/AbstractReadHolder.java
+++ b/fesod-sheet/src/main/java/org/apache/fesod/sheet/read/metadata/holder/AbstractReadHolder.java
@@ -120,7 +120,10 @@ public abstract class AbstractReadHolder extends AbstractHolder implements ReadH
         }
 
         if (parentAbstractReadHolder == null) {
-            setConverterMap(DefaultConverterLoader.loadDefaultReadConverter());
+            // Copy the defaults instead of aliasing the shared static map, otherwise custom
+            // converters registered below mutate DefaultConverterLoader's global map and leak
+            // into every later read. Mirrors the write side (AbstractWriteHolder).
+            setConverterMap(new HashMap<>(DefaultConverterLoader.loadDefaultReadConverter()));
         } else {
             setConverterMap(new HashMap<>(parentAbstractReadHolder.getConverterMap()));
         }

--- a/fesod-sheet/src/main/java/org/apache/fesod/sheet/read/metadata/holder/AbstractReadHolder.java
+++ b/fesod-sheet/src/main/java/org/apache/fesod/sheet/read/metadata/holder/AbstractReadHolder.java
@@ -120,10 +120,7 @@ public abstract class AbstractReadHolder extends AbstractHolder implements ReadH
         }
 
         if (parentAbstractReadHolder == null) {
-            // Copy the defaults instead of aliasing the shared static map, otherwise custom
-            // converters registered below mutate DefaultConverterLoader's global map and leak
-            // into every later read. Mirrors the write side (AbstractWriteHolder).
-            setConverterMap(new HashMap<>(DefaultConverterLoader.loadDefaultReadConverter()));
+            setConverterMap(DefaultConverterLoader.copyDefaultReadConverter());
         } else {
             setConverterMap(new HashMap<>(parentAbstractReadHolder.getConverterMap()));
         }

--- a/fesod-sheet/src/main/java/org/apache/fesod/sheet/write/metadata/holder/AbstractWriteHolder.java
+++ b/fesod-sheet/src/main/java/org/apache/fesod/sheet/write/metadata/holder/AbstractWriteHolder.java
@@ -268,7 +268,7 @@ public abstract class AbstractWriteHolder extends AbstractHolder implements Writ
 
         // Set converterMap
         if (parentAbstractWriteHolder == null) {
-            setConverterMap(new HashMap<>(DefaultConverterLoader.loadDefaultWriteConverter()));
+            setConverterMap(DefaultConverterLoader.copyDefaultWriteConverter());
         } else {
             setConverterMap(new HashMap<>(parentAbstractWriteHolder.getConverterMap()));
             if (CollectionUtils.isNotEmpty(parentAbstractWriteHolder.getCustomConverterList())) {

--- a/fesod-sheet/src/test/java/org/apache/fesod/sheet/converters/DefaultConverterLoaderTest.java
+++ b/fesod-sheet/src/test/java/org/apache/fesod/sheet/converters/DefaultConverterLoaderTest.java
@@ -29,15 +29,13 @@ public class DefaultConverterLoaderTest {
     @Test
     void loadDefaultWriteConverterIsImmutableAndCopyIsMutable() {
         assertLoadIsImmutableAndCopyIsMutable(
-                DefaultConverterLoader.loadDefaultWriteConverter(),
-                DefaultConverterLoader.copyDefaultWriteConverter());
+                DefaultConverterLoader.loadDefaultWriteConverter(), DefaultConverterLoader.copyDefaultWriteConverter());
     }
 
     @Test
     void loadDefaultReadConverterIsImmutableAndCopyIsMutable() {
         assertLoadIsImmutableAndCopyIsMutable(
-                DefaultConverterLoader.loadDefaultReadConverter(),
-                DefaultConverterLoader.copyDefaultReadConverter());
+                DefaultConverterLoader.loadDefaultReadConverter(), DefaultConverterLoader.copyDefaultReadConverter());
     }
 
     @Test
@@ -48,7 +46,8 @@ public class DefaultConverterLoaderTest {
 
     private static void assertLoadIsImmutableAndCopyIsMutable(
             Map<ConverterKey, Converter<?>> loaded, Map<ConverterKey, Converter<?>> copy) {
-        Map.Entry<ConverterKey, Converter<?>> entry = loaded.entrySet().iterator().next();
+        Map.Entry<ConverterKey, Converter<?>> entry =
+                loaded.entrySet().iterator().next();
 
         Assertions.assertThrows(
                 UnsupportedOperationException.class, () -> loaded.put(entry.getKey(), entry.getValue()));

--- a/fesod-sheet/src/test/java/org/apache/fesod/sheet/converters/DefaultConverterLoaderTest.java
+++ b/fesod-sheet/src/test/java/org/apache/fesod/sheet/converters/DefaultConverterLoaderTest.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.fesod.sheet.converters;
+
+import java.util.Map;
+import org.apache.fesod.sheet.converters.ConverterKeyBuild.ConverterKey;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class DefaultConverterLoaderTest {
+
+    @Test
+    void loadDefaultWriteConverterIsImmutableAndCopyIsMutable() {
+        assertLoadIsImmutableAndCopyIsMutable(
+                DefaultConverterLoader.loadDefaultWriteConverter(),
+                DefaultConverterLoader.copyDefaultWriteConverter());
+    }
+
+    @Test
+    void loadDefaultReadConverterIsImmutableAndCopyIsMutable() {
+        assertLoadIsImmutableAndCopyIsMutable(
+                DefaultConverterLoader.loadDefaultReadConverter(),
+                DefaultConverterLoader.copyDefaultReadConverter());
+    }
+
+    @Test
+    void loadAllConverterIsImmutableAndCopyIsMutable() {
+        assertLoadIsImmutableAndCopyIsMutable(
+                DefaultConverterLoader.loadAllConverter(), DefaultConverterLoader.copyAllConverter());
+    }
+
+    private static void assertLoadIsImmutableAndCopyIsMutable(
+            Map<ConverterKey, Converter<?>> loaded, Map<ConverterKey, Converter<?>> copy) {
+        Map.Entry<ConverterKey, Converter<?>> entry = loaded.entrySet().iterator().next();
+
+        Assertions.assertThrows(
+                UnsupportedOperationException.class, () -> loaded.put(entry.getKey(), entry.getValue()));
+
+        copy.remove(entry.getKey());
+        Assertions.assertFalse(copy.containsKey(entry.getKey()));
+        Assertions.assertTrue(loaded.containsKey(entry.getKey()));
+    }
+}

--- a/fesod-sheet/src/test/java/org/apache/fesod/sheet/read/ReadConverterIsolationTest.java
+++ b/fesod-sheet/src/test/java/org/apache/fesod/sheet/read/ReadConverterIsolationTest.java
@@ -1,17 +1,19 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements. See the NOTICE file distributed with this
- * work for additional information regarding copyright ownership. The ASF
- * licenses this file to You under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
  *
  *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
  * under the License.
  */
 package org.apache.fesod.sheet.read;

--- a/fesod-sheet/src/test/java/org/apache/fesod/sheet/read/ReadConverterIsolationTest.java
+++ b/fesod-sheet/src/test/java/org/apache/fesod/sheet/read/ReadConverterIsolationTest.java
@@ -16,6 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+
 package org.apache.fesod.sheet.read;
 
 import java.io.File;

--- a/fesod-sheet/src/test/java/org/apache/fesod/sheet/read/ReadConverterIsolationTest.java
+++ b/fesod-sheet/src/test/java/org/apache/fesod/sheet/read/ReadConverterIsolationTest.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership. The ASF
+ * licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fesod.sheet.read;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import lombok.Data;
+import org.apache.fesod.sheet.FesodSheet;
+import org.apache.fesod.sheet.converters.Converter;
+import org.apache.fesod.sheet.enums.CellDataTypeEnum;
+import org.apache.fesod.sheet.metadata.GlobalConfiguration;
+import org.apache.fesod.sheet.metadata.data.ReadCellData;
+import org.apache.fesod.sheet.metadata.data.WriteCellData;
+import org.apache.fesod.sheet.metadata.property.ExcelContentProperty;
+import org.apache.fesod.sheet.read.listener.PageReadListener;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * A converter registered on one {@link org.apache.fesod.sheet.ExcelReader} must not leak into a
+ * later, unrelated read.
+ */
+public class ReadConverterIsolationTest {
+
+    @Data
+    public static class StringRow {
+        private String value;
+    }
+
+    /** Appends a marker so leakage is observable. */
+    public static class MarkerConverter implements Converter<String> {
+        @Override
+        public Class<?> supportJavaTypeKey() {
+            return String.class;
+        }
+
+        @Override
+        public CellDataTypeEnum supportExcelTypeKey() {
+            return CellDataTypeEnum.STRING;
+        }
+
+        @Override
+        public String convertToJavaData(
+                ReadCellData<?> cellData,
+                ExcelContentProperty contentProperty,
+                GlobalConfiguration globalConfiguration) {
+            return cellData.getStringValue() + " [MARKER]";
+        }
+
+        @Override
+        public WriteCellData<?> convertToExcelData(
+                String value, ExcelContentProperty contentProperty, GlobalConfiguration globalConfiguration) {
+            return new WriteCellData<>(value);
+        }
+    }
+
+    @Test
+    void registeredConverterDoesNotLeakIntoLaterRead() throws Exception {
+        File file = File.createTempFile("conv-iso", ".xlsx");
+        file.deleteOnExit();
+        StringRow out = new StringRow();
+        out.setValue("hello");
+        FesodSheet.write(file, StringRow.class).sheet().doWrite(Collections.singletonList(out));
+
+        // First read: register the marker converter -> values carry the marker.
+        List<StringRow> first = new ArrayList<>();
+        FesodSheet.read(file, StringRow.class, new PageReadListener<StringRow>(first::addAll))
+                .registerConverter(new MarkerConverter())
+                .sheet()
+                .doRead();
+        Assertions.assertEquals(Collections.singletonList("hello [MARKER]"), values(first));
+
+        // Second read: fresh reader, NO converter registered -> must NOT see the marker.
+        List<StringRow> second = new ArrayList<>();
+        FesodSheet.read(file, StringRow.class, new PageReadListener<StringRow>(second::addAll))
+                .sheet()
+                .doRead();
+        Assertions.assertEquals(Collections.singletonList("hello"), values(second));
+    }
+
+    private static List<String> values(List<StringRow> rows) {
+        List<String> out = new ArrayList<>();
+        for (StringRow r : rows) {
+            out.add(r.getValue());
+        }
+        return out;
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #971.

The workbook-level read holder aliased `DefaultConverterLoader`'s shared static `allConverter` map instead of copying it, so custom converters registered via `registerConverter(...)` were `put()` into the global map and leaked into every later, unrelated read on the same JVM. This mirrors the write side (`AbstractWriteHolder:271`), which already copies.

## Root cause

`AbstractReadHolder`:

```java
if (parentAbstractReadHolder == null) {
    setConverterMap(DefaultConverterLoader.loadDefaultReadConverter()); // shared static, no copy
} else {
    setConverterMap(new HashMap<>(parentAbstractReadHolder.getConverterMap()));
}
```

`loadDefaultReadConverter()` returns the static `allConverter` map by reference, so the `getConverterMap().put(...)` loop right below mutates the shared map and the registration survives the reader.

## Fix

```java
setConverterMap(new HashMap<>(DefaultConverterLoader.loadDefaultReadConverter()));
```

## Verification

Added `ReadConverterIsolationTest` which:

1. reads a file with a registered marker converter → values carry the marker (expected);
2. reads the same file with a **fresh reader and no converter** → asserts values carry **no** marker.

Before the fix, step 2 failed (`hello [MARKER]` instead of `hello`). After the fix it passes. Full `fesod-sheet` suite: `Tests run: 668, Failures: 0, Errors: 0`.
