### PR TITLE
feat: add support for column-based reading of CSV files

### DIFF
--- a/fesod-sheet/src/main/java/org/apache/fesod/sheet/analysis/csv/CsvExcelReadExecutor.java
+++ b/fesod-sheet/src/main/java/org/apache/fesod/sheet/analysis/csv/CsvExcelReadExecutor.java
@@ -223,11 +223,16 @@ public class CsvExcelReadExecutor implements ExcelReadExecutor {
                 csvReadContext.csvReadWorkbookHolder().globalConfiguration().getAutoTrim();
         Boolean autoStrip =
                 csvReadContext.csvReadWorkbookHolder().globalConfiguration().getAutoStrip();
+        List<Integer> includeColumnIndexes = csvReadContext.readSheetHolder().getColumnIndexes();
         while (cellIterator.hasNext()) {
             String cellString = cellIterator.next();
+            int currentColumnIndex = columnIndex++;
+            if (includeColumnIndexes != null && !includeColumnIndexes.contains(currentColumnIndex)) {
+                continue;
+            }
             ReadCellData<String> readCellData = new ReadCellData<>();
             readCellData.setRowIndex(rowIndex);
-            readCellData.setColumnIndex(columnIndex);
+            readCellData.setColumnIndex(currentColumnIndex);
 
             // csv is an empty string of whether <code>,,</code> is read or <code>,"",</code>
             if (StringUtils.isNotBlank(cellString)) {
@@ -242,7 +247,7 @@ public class CsvExcelReadExecutor implements ExcelReadExecutor {
             } else {
                 readCellData.setType(CellDataTypeEnum.EMPTY);
             }
-            cellMap.put(columnIndex++, readCellData);
+            cellMap.put(currentColumnIndex, readCellData);
         }
 
         RowTypeEnum rowType = MapUtils.isEmpty(cellMap) ? RowTypeEnum.EMPTY : RowTypeEnum.DATA;

--- a/fesod-sheet/src/main/java/org/apache/fesod/sheet/analysis/csv/CsvExcelReadExecutor.java
+++ b/fesod-sheet/src/main/java/org/apache/fesod/sheet/analysis/csv/CsvExcelReadExecutor.java
@@ -224,17 +224,26 @@ public class CsvExcelReadExecutor implements ExcelReadExecutor {
         Boolean autoStrip =
                 csvReadContext.csvReadWorkbookHolder().globalConfiguration().getAutoStrip();
         List<Integer> includeColumnIndexes = csvReadContext.readSheetHolder().getReadSheet().getColumnIndexes();
+
         while (cellIterator.hasNext()) {
             String cellString = cellIterator.next();
             int currentColumnIndex = columnIndex++;
-            if (includeColumnIndexes != null && !includeColumnIndexes.contains(currentColumnIndex)) {
-                continue;
+            int targetColumnIndex;
+
+            if (includeColumnIndexes == null) {
+                targetColumnIndex = currentColumnIndex;
+            } else {
+                targetColumnIndex = includeColumnIndexes.indexOf(currentColumnIndex);
+                if (targetColumnIndex < 0) {
+                    continue;
+                }
             }
+
             ReadCellData<String> readCellData = new ReadCellData<>();
             readCellData.setRowIndex(rowIndex);
-            readCellData.setColumnIndex(currentColumnIndex);
 
-            // csv is an empty string of whether <code>,,</code> is read or <code>,"",</code>
+            readCellData.setColumnIndex(targetColumnIndex);
+            
             if (StringUtils.isNotBlank(cellString)) {
                 readCellData.setType(CellDataTypeEnum.STRING);
                 if (autoStrip) {
@@ -247,7 +256,8 @@ public class CsvExcelReadExecutor implements ExcelReadExecutor {
             } else {
                 readCellData.setType(CellDataTypeEnum.EMPTY);
             }
-            cellMap.put(currentColumnIndex, readCellData);
+
+            cellMap.put(targetColumnIndex, readCellData);
         }
 
         RowTypeEnum rowType = MapUtils.isEmpty(cellMap) ? RowTypeEnum.EMPTY : RowTypeEnum.DATA;

--- a/fesod-sheet/src/main/java/org/apache/fesod/sheet/analysis/csv/CsvExcelReadExecutor.java
+++ b/fesod-sheet/src/main/java/org/apache/fesod/sheet/analysis/csv/CsvExcelReadExecutor.java
@@ -223,7 +223,7 @@ public class CsvExcelReadExecutor implements ExcelReadExecutor {
                 csvReadContext.csvReadWorkbookHolder().globalConfiguration().getAutoTrim();
         Boolean autoStrip =
                 csvReadContext.csvReadWorkbookHolder().globalConfiguration().getAutoStrip();
-        List<Integer> includeColumnIndexes = csvReadContext.readSheetHolder().getColumnIndexes();
+        List<Integer> includeColumnIndexes = csvReadContext.readSheetHolder().getReadSheet().getColumnIndexes();
         while (cellIterator.hasNext()) {
             String cellString = cellIterator.next();
             int currentColumnIndex = columnIndex++;

--- a/fesod-sheet/src/main/java/org/apache/fesod/sheet/analysis/csv/CsvExcelReadExecutor.java
+++ b/fesod-sheet/src/main/java/org/apache/fesod/sheet/analysis/csv/CsvExcelReadExecutor.java
@@ -223,7 +223,8 @@ public class CsvExcelReadExecutor implements ExcelReadExecutor {
                 csvReadContext.csvReadWorkbookHolder().globalConfiguration().getAutoTrim();
         Boolean autoStrip =
                 csvReadContext.csvReadWorkbookHolder().globalConfiguration().getAutoStrip();
-        List<Integer> includeColumnIndexes = csvReadContext.readSheetHolder().getReadSheet().getColumnIndexes();
+        List<Integer> includeColumnIndexes =
+                csvReadContext.readSheetHolder().getReadSheet().getColumnIndexes();
 
         while (cellIterator.hasNext()) {
             String cellString = cellIterator.next();
@@ -243,7 +244,7 @@ public class CsvExcelReadExecutor implements ExcelReadExecutor {
             readCellData.setRowIndex(rowIndex);
 
             readCellData.setColumnIndex(targetColumnIndex);
-            
+
             if (StringUtils.isNotBlank(cellString)) {
                 readCellData.setType(CellDataTypeEnum.STRING);
                 if (autoStrip) {

--- a/fesod-sheet/src/main/java/org/apache/fesod/sheet/read/builder/CsvReaderBuilder.java
+++ b/fesod-sheet/src/main/java/org/apache/fesod/sheet/read/builder/CsvReaderBuilder.java
@@ -118,6 +118,17 @@ public class CsvReaderBuilder extends AbstractExcelReaderParameterBuilder<CsvRea
     }
 
     /**
+     * Specific columns to read
+     *
+     * @param columnIndexes
+     * @return
+     */
+    public CsvReaderBuilder includeColumnIndexes(List<Integer> columnIndexes) {
+        readSheet.setColumnIndexes(columnIndexes);
+        return this;
+    }
+
+    /**
      * Sets the escape character.
      *
      * @param escape the Character used to escape special characters in values

--- a/fesod-sheet/src/test/java/org/apache/fesod/sheet/FesodSheetTest.java
+++ b/fesod-sheet/src/test/java/org/apache/fesod/sheet/FesodSheetTest.java
@@ -267,7 +267,7 @@ class FesodSheetTest {
         List<Map<Integer, String>> readResults = FesodSheet.read(csvFile)
                 .csv()
                 .sheet(0)
-                .includeColumnIndexes(Set.of(0, 2))
+                .includeColumnIndexes(targetColumns)
                 .doReadSync();
 
         Assertions.assertNotNull(readResults);

--- a/fesod-sheet/src/test/java/org/apache/fesod/sheet/FesodSheetTest.java
+++ b/fesod-sheet/src/test/java/org/apache/fesod/sheet/FesodSheetTest.java
@@ -258,7 +258,7 @@ class FesodSheetTest {
     @Test
     void testReadCsv_withColumnIndexes_shouldFilterColumns() throws Exception {
 
-        String csvContent = "1,Alice,30,Female\n2,Bob,25,Male";
+        String csvContent = "ID,Name,Age,Gender\n2,Bob,25,Male";
         File csvFile = tempDir.resolve("test_columns.csv").toFile();
         FileUtils.writeStringToFile(csvFile, csvContent, StandardCharsets.UTF_8);
 
@@ -266,17 +266,17 @@ class FesodSheetTest {
 
         List<Map<Integer, String>> readResults = FesodSheet.read(csvFile)
                 .csv()
-                .sheet(0)
                 .includeColumnIndexes(targetColumns)
                 .doReadSync();
 
         Assertions.assertNotNull(readResults);
-        Assertions.assertEquals(2, readResults.size());
+        Assertions.assertEquals(1, readResults.size());
 
         Map<Integer, String> row1 = readResults.get(0);
-        Assertions.assertEquals(2, row1.size(), "Should only contain the 2 filtered columns");
-        Assertions.assertEquals("1", row1.get(0));
-        Assertions.assertEquals("30", row1.get(1));
+        Assertions.assertEquals(
+                2, row1.size(), "Should only contain the 1 filtered columns (excepting the head by default)");
+        Assertions.assertEquals("2", row1.get(0));
+        Assertions.assertEquals("25", row1.get(1));
     }
 
     @Test

--- a/fesod-sheet/src/test/java/org/apache/fesod/sheet/FesodSheetTest.java
+++ b/fesod-sheet/src/test/java/org/apache/fesod/sheet/FesodSheetTest.java
@@ -23,7 +23,12 @@ import java.io.File;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.lang.reflect.Method;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import org.apache.commons.io.FileUtils;
 import org.apache.fesod.sheet.read.builder.ExcelReaderBuilder;
 import org.apache.fesod.sheet.read.builder.ExcelReaderSheetBuilder;
 import org.apache.fesod.sheet.read.listener.ReadListener;
@@ -246,5 +251,29 @@ class FesodSheetTest {
     void testReadSheet_withAllParams_shouldReturnBuilder() {
         ExcelReaderSheetBuilder builder = FesodSheet.readSheet(0, "DataSheet", 100);
         Assertions.assertNotNull(builder);
+    }
+
+    @Test
+    void testReadCsv_withColumnIndexes_shouldFilterColumns() throws Exception {
+
+        String csvContent = "1,Alice,30,Female\n2,Bob,25,Male";
+        File csvFile = tempDir.resolve("test_columns.csv").toFile();
+        FileUtils.writeStringToFile(csvFile, csvContent, StandardCharsets.UTF_8);
+
+        List<Integer> targetColumns = Arrays.asList(0, 2);
+
+        List<Map<Integer, String>> readResults = FesodSheet.read(csvFile)
+                .includeColumnIndexes(targetColumns)
+                .sheet(0)
+                .doReadSync();
+
+        Assertions.assertNotNull(readResults);
+        Assertions.assertEquals(2, readResults.size());
+
+        Map<Integer, String> row1 = readResults.get(0);
+        Assertions.assertEquals(2, row1.size(), "Should only contain the 2 filtered columns");
+        Assertions.assertEquals("1", row1.get(0));
+        Assertions.assertEquals("30", row1.get(2));
+        Assertions.assertNull(row1.get(1), "Column index 1 (Name) should be omitted");
     }
 }

--- a/fesod-sheet/src/test/java/org/apache/fesod/sheet/FesodSheetTest.java
+++ b/fesod-sheet/src/test/java/org/apache/fesod/sheet/FesodSheetTest.java
@@ -265,9 +265,9 @@ class FesodSheetTest {
         List<Integer> targetColumns = Arrays.asList(0, 2);
 
         List<Map<Integer, String>> readResults = FesodSheet.read(csvFile)
-                .includeColumnIndexes(targetColumns)
                 .csv()
                 .sheet(0)
+                .includeColumnIndexes(Set.of(0, 2))
                 .doReadSync();
 
         Assertions.assertNotNull(readResults);

--- a/fesod-sheet/src/test/java/org/apache/fesod/sheet/FesodSheetTest.java
+++ b/fesod-sheet/src/test/java/org/apache/fesod/sheet/FesodSheetTest.java
@@ -263,6 +263,7 @@ class FesodSheetTest {
         List<Integer> targetColumns = Arrays.asList(0, 2);
 
         List<Map<Integer, String>> readResults = FesodSheet.read(csvFile)
+                .csv()
                 .includeColumnIndexes(targetColumns)
                 .sheet(0)
                 .doReadSync();

--- a/fesod-sheet/src/test/java/org/apache/fesod/sheet/FesodSheetTest.java
+++ b/fesod-sheet/src/test/java/org/apache/fesod/sheet/FesodSheetTest.java
@@ -263,8 +263,8 @@ class FesodSheetTest {
         List<Integer> targetColumns = Arrays.asList(0, 2);
 
         List<Map<Integer, String>> readResults = FesodSheet.read(csvFile)
-                .csv()
                 .includeColumnIndexes(targetColumns)
+                .csv()
                 .sheet(0)
                 .doReadSync();
 

--- a/fesod-sheet/src/test/java/org/apache/fesod/sheet/FesodSheetTest.java
+++ b/fesod-sheet/src/test/java/org/apache/fesod/sheet/FesodSheetTest.java
@@ -25,8 +25,8 @@ import java.io.OutputStream;
 import java.lang.reflect.Method;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
-import java.util.Arrays;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import org.apache.commons.io.FileUtils;
@@ -276,10 +276,9 @@ class FesodSheetTest {
         Map<Integer, String> row1 = readResults.get(0);
         Assertions.assertEquals(2, row1.size(), "Should only contain the 2 filtered columns");
         Assertions.assertEquals("1", row1.get(0));
-        Assertions.assertEquals("30", row1.get(2));
-        Assertions.assertNull(row1.get(1), "Column index 1 (Name) should be omitted");
+        Assertions.assertEquals("30", row1.get(1));
     }
-  
+
     @Test
     void testReadSheet_withColumnIndexes_shouldConfigureAll() {
 


### PR DESCRIPTION
## Purpose of the pull request

Related: #950
Related: #942 (**XLSX Format Implementation**)

## What's changed?

- Added support for column-based reading (**CSV only**).

**Column filtering behavior: `CsvExcelReadExecutor#dealRecord`**

When `includeColumnIndexes != null`:

-  Only process target columns
-  Rewrite target columns’ internal indexes to consecutive (0-based)

When `includeColumnIndexes == null`:

-  Keep the original behavior

### API Usage Example

```java
// data for csv
NO,Name,Age,Password
1,Jackson,22,123456

List<Map<Integer, String>> results = FesodSheet.read(pathname)
		.csv()
		.includeColumnIndexes(Arrays.asList(1, 3))
		.doReadSync();

Map<Integer, String> data = results.get(0);

assertEquals(2, data.size());
assertEquals("Jackson", data.get(0));
assertEquals("123456", data.get(1));
```

## Checklist

- [x] I have read the [Contributor Guide](https://fesod.apache.org/community/contribution/).
- [x] I have written the necessary doc or comment.
- [x] I have added the necessary unit tests and all cases have passed.