### PR TITLE
fix: eliminate implicit numeric cast warning in date generation

### DIFF
--- a/fesod-examples/fesod-sheet-examples/src/main/java/org/apache/fesod/sheet/examples/util/ExampleDataGenerator.java
+++ b/fesod-examples/fesod-sheet-examples/src/main/java/org/apache/fesod/sheet/examples/util/ExampleDataGenerator.java
@@ -55,7 +55,7 @@ public class ExampleDataGenerator {
         List<Date> list = new ArrayList<>();
         long now = System.currentTimeMillis();
         for (int i = 0; i < count; i++) {
-            list.add(new Date(now + i * 1000 * 60 * 60 * 24));
+            list.add(new Date(now + (long) i * 1000 * 60 * 60 * 24));
         }
         return list;
     }


### PR DESCRIPTION
<!--
Thanks very much for contributing to Apache Fesod (Incubating)! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

Closed: #ISSUE
Related: #ISSUE

-->

## Purpose of the pull request

fix: eliminate implicit numeric cast warning in date generation

## What's changed?

cast int to long.

## Checklist

- [x] I have read the [Contributor Guide](https://fesod.apache.org/community/contribution/).
- [x] I have written the necessary doc or comment.
- [x] I have added the necessary unit tests and all cases have passed.
