### PR TITLE
fix: mark CsvCell Calendar value as a date to avoid silent empty write

### DIFF
--- a/fesod-sheet/src/main/java/org/apache/fesod/sheet/metadata/csv/CsvCell.java
+++ b/fesod-sheet/src/main/java/org/apache/fesod/sheet/metadata/csv/CsvCell.java
@@ -190,6 +190,10 @@ public class CsvCell extends CellBase {
         }
         this.dateValue = LocalDateTime.ofInstant(value.toInstant(), ZoneId.systemDefault());
         this.cellType = CellType.NUMERIC;
+        // Mark the numeric cell as a date so CsvSheet.buildCellValue takes the date
+        // branch; otherwise it falls back to numberValue (null) and writes an empty
+        // field, silently dropping the Calendar value. Mirrors the Date/LocalDateTime setters.
+        this.numericCellType = NumericCellTypeEnum.DATE;
     }
 
     @Override

--- a/fesod-sheet/src/test/java/org/apache/fesod/sheet/format/CsvRowTest.java
+++ b/fesod-sheet/src/test/java/org/apache/fesod/sheet/format/CsvRowTest.java
@@ -208,6 +208,46 @@ public class CsvRowTest {
         Assertions.assertTrue(line.contains("12:30:45"), "CSV should contain time 12:30:45, got: " + line);
     }
 
+    /**
+     * Real-file integration test: writes a physical CSV file containing a
+     * {@link Calendar} value via the {@link CsvCell} API, then reads the file
+     * back to verify the output.
+     * <p>
+     * Without the fix, {@link CsvCell#setCellValueImpl(Calendar)} sets the cell
+     * to {@code NUMERIC} but does not mark it as a date
+     * ({@code numericCellType = NumericCellTypeEnum.DATE}), so
+     * {@link CsvSheet} takes the number branch in {@code buildCellValue},
+     * finds {@code numberValue} null, and writes an empty field - the
+     * Calendar value is silently lost. The sibling {@code Date} and
+     * {@code LocalDateTime} setters already set the date type.
+     */
+    @Test
+    void csvWrite_withCalendar_producesCorrectFile() throws Exception {
+        File csvFile = new File(tempDir, "calendar-test.csv");
+
+        Calendar cal = Calendar.getInstance();
+        cal.set(2024, Calendar.JANUARY, 15, 12, 30, 45);
+        cal.set(Calendar.MILLISECOND, 0);
+
+        try (java.io.Writer writer = Files.newBufferedWriter(csvFile.toPath(), StandardCharsets.UTF_8)) {
+            CsvWorkbook workbook = new CsvWorkbook(writer, null, false, false, StandardCharsets.UTF_8, false);
+            CsvSheet sheet = (CsvSheet) workbook.createSheet();
+            CsvRow row = (CsvRow) sheet.createRow(0);
+
+            // Calendar - without fix: written as an empty field (silent data loss)
+            Cell cell = row.createCell(0, CellType.NUMERIC);
+            cell.setCellValue(cal);
+
+            sheet.close();
+        }
+
+        List<String> lines = Files.readAllLines(csvFile.toPath(), StandardCharsets.UTF_8);
+        Assertions.assertEquals(1, lines.size());
+        String line = lines.get(0);
+        Assertions.assertTrue(
+                line.contains("2024-01-15"), "CSV should contain the calendar date 2024-01-15, got: " + line);
+    }
+
     private static List<SimpleCsvData> modelData() {
         List<SimpleCsvData> data = new ArrayList<>();
         data.add(new SimpleCsvData("1", "Jackson", "20"));


### PR DESCRIPTION
## Summary

Fixes #973.

`CsvCell.setCellValueImpl(Calendar)` set `cellType = NUMERIC` but did not set `numericCellType = NumericCellTypeEnum.DATE`, so `CsvSheet.buildCellValue` took the number branch, found `numberValue` was `null`, and wrote an empty field — silently dropping the `Calendar` value. The sibling `Date` and `LocalDateTime` setters already set the date type.

## Root cause

`CsvCell`:

```java
@Override
protected void setCellValueImpl(Calendar value) {
    if (value == null) {
        return;
    }
    this.dateValue = LocalDateTime.ofInstant(value.toInstant(), ZoneId.systemDefault());
    this.cellType = CellType.NUMERIC;
    // missing: this.numericCellType = NumericCellTypeEnum.DATE;
}
```

`CsvSheet.buildCellValue` dispatches on `csvCell.getNumericCellType() == NumericCellTypeEnum.DATE`; without it the cell falls through to the number branch, where `numberValue` is `null`, and returns `null` → empty field.

## Fix

```java
this.numericCellType = NumericCellTypeEnum.DATE;
```

## Verification

Added `CsvRowTest.csvWrite_withCalendar_producesCorrectFile`: writes a `Calendar` (2024-01-15 12:30:45) to a `CsvCell` via the POI `Cell` API and reads the CSV file back. Before the fix the cell was an empty field; after the fix the line contains `2024-01-15`. Full `fesod-sheet` suite: `Tests run: 668, Failures: 0`.
