### PR TITLE
fix: remove indexFieldMap entry by field key, not running counter

### DIFF
--- a/fesod-sheet/src/main/java/org/apache/fesod/sheet/util/ClassUtils.java
+++ b/fesod-sheet/src/main/java/org/apache/fesod/sheet/util/ClassUtils.java
@@ -364,7 +364,11 @@ public class ClassUtils {
             // The current field needs to be ignored
             if (writeHolder.ignore(field.getFieldName(), entry.getKey())) {
                 ignoreSet.add(field.getFieldName());
-                indexFieldMap.remove(index);
+                // indexFieldMap is keyed by the field's explicit @ExcelProperty(index), which for
+                // explicit-index fields equals the sortedFieldMap position (entry.getKey()); remove
+                // by that key, not the running counter, otherwise an unrelated explicit-index entry
+                // is dropped and the ignored field's entry may survive.
+                indexFieldMap.remove(key);
             } else {
                 // Mandatory sorted fields
                 if (indexFieldMap.containsKey(key)) {

--- a/fesod-sheet/src/test/java/org/apache/fesod/sheet/util/ClassUtilsTest.java
+++ b/fesod-sheet/src/test/java/org/apache/fesod/sheet/util/ClassUtilsTest.java
@@ -203,6 +203,29 @@ class ClassUtilsTest {
     }
 
     @Test
+    void test_declaredFields_WriteHolder_exclude_preservesUnrelatedExplicitIndex() {
+        // Excluding a field that has NO explicit @ExcelProperty(index) (here "email",
+        // which uses order=10) must not perturb indexFieldMap, which only holds fields
+        // that DO carry an explicit index (ComplexEntity: id->0, name->2).
+        Mockito.when(globalConfiguration.getFiledCacheLocation()).thenReturn(CacheLocationEnum.NONE);
+
+        Mockito.when(writeHolder.excludeColumnFieldNames()).thenReturn(Collections.singleton("email"));
+        Mockito.when(writeHolder.ignore(Mockito.anyString(), Mockito.anyInt())).thenReturn(false);
+        Mockito.when(writeHolder.ignore(Mockito.eq("email"), Mockito.anyInt())).thenReturn(true);
+
+        FieldCache fieldCache = ClassUtils.declaredFields(ComplexEntity.class, writeHolder);
+
+        Map<Integer, FieldWrapper> indexFieldMap = fieldCache.getIndexFieldMap();
+        // id (@ExcelProperty(index = 0)) and name (index = 2) must still be present and
+        // bound to their explicit indices; the ignored field was never in this map.
+        Assertions.assertTrue(indexFieldMap.containsKey(0), "explicit index 0 (id) must remain");
+        Assertions.assertEquals("id", indexFieldMap.get(0).getFieldName());
+        Assertions.assertTrue(indexFieldMap.containsKey(2), "explicit index 2 (name) must remain");
+        Assertions.assertEquals("name", indexFieldMap.get(2).getFieldName());
+        Assertions.assertFalse(indexFieldMap.values().stream().anyMatch(f -> "email".equals(f.getFieldName())));
+    }
+
+    @Test
     void test_declaredFields_resort() {
         Mockito.when(globalConfiguration.getFiledCacheLocation()).thenReturn(CacheLocationEnum.NONE);
 


### PR DESCRIPTION
## Summary

Fixes #976.

When a `WriteHolder` excludes a column, the ignored branch removed from `indexFieldMap` using the running loop counter `index` instead of the field's own `sortedFieldMap` key. For explicit-index fields, that key (`entry.getKey()`) equals the field's `@ExcelProperty(index)` — its `indexFieldMap` key — so removing by the counter dropped an unrelated explicit-index entry and left the ignored field's entry in place.

## Root cause

`ClassUtils.doDeclaredFields`:

```java
if (writeHolder.ignore(field.getFieldName(), entry.getKey())) {
    ignoreSet.add(field.getFieldName());
    indexFieldMap.remove(index);   // BUG: 'index' is the running counter, not the field's key
} else {
    ...
}
```

`indexFieldMap` is keyed by the field's explicit `@ExcelProperty(index = N)` (see `declaredOneField`), and for explicit-index fields the `sortedFieldMap` position `entry.getKey()` equals that index (see `buildSortedAllFieldMap`). So the ignored field's own entry is keyed by `entry.getKey()`, not the counter.

## Fix

```java
indexFieldMap.remove(key);
```

For a field with an explicit index, `key == entry.getKey()` is its `indexFieldMap` key, so its own entry is removed; for a field without an explicit index, `key` is not in `indexFieldMap`, so the call is a no-op (correct — it was never there).

The corruption is observable downstream: `ExcelHeadProperty.initColumnProperties` passes `indexFieldMap.containsKey(entry.getKey())` as `forceIndex` into each `Head`, which `DefaultAnalysisEventProcessor` reads to drive head-to-column matching.

## Verification

Added `ClassUtilsTest.test_declaredFields_WriteHolder_exclude_preservesUnrelatedExplicitIndex`: with `ComplexEntity` (`id` index 0, `name` index 2, `email` order 10), excluding `email` must keep `indexFieldMap` as `{0: id, 2: name}`. Before the fix `id` (index 0) was wrongly removed; after the fix it stays. Full `fesod-sheet` suite: `Tests run: 668, Failures: 0`.
