### PR TITLE
Update dependabot configuration for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -35,9 +35,6 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-    ignore:
-      - dependency-name: "*"
-        update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
     labels:
       - "dependencies"
       - "github actions"


### PR DESCRIPTION
Removed ignore rules for major and minor updates in GitHub Actions.

It is against ASF recommendations to use old GitHub Actions. Supply Chain Attacks are a real issue.

I would question why you are blocking updates for other categories too and why you are not trying to get npm and jars up to date too. We have reached peak CVE with all the AI driven security alerts.