### PR TITLE
refactor: unify and overload readSheet methods for flexible usage

### DIFF
--- a/fesod-sheet/src/main/java/org/apache/fesod/sheet/FesodSheet.java
+++ b/fesod-sheet/src/main/java/org/apache/fesod/sheet/FesodSheet.java
@@ -314,7 +314,7 @@ public class FesodSheet {
      * @return Excel sheet reader builder.
      */
     public static ExcelReaderSheetBuilder readSheet(Integer sheetNo, String sheetName) {
-        return readSheet(sheetNo, sheetName, null);
+        return readSheet(sheetNo, sheetName, null, null);
     }
 
     /**
@@ -326,25 +326,36 @@ public class FesodSheet {
      * @return
      */
     public static ExcelReaderSheetBuilder readSheet(Integer sheetNo, String sheetName, Integer numRows) {
-        return new ExcelReaderSheetBuilder()
-                .sheetNoIfNotNull(sheetNo)
-                .sheetNameIfNotNull(sheetName)
-                .numRowsIfNotNull(numRows);
+        return readSheet(sheetNo, sheetName, numRows, null);
     }
 
     /**
      * Build excel the 'readSheet' targeting specific column indexes.
      *
      * @param sheetNo       Index of sheet, 0 base.
+     * @param sheetName     The name of sheet.
      * @param columnIndexes Specific columns to read (e.g., [0, 2] for Column A and C).
      * @return Excel sheet reader builder.
      */
-    public static ExcelReaderSheetBuilder readSheetWithColumns(
+    public static ExcelReaderSheetBuilder readSheet(Integer sheetNo, String sheetName, List<Integer> columnIndexes) {
+        return readSheet(sheetNo, sheetName, null, columnIndexes);
+    }
+
+    /**
+     * Build excel the 'ReadSheet'.
+     *
+     * @param sheetNo       Index of sheet, 0 base.
+     * @param sheetName     The name of sheet.
+     * @param numRows       The number of rows to read, the default is all, start with 0.
+     * @param columnIndexes Specific columns to read (e.g., [0, 2] for Column A and C).
+     * @return Excel sheet reader builder.
+     */
+    public static ExcelReaderSheetBuilder readSheet(
             Integer sheetNo, String sheetName, Integer numRows, List<Integer> columnIndexes) {
         return new ExcelReaderSheetBuilder()
                 .sheetNoIfNotNull(sheetNo)
                 .sheetNameIfNotNull(sheetName)
                 .numRowsIfNotNull(numRows)
-                .includeColumnIndexes(columnIndexes);
+                .includeColumnIndexesIfNotNull(columnIndexes);
     }
 }

--- a/fesod-sheet/src/test/java/org/apache/fesod/sheet/FesodSheetTest.java
+++ b/fesod-sheet/src/test/java/org/apache/fesod/sheet/FesodSheetTest.java
@@ -19,6 +19,18 @@
 
 package org.apache.fesod.sheet;
 
+import java.io.File;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.lang.reflect.Method;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
 import org.apache.commons.io.FileUtils;
 import org.apache.fesod.sheet.read.builder.ExcelReaderBuilder;
 import org.apache.fesod.sheet.read.builder.ExcelReaderSheetBuilder;
@@ -40,19 +52,6 @@ import org.junit.jupiter.api.io.TempDir;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.io.File;
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.lang.reflect.Method;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Path;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.Date;
-import java.util.List;
-import java.util.Map;
-
 @Tag(Tags.UNIT)
 @ExtendWith(MockitoExtension.class)
 @DisplayName("FesodSheet Unit Tests")
@@ -73,8 +72,7 @@ class FesodSheetTest {
     private File tempFile;
     private String tempFilePath;
 
-    private static class DemoData {
-    }
+    private static class DemoData {}
 
     private WriteWorkbook writeWorkbook(ExcelWriterBuilder builder) {
         try {

--- a/fesod-sheet/src/test/java/org/apache/fesod/sheet/FesodSheetTest.java
+++ b/fesod-sheet/src/test/java/org/apache/fesod/sheet/FesodSheetTest.java
@@ -297,7 +297,7 @@ class FesodSheetTest {
 
         List<Integer> targetColumns = Arrays.asList(0, 2);
 
-        ExcelReaderSheetBuilder builder = FesodSheet.readSheetWithColumns(0, "Sheet1", 100, targetColumns);
+        ExcelReaderSheetBuilder builder = FesodSheet.readSheet(0, "Sheet1", targetColumns);
         ReadSheet configuredSheet = builder.build();
         List<Map<Integer, String>> readResults = FesodSheet.read(tempFile)
                 .sheet(0)

--- a/fesod-sheet/src/test/java/org/apache/fesod/sheet/FesodSheetTest.java
+++ b/fesod-sheet/src/test/java/org/apache/fesod/sheet/FesodSheetTest.java
@@ -19,18 +19,6 @@
 
 package org.apache.fesod.sheet;
 
-import java.io.File;
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.lang.reflect.Method;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Path;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.Date;
-import java.util.List;
-import java.util.Map;
 import org.apache.commons.io.FileUtils;
 import org.apache.fesod.sheet.read.builder.ExcelReaderBuilder;
 import org.apache.fesod.sheet.read.builder.ExcelReaderSheetBuilder;
@@ -52,6 +40,19 @@ import org.junit.jupiter.api.io.TempDir;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.io.File;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.lang.reflect.Method;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+
 @Tag(Tags.UNIT)
 @ExtendWith(MockitoExtension.class)
 @DisplayName("FesodSheet Unit Tests")
@@ -72,7 +73,8 @@ class FesodSheetTest {
     private File tempFile;
     private String tempFilePath;
 
-    private static class DemoData {}
+    private static class DemoData {
+    }
 
     private WriteWorkbook writeWorkbook(ExcelWriterBuilder builder) {
         try {
@@ -297,7 +299,7 @@ class FesodSheetTest {
 
         List<Integer> targetColumns = Arrays.asList(0, 2);
 
-        ExcelReaderSheetBuilder builder = FesodSheet.readSheet(0, "Sheet1", targetColumns);
+        ExcelReaderSheetBuilder builder = FesodSheet.readSheet(0, "Sheet1", 100, targetColumns);
         ReadSheet configuredSheet = builder.build();
         List<Map<Integer, String>> readResults = FesodSheet.read(tempFile)
                 .sheet(0)

--- a/website/docs/sheet/read/sheet.md
+++ b/website/docs/sheet/read/sheet.md
@@ -120,6 +120,13 @@ String fileName = "path/to/demo.xls";
     // Specify 0-based column indices to include (e.g., Column A, C, E)
     List<Integer> includeColumnIndexes = Arrays.asList(0, 2, 4);
 
+    // Option 1
+    try (ExcelReader excelReader = FesodSheet.read(fileName, DemoData.class, new DemoDataListener()).build()) {
+        ReadSheet readSheet = FesodSheet.readSheet(0, "Sheet1", targetColumns).build();
+        excelReader.read(readSheet);
+    }
+
+    // Option 2
     try (ExcelReader excelReader = FesodSheet.read(fileName).build()) {
         ReadSheet readSheet = FesodSheet.readSheet(0)
                 .head(DemoData.class)

--- a/website/i18n/zh-cn/docusaurus-plugin-content-docs/current/sheet/read/sheet.md
+++ b/website/i18n/zh-cn/docusaurus-plugin-content-docs/current/sheet/read/sheet.md
@@ -99,6 +99,13 @@ public void readSpecificColumns() {
     // 指定需要读取的列索引（从 0 开始，例如 0, 2, 4 代表 A, C, E 列）
     List<Integer> includeColumnIndexes = Arrays.asList(0, 2, 4);
 
+    // 方案 1
+    try (ExcelReader excelReader = FesodSheet.read(fileName, DemoData.class, new DemoDataListener()).build()) {
+        ReadSheet readSheet = FesodSheet.readSheet(0, "Sheet1", targetColumns).build();
+        excelReader.read(readSheet);
+    }
+
+    // 方案 2
     try (ExcelReader excelReader = FesodSheet.read(fileName).build()) {
         ReadSheet readSheet = FesodSheet.readSheet(0)
                 .head(DemoData.class)


### PR DESCRIPTION
## Purpose of the pull request

As title.

## What's changed?

- Added overloaded `readSheet` methods in `FesodSheet.java` to allow specifying column indexes directly.
- Updated the test in `FesodSheetTest.java` to use the new overloaded `readSheet` method with column indexes.
- Updated thedocumentation in `website/docs/sheet/read/sheet.md`.

## Checklist

- [x] I have read the [Contributor Guide](https://fesod.apache.org/community/contribution/).
- [x] I have written the necessary doc or comment.
- [x] I have added the necessary unit tests and all cases have passed.
