### PR TITLE
refactor: generate trivial accessors with Lombok

### DIFF
--- a/fesod-sheet/src/main/java/org/apache/fesod/sheet/metadata/CellExtra.java
+++ b/fesod-sheet/src/main/java/org/apache/fesod/sheet/metadata/CellExtra.java
@@ -25,6 +25,8 @@
 
 package org.apache.fesod.sheet.metadata;
 
+import lombok.Getter;
+import lombok.Setter;
 import org.apache.fesod.sheet.constant.ExcelXmlConstants;
 import org.apache.fesod.sheet.enums.CellExtraTypeEnum;
 import org.apache.poi.ss.util.CellReference;
@@ -34,6 +36,8 @@ import org.apache.poi.ss.util.CellReference;
  *
  *
  */
+@Getter
+@Setter
 public class CellExtra extends AbstractCell {
     /**
      * Cell extra type
@@ -97,54 +101,6 @@ public class CellExtra extends AbstractCell {
         this.firstRowIndex = firstRowIndex;
         this.firstColumnIndex = firstColumnIndex;
         this.lastRowIndex = lastRowIndex;
-        this.lastColumnIndex = lastColumnIndex;
-    }
-
-    public CellExtraTypeEnum getType() {
-        return type;
-    }
-
-    public void setType(CellExtraTypeEnum type) {
-        this.type = type;
-    }
-
-    public String getText() {
-        return text;
-    }
-
-    public void setText(String text) {
-        this.text = text;
-    }
-
-    public Integer getFirstRowIndex() {
-        return firstRowIndex;
-    }
-
-    public void setFirstRowIndex(Integer firstRowIndex) {
-        this.firstRowIndex = firstRowIndex;
-    }
-
-    public Integer getFirstColumnIndex() {
-        return firstColumnIndex;
-    }
-
-    public void setFirstColumnIndex(Integer firstColumnIndex) {
-        this.firstColumnIndex = firstColumnIndex;
-    }
-
-    public Integer getLastRowIndex() {
-        return lastRowIndex;
-    }
-
-    public void setLastRowIndex(Integer lastRowIndex) {
-        this.lastRowIndex = lastRowIndex;
-    }
-
-    public Integer getLastColumnIndex() {
-        return lastColumnIndex;
-    }
-
-    public void setLastColumnIndex(Integer lastColumnIndex) {
         this.lastColumnIndex = lastColumnIndex;
     }
 }

--- a/fesod-sheet/src/main/java/org/apache/fesod/sheet/metadata/property/ColumnWidthProperty.java
+++ b/fesod-sheet/src/main/java/org/apache/fesod/sheet/metadata/property/ColumnWidthProperty.java
@@ -25,6 +25,8 @@
 
 package org.apache.fesod.sheet.metadata.property;
 
+import lombok.Getter;
+import lombok.Setter;
 import org.apache.fesod.sheet.annotation.write.style.ColumnWidth;
 
 /**
@@ -32,6 +34,8 @@ import org.apache.fesod.sheet.annotation.write.style.ColumnWidth;
  *
  *
  */
+@Getter
+@Setter
 public class ColumnWidthProperty {
     private Integer width;
 
@@ -44,13 +48,5 @@ public class ColumnWidthProperty {
             return null;
         }
         return new ColumnWidthProperty(columnWidth.value());
-    }
-
-    public Integer getWidth() {
-        return width;
-    }
-
-    public void setWidth(Integer width) {
-        this.width = width;
     }
 }

--- a/fesod-sheet/src/main/java/org/apache/fesod/sheet/metadata/property/LoopMergeProperty.java
+++ b/fesod-sheet/src/main/java/org/apache/fesod/sheet/metadata/property/LoopMergeProperty.java
@@ -25,6 +25,8 @@
 
 package org.apache.fesod.sheet.metadata.property;
 
+import lombok.Getter;
+import lombok.Setter;
 import org.apache.fesod.sheet.annotation.write.style.ContentLoopMerge;
 
 /**
@@ -32,6 +34,8 @@ import org.apache.fesod.sheet.annotation.write.style.ContentLoopMerge;
  *
  *
  */
+@Getter
+@Setter
 public class LoopMergeProperty {
     /**
      * Each row
@@ -52,21 +56,5 @@ public class LoopMergeProperty {
             return null;
         }
         return new LoopMergeProperty(contentLoopMerge.eachRow(), contentLoopMerge.columnExtend());
-    }
-
-    public int getEachRow() {
-        return eachRow;
-    }
-
-    public void setEachRow(int eachRow) {
-        this.eachRow = eachRow;
-    }
-
-    public int getColumnExtend() {
-        return columnExtend;
-    }
-
-    public void setColumnExtend(int columnExtend) {
-        this.columnExtend = columnExtend;
     }
 }

--- a/fesod-sheet/src/main/java/org/apache/fesod/sheet/metadata/property/NumberFormatProperty.java
+++ b/fesod-sheet/src/main/java/org/apache/fesod/sheet/metadata/property/NumberFormatProperty.java
@@ -26,6 +26,8 @@
 package org.apache.fesod.sheet.metadata.property;
 
 import java.math.RoundingMode;
+import lombok.Getter;
+import lombok.Setter;
 import org.apache.fesod.sheet.annotation.format.NumberFormat;
 
 /**
@@ -33,6 +35,8 @@ import org.apache.fesod.sheet.annotation.format.NumberFormat;
  *
  *
  */
+@Getter
+@Setter
 public class NumberFormatProperty {
     private String format;
     private RoundingMode roundingMode;
@@ -47,21 +51,5 @@ public class NumberFormatProperty {
             return null;
         }
         return new NumberFormatProperty(numberFormat.value(), numberFormat.roundingMode());
-    }
-
-    public String getFormat() {
-        return format;
-    }
-
-    public void setFormat(String format) {
-        this.format = format;
-    }
-
-    public RoundingMode getRoundingMode() {
-        return roundingMode;
-    }
-
-    public void setRoundingMode(RoundingMode roundingMode) {
-        this.roundingMode = roundingMode;
     }
 }

--- a/fesod-sheet/src/main/java/org/apache/fesod/sheet/metadata/property/OnceAbsoluteMergeProperty.java
+++ b/fesod-sheet/src/main/java/org/apache/fesod/sheet/metadata/property/OnceAbsoluteMergeProperty.java
@@ -25,6 +25,8 @@
 
 package org.apache.fesod.sheet.metadata.property;
 
+import lombok.Getter;
+import lombok.Setter;
 import org.apache.fesod.sheet.annotation.write.style.OnceAbsoluteMerge;
 
 /**
@@ -32,6 +34,8 @@ import org.apache.fesod.sheet.annotation.write.style.OnceAbsoluteMerge;
  *
  *
  */
+@Getter
+@Setter
 public class OnceAbsoluteMergeProperty {
     /**
      * First row
@@ -66,37 +70,5 @@ public class OnceAbsoluteMergeProperty {
                 onceAbsoluteMerge.lastRowIndex(),
                 onceAbsoluteMerge.firstColumnIndex(),
                 onceAbsoluteMerge.lastColumnIndex());
-    }
-
-    public int getFirstRowIndex() {
-        return firstRowIndex;
-    }
-
-    public void setFirstRowIndex(int firstRowIndex) {
-        this.firstRowIndex = firstRowIndex;
-    }
-
-    public int getLastRowIndex() {
-        return lastRowIndex;
-    }
-
-    public void setLastRowIndex(int lastRowIndex) {
-        this.lastRowIndex = lastRowIndex;
-    }
-
-    public int getFirstColumnIndex() {
-        return firstColumnIndex;
-    }
-
-    public void setFirstColumnIndex(int firstColumnIndex) {
-        this.firstColumnIndex = firstColumnIndex;
-    }
-
-    public int getLastColumnIndex() {
-        return lastColumnIndex;
-    }
-
-    public void setLastColumnIndex(int lastColumnIndex) {
-        this.lastColumnIndex = lastColumnIndex;
     }
 }

--- a/fesod-sheet/src/main/java/org/apache/fesod/sheet/metadata/property/RowHeightProperty.java
+++ b/fesod-sheet/src/main/java/org/apache/fesod/sheet/metadata/property/RowHeightProperty.java
@@ -25,6 +25,8 @@
 
 package org.apache.fesod.sheet.metadata.property;
 
+import lombok.Getter;
+import lombok.Setter;
 import org.apache.fesod.sheet.annotation.write.style.ContentRowHeight;
 import org.apache.fesod.sheet.annotation.write.style.HeadRowHeight;
 
@@ -33,6 +35,8 @@ import org.apache.fesod.sheet.annotation.write.style.HeadRowHeight;
  *
  *
  */
+@Getter
+@Setter
 public class RowHeightProperty {
     private Short height;
 
@@ -52,13 +56,5 @@ public class RowHeightProperty {
             return null;
         }
         return new RowHeightProperty(contentRowHeight.value());
-    }
-
-    public Short getHeight() {
-        return height;
-    }
-
-    public void setHeight(Short height) {
-        this.height = height;
     }
 }

--- a/fesod-sheet/src/main/java/org/apache/fesod/sheet/read/metadata/holder/ReadRowHolder.java
+++ b/fesod-sheet/src/main/java/org/apache/fesod/sheet/read/metadata/holder/ReadRowHolder.java
@@ -26,6 +26,8 @@
 package org.apache.fesod.sheet.read.metadata.holder;
 
 import java.util.Map;
+import lombok.Getter;
+import lombok.Setter;
 import org.apache.fesod.sheet.enums.HolderEnum;
 import org.apache.fesod.sheet.enums.RowTypeEnum;
 import org.apache.fesod.sheet.metadata.Cell;
@@ -37,6 +39,8 @@ import org.apache.fesod.sheet.metadata.Holder;
  *
  *
  */
+@Getter
+@Setter
 public class ReadRowHolder implements Holder {
     /**
      * Returns row index of a row in the sheet that contains this cell.Start form 0.
@@ -67,46 +71,6 @@ public class ReadRowHolder implements Holder {
         this.rowIndex = rowIndex;
         this.rowType = rowType;
         this.globalConfiguration = globalConfiguration;
-        this.cellMap = cellMap;
-    }
-
-    public GlobalConfiguration getGlobalConfiguration() {
-        return globalConfiguration;
-    }
-
-    public void setGlobalConfiguration(GlobalConfiguration globalConfiguration) {
-        this.globalConfiguration = globalConfiguration;
-    }
-
-    public Object getCurrentRowAnalysisResult() {
-        return currentRowAnalysisResult;
-    }
-
-    public void setCurrentRowAnalysisResult(Object currentRowAnalysisResult) {
-        this.currentRowAnalysisResult = currentRowAnalysisResult;
-    }
-
-    public Integer getRowIndex() {
-        return rowIndex;
-    }
-
-    public void setRowIndex(Integer rowIndex) {
-        this.rowIndex = rowIndex;
-    }
-
-    public RowTypeEnum getRowType() {
-        return rowType;
-    }
-
-    public void setRowType(RowTypeEnum rowType) {
-        this.rowType = rowType;
-    }
-
-    public Map<Integer, Cell> getCellMap() {
-        return cellMap;
-    }
-
-    public void setCellMap(Map<Integer, Cell> cellMap) {
         this.cellMap = cellMap;
     }
 

--- a/fesod-sheet/src/main/java/org/apache/fesod/sheet/write/metadata/fill/FillWrapper.java
+++ b/fesod-sheet/src/main/java/org/apache/fesod/sheet/write/metadata/fill/FillWrapper.java
@@ -26,12 +26,16 @@
 package org.apache.fesod.sheet.write.metadata.fill;
 
 import java.util.Collection;
+import lombok.Getter;
+import lombok.Setter;
 
 /**
  * Multiple lists are supported when packing
  *
  *
  **/
+@Getter
+@Setter
 public class FillWrapper {
     /**
      * The collection prefix that needs to be filled.
@@ -48,22 +52,6 @@ public class FillWrapper {
 
     public FillWrapper(String name, Collection collectionData) {
         this.name = name;
-        this.collectionData = collectionData;
-    }
-
-    public String getName() {
-        return name;
-    }
-
-    public void setName(String name) {
-        this.name = name;
-    }
-
-    public Collection getCollectionData() {
-        return collectionData;
-    }
-
-    public void setCollectionData(Collection collectionData) {
         this.collectionData = collectionData;
     }
 }


### PR DESCRIPTION
Closed: #994

## Purpose of the pull request

Remove hand-written boilerplate accessors in favour of Lombok

## What's changed?

Replaced hand-written trivial accessors with class-level `@Getter`/`@Setter` (+32 / −184):

- `metadata/CellExtra`
- `metadata/property/ColumnWidthProperty`
- `metadata/property/RowHeightProperty`
- `metadata/property/NumberFormatProperty`
- `metadata/property/LoopMergeProperty`
- `metadata/property/OnceAbsoluteMergeProperty`
- `read/metadata/holder/ReadRowHolder`
- `write/metadata/fill/FillWrapper`

## Checklist

- [x] I have read the [Contributor Guide](https://fesod.apache.org/community/contribution/).
- [x] I have written the necessary doc or comment.
- [x] I have added the necessary unit tests and all cases have passed.
