### PR TITLE
refactor: reuse Head#field in ModelBuildEventListener field-assignment fallback

### DIFF
--- a/fesod-sheet/src/main/java/org/apache/fesod/sheet/read/listener/ModelBuildEventListener.java
+++ b/fesod-sheet/src/main/java/org/apache/fesod/sheet/read/listener/ModelBuildEventListener.java
@@ -200,17 +200,22 @@ public class ModelBuildEventListener implements IgnoreExceptionReadListener<Map<
             if (value != null) {
                 dataMap.put(fieldName, value);
 
-                // 规避由于实体类 setter 不规范导致无法赋值的问题
+                // Avoid the problem where values cannot be assigned due to non-standard setters in entity classes
                 if (dataMap.get(fieldName) == null) {
-                    Object bean = dataMap.getBean();
                     try {
-                        Field field = bean.getClass().getDeclaredField(fieldName);
-                        field.setAccessible(true);
-                        field.set(bean, value);
-                    } catch (NoSuchFieldException ignore) {
-                        // ignore
+                        Field field = head.getField();
+                        if (!field.isAccessible()) {
+                            field.setAccessible(true);
+                        }
+                        field.set(dataMap.getBean(), value);
                     } catch (IllegalAccessException e) {
-                        throw new RuntimeException(e);
+                        throw new ExcelDataConvertException(
+                                context.readRowHolder().getRowIndex(),
+                                head.getColumnIndex(),
+                                cellData,
+                                null,
+                                "Cannot access field: " + fieldName,
+                                e);
                     }
                 }
             }

--- a/fesod-sheet/src/test/java/org/apache/fesod/sheet/read/listener/ModelBuildEventListenerTest.java
+++ b/fesod-sheet/src/test/java/org/apache/fesod/sheet/read/listener/ModelBuildEventListenerTest.java
@@ -24,6 +24,8 @@ import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.experimental.Accessors;
 import org.apache.fesod.sheet.annotation.ExcelProperty;
 import org.apache.fesod.sheet.testkit.Tags;
 import org.apache.fesod.sheet.testkit.base.AbstractExcelTest;
@@ -55,6 +57,28 @@ class ModelBuildEventListenerTest extends AbstractExcelTest {
     public static class PrivateGetterOnlyData {
         @ExcelProperty("name")
         private String name;
+    }
+
+    @Setter
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Accessors(chain = true)
+    public static class FluentSetterData {
+        @ExcelProperty("name")
+        private String name;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class NonStandardSetterData {
+        @ExcelProperty("name")
+        private String name;
+
+        public String setName(String name) {
+            return this.name = name;
+        }
     }
 
     @ParameterizedTest
@@ -89,6 +113,28 @@ class ModelBuildEventListenerTest extends AbstractExcelTest {
                 createTempFile(format),
                 PrivateGetterOnlyData.class,
                 Collections.singletonList(new PrivateGetterOnlyData("hello")));
+
+        Assertions.assertEquals("hello", result.get(0).getName());
+    }
+
+    @ParameterizedTest
+    @ExcelFormatSource
+    void shouldAssignFieldValueWhenSetterIsFluent(ExcelFormat format) throws Exception {
+        List<FluentSetterData> result = RoundTripHelper.writeAndRead(
+                createTempFile(format),
+                FluentSetterData.class,
+                Collections.singletonList(new FluentSetterData("hello")));
+
+        Assertions.assertEquals("hello", result.get(0).getName());
+    }
+
+    @ParameterizedTest
+    @ExcelFormatSource
+    void shouldAssignFieldValueWhenSetterIsNonStandard(ExcelFormat format) throws Exception {
+        List<NonStandardSetterData> result = RoundTripHelper.writeAndRead(
+                createTempFile(format),
+                NonStandardSetterData.class,
+                Collections.singletonList(new NonStandardSetterData("hello")));
 
         Assertions.assertEquals("hello", result.get(0).getName());
     }

--- a/fesod-sheet/src/test/java/org/apache/fesod/sheet/read/listener/ModelBuildEventListenerTest.java
+++ b/fesod-sheet/src/test/java/org/apache/fesod/sheet/read/listener/ModelBuildEventListenerTest.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.fesod.sheet.read.listener;
+
+import java.util.Collections;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.apache.fesod.sheet.annotation.ExcelProperty;
+import org.apache.fesod.sheet.testkit.Tags;
+import org.apache.fesod.sheet.testkit.base.AbstractExcelTest;
+import org.apache.fesod.sheet.testkit.enums.ExcelFormat;
+import org.apache.fesod.sheet.testkit.helpers.RoundTripHelper;
+import org.apache.fesod.sheet.testkit.params.ExcelFormatSource;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.params.ParameterizedTest;
+
+/**
+ * Tests the field-assignment fallback in {@link ModelBuildEventListener} for models whose mapped
+ * property has no standard JavaBeans setter.
+ */
+@Tag(Tags.ROUND_TRIP)
+class ModelBuildEventListenerTest extends AbstractExcelTest {
+
+    @Getter
+    public static class GetterOnlyData {
+        @ExcelProperty("name")
+        public String name;
+    }
+
+    public static class InheritedGetterOnlyData extends GetterOnlyData {}
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class PrivateGetterOnlyData {
+        @ExcelProperty("name")
+        private String name;
+    }
+
+    @ParameterizedTest
+    @ExcelFormatSource
+    void shouldAssignFieldValueDirectlyWhenSetterIsMissing(ExcelFormat format) throws Exception {
+        GetterOnlyData out = new GetterOnlyData();
+        out.name = "hello";
+        List<GetterOnlyData> result = RoundTripHelper.writeAndRead(
+                createTempFile(format), GetterOnlyData.class, Collections.singletonList(out));
+
+        Assertions.assertEquals("hello", result.get(0).getName());
+    }
+
+    @ParameterizedTest
+    @ExcelFormatSource
+    void shouldAssignInheritedFieldValueWhenSetterIsMissing(ExcelFormat format) throws Exception {
+        GetterOnlyData out = new GetterOnlyData();
+        out.name = "hello";
+        List<InheritedGetterOnlyData> result = RoundTripHelper.writeAndRead(
+                createTempFile(format),
+                GetterOnlyData.class,
+                Collections.singletonList(out),
+                InheritedGetterOnlyData.class);
+
+        Assertions.assertEquals("hello", result.get(0).getName());
+    }
+
+    @ParameterizedTest
+    @ExcelFormatSource
+    void shouldAssignPrivateFieldValueWhenSetterIsMissing(ExcelFormat format) throws Exception {
+        List<PrivateGetterOnlyData> result = RoundTripHelper.writeAndRead(
+                createTempFile(format),
+                PrivateGetterOnlyData.class,
+                Collections.singletonList(new PrivateGetterOnlyData("hello")));
+
+        Assertions.assertEquals("hello", result.get(0).getName());
+    }
+}


### PR DESCRIPTION


<!--
Thanks very much for contributing to Apache Fesod (Incubating)! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

Closed: #ISSUE
Related: #ISSUE

-->

## Purpose of the pull request

As title.

## What's changed?

- Replace the per-row `getDeclaredField(fieldName)` lookup with the `Field` already resolved on `Head`; the old lookup also missed superclass fields and silently dropped their values.
- Wrap `IllegalAccessException` in `ExcelDataConvertException` with row/column context instead of a bare `RuntimeException`.

## Checklist

- [x] I have read the [Contributor Guide](https://fesod.apache.org/community/contribution/).
- [x] I have written the necessary doc or comment.
- [x] I have added the necessary unit tests and all cases have passed.
