### PR TITLE
feat: add java.time.OffsetDateTime converters (#1017)

### DIFF
--- a/fesod-sheet/src/main/java/org/apache/fesod/sheet/converters/DefaultConverterLoader.java
+++ b/fesod-sheet/src/main/java/org/apache/fesod/sheet/converters/DefaultConverterLoader.java
@@ -70,6 +70,9 @@ import org.apache.fesod.sheet.converters.localtime.LocalTimeStringConverter;
 import org.apache.fesod.sheet.converters.longconverter.LongBooleanConverter;
 import org.apache.fesod.sheet.converters.longconverter.LongNumberConverter;
 import org.apache.fesod.sheet.converters.longconverter.LongStringConverter;
+import org.apache.fesod.sheet.converters.offsetdatetime.OffsetDateTimeDateConverter;
+import org.apache.fesod.sheet.converters.offsetdatetime.OffsetDateTimeNumberConverter;
+import org.apache.fesod.sheet.converters.offsetdatetime.OffsetDateTimeStringConverter;
 import org.apache.fesod.sheet.converters.shortconverter.ShortBooleanConverter;
 import org.apache.fesod.sheet.converters.shortconverter.ShortNumberConverter;
 import org.apache.fesod.sheet.converters.shortconverter.ShortStringConverter;
@@ -122,6 +125,8 @@ public class DefaultConverterLoader {
 
         putAllConverter(new LocalTimeNumberConverter());
         putAllConverter(new LocalTimeStringConverter());
+        putAllConverter(new OffsetDateTimeNumberConverter());
+        putAllConverter(new OffsetDateTimeStringConverter());
 
         putAllConverter(new DoubleBooleanConverter());
         putAllConverter(new DoubleNumberConverter());
@@ -160,6 +165,7 @@ public class DefaultConverterLoader {
         putWriteConverter(new LocalDateTimeDateConverter());
         putWriteConverter(new LocalDateDateConverter());
         putWriteConverter(new LocalTimeDateConverter());
+        putWriteConverter(new OffsetDateTimeDateConverter());
         putWriteConverter(new DoubleNumberConverter());
         putWriteConverter(new FloatNumberConverter());
         putWriteConverter(new IntegerNumberConverter());
@@ -181,6 +187,7 @@ public class DefaultConverterLoader {
         putWriteStringConverter(new LocalDateStringConverter());
         putWriteStringConverter(new LocalDateTimeStringConverter());
         putWriteStringConverter(new LocalTimeStringConverter());
+        putWriteStringConverter(new OffsetDateTimeStringConverter());
         putWriteStringConverter(new DoubleStringConverter());
         putWriteStringConverter(new FloatStringConverter());
         putWriteStringConverter(new IntegerStringConverter());

--- a/fesod-sheet/src/main/java/org/apache/fesod/sheet/converters/offsetdatetime/OffsetDateTimeDateConverter.java
+++ b/fesod-sheet/src/main/java/org/apache/fesod/sheet/converters/offsetdatetime/OffsetDateTimeDateConverter.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*
+ * This file is part of the Apache Fesod (Incubating) project, which was derived from Alibaba EasyExcel.
+ *
+ * Copyright (C) 2018-2024 Alibaba Group Holding Ltd.
+ */
+
+package org.apache.fesod.sheet.converters.offsetdatetime;
+
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import org.apache.fesod.sheet.converters.Converter;
+import org.apache.fesod.sheet.metadata.GlobalConfiguration;
+import org.apache.fesod.sheet.metadata.data.WriteCellData;
+import org.apache.fesod.sheet.metadata.property.ExcelContentProperty;
+import org.apache.fesod.sheet.util.DateUtils;
+import org.apache.fesod.sheet.util.WorkBookUtil;
+
+/** OffsetDateTime and date converter. */
+public class OffsetDateTimeDateConverter implements Converter<OffsetDateTime> {
+    @Override
+    public Class<?> supportJavaTypeKey() {
+        return OffsetDateTime.class;
+    }
+
+    @Override
+    public WriteCellData<?> convertToExcelData(
+            OffsetDateTime value, ExcelContentProperty contentProperty, GlobalConfiguration globalConfiguration)
+            throws Exception {
+        LocalDateTime localDateTime = value.toLocalDateTime();
+        WriteCellData<?> cellData = new WriteCellData<>(localDateTime);
+        String format = null;
+        if (contentProperty != null && contentProperty.getDateTimeFormatProperty() != null) {
+            format = contentProperty.getDateTimeFormatProperty().getFormat();
+        }
+        WorkBookUtil.fillDataFormat(cellData, format, DateUtils.defaultDateFormat);
+        return cellData;
+    }
+}

--- a/fesod-sheet/src/main/java/org/apache/fesod/sheet/converters/offsetdatetime/OffsetDateTimeDateConverter.java
+++ b/fesod-sheet/src/main/java/org/apache/fesod/sheet/converters/offsetdatetime/OffsetDateTimeDateConverter.java
@@ -27,6 +27,7 @@ package org.apache.fesod.sheet.converters.offsetdatetime;
 
 import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
+import org.apache.fesod.common.util.StringUtils;
 import org.apache.fesod.sheet.converters.Converter;
 import org.apache.fesod.sheet.metadata.GlobalConfiguration;
 import org.apache.fesod.sheet.metadata.data.WriteCellData;
@@ -50,6 +51,9 @@ public class OffsetDateTimeDateConverter implements Converter<OffsetDateTime> {
         String format = null;
         if (contentProperty != null && contentProperty.getDateTimeFormatProperty() != null) {
             format = contentProperty.getDateTimeFormatProperty().getFormat();
+            if (StringUtils.isEmpty(format)) {
+                format = null;
+            }
         }
         WorkBookUtil.fillDataFormat(cellData, format, DateUtils.defaultDateFormat);
         return cellData;

--- a/fesod-sheet/src/main/java/org/apache/fesod/sheet/converters/offsetdatetime/OffsetDateTimeDateConverter.java
+++ b/fesod-sheet/src/main/java/org/apache/fesod/sheet/converters/offsetdatetime/OffsetDateTimeDateConverter.java
@@ -17,12 +17,6 @@
  * under the License.
  */
 
-/*
- * This file is part of the Apache Fesod (Incubating) project, which was derived from Alibaba EasyExcel.
- *
- * Copyright (C) 2018-2024 Alibaba Group Holding Ltd.
- */
-
 package org.apache.fesod.sheet.converters.offsetdatetime;
 
 import java.time.LocalDateTime;

--- a/fesod-sheet/src/main/java/org/apache/fesod/sheet/converters/offsetdatetime/OffsetDateTimeNumberConverter.java
+++ b/fesod-sheet/src/main/java/org/apache/fesod/sheet/converters/offsetdatetime/OffsetDateTimeNumberConverter.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*
+ * This file is part of the Apache Fesod (Incubating) project, which was derived from Alibaba EasyExcel.
+ *
+ * Copyright (C) 2018-2024 Alibaba Group Holding Ltd.
+ */
+
+package org.apache.fesod.sheet.converters.offsetdatetime;
+
+import java.math.BigDecimal;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import org.apache.fesod.sheet.converters.Converter;
+import org.apache.fesod.sheet.enums.CellDataTypeEnum;
+import org.apache.fesod.sheet.metadata.GlobalConfiguration;
+import org.apache.fesod.sheet.metadata.data.ReadCellData;
+import org.apache.fesod.sheet.metadata.data.WriteCellData;
+import org.apache.fesod.sheet.metadata.property.ExcelContentProperty;
+import org.apache.fesod.sheet.util.DateUtils;
+import org.apache.poi.ss.usermodel.DateUtil;
+
+/** OffsetDateTime and number converter. */
+public class OffsetDateTimeNumberConverter implements Converter<OffsetDateTime> {
+    @Override
+    public Class<?> supportJavaTypeKey() {
+        return OffsetDateTime.class;
+    }
+
+    @Override
+    public CellDataTypeEnum supportExcelTypeKey() {
+        return CellDataTypeEnum.NUMBER;
+    }
+
+    @Override
+    public OffsetDateTime convertToJavaData(
+            ReadCellData<?> cellData, ExcelContentProperty contentProperty, GlobalConfiguration globalConfiguration) {
+        boolean use1904windowing = globalConfiguration.getUse1904windowing();
+        if (contentProperty != null && contentProperty.getDateTimeFormatProperty() != null) {
+            use1904windowing = contentProperty.getDateTimeFormatProperty().getUse1904windowing();
+        }
+        return DateUtils.getLocalDateTime(cellData.getNumberValue().doubleValue(), use1904windowing)
+                .atZone(ZoneId.systemDefault())
+                .toOffsetDateTime();
+    }
+
+    @Override
+    public WriteCellData<?> convertToExcelData(
+            OffsetDateTime value, ExcelContentProperty contentProperty, GlobalConfiguration globalConfiguration) {
+        boolean use1904windowing = globalConfiguration.getUse1904windowing();
+        if (contentProperty != null && contentProperty.getDateTimeFormatProperty() != null) {
+            use1904windowing = contentProperty.getDateTimeFormatProperty().getUse1904windowing();
+        }
+        return new WriteCellData<>(
+                BigDecimal.valueOf(DateUtil.getExcelDate(value.toLocalDateTime(), use1904windowing)));
+    }
+}

--- a/fesod-sheet/src/main/java/org/apache/fesod/sheet/converters/offsetdatetime/OffsetDateTimeNumberConverter.java
+++ b/fesod-sheet/src/main/java/org/apache/fesod/sheet/converters/offsetdatetime/OffsetDateTimeNumberConverter.java
@@ -77,6 +77,7 @@ public class OffsetDateTimeNumberConverter implements Converter<OffsetDateTime> 
                 return propertyUse1904windowing;
             }
         }
-        return globalConfiguration.getUse1904windowing();
+        Boolean globalUse1904windowing = globalConfiguration.getUse1904windowing();
+        return globalUse1904windowing != null && globalUse1904windowing;
     }
 }

--- a/fesod-sheet/src/main/java/org/apache/fesod/sheet/converters/offsetdatetime/OffsetDateTimeNumberConverter.java
+++ b/fesod-sheet/src/main/java/org/apache/fesod/sheet/converters/offsetdatetime/OffsetDateTimeNumberConverter.java
@@ -26,6 +26,7 @@
 package org.apache.fesod.sheet.converters.offsetdatetime;
 
 import java.math.BigDecimal;
+import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneId;
 import org.apache.fesod.sheet.converters.Converter;
@@ -52,23 +53,30 @@ public class OffsetDateTimeNumberConverter implements Converter<OffsetDateTime> 
     @Override
     public OffsetDateTime convertToJavaData(
             ReadCellData<?> cellData, ExcelContentProperty contentProperty, GlobalConfiguration globalConfiguration) {
-        boolean use1904windowing = globalConfiguration.getUse1904windowing();
-        if (contentProperty != null && contentProperty.getDateTimeFormatProperty() != null) {
-            use1904windowing = contentProperty.getDateTimeFormatProperty().getUse1904windowing();
+        LocalDateTime localDateTime = DateUtils.getLocalDateTime(
+                cellData.getNumberValue().doubleValue(), resolveUse1904windowing(contentProperty, globalConfiguration));
+        if (localDateTime == null) {
+            return null;
         }
-        return DateUtils.getLocalDateTime(cellData.getNumberValue().doubleValue(), use1904windowing)
-                .atZone(ZoneId.systemDefault())
-                .toOffsetDateTime();
+        return localDateTime.atZone(ZoneId.systemDefault()).toOffsetDateTime();
     }
 
     @Override
     public WriteCellData<?> convertToExcelData(
             OffsetDateTime value, ExcelContentProperty contentProperty, GlobalConfiguration globalConfiguration) {
-        boolean use1904windowing = globalConfiguration.getUse1904windowing();
+        return new WriteCellData<>(BigDecimal.valueOf(DateUtil.getExcelDate(
+                value.toLocalDateTime(), resolveUse1904windowing(contentProperty, globalConfiguration))));
+    }
+
+    private boolean resolveUse1904windowing(
+            ExcelContentProperty contentProperty, GlobalConfiguration globalConfiguration) {
         if (contentProperty != null && contentProperty.getDateTimeFormatProperty() != null) {
-            use1904windowing = contentProperty.getDateTimeFormatProperty().getUse1904windowing();
+            Boolean propertyUse1904windowing =
+                    contentProperty.getDateTimeFormatProperty().getUse1904windowing();
+            if (propertyUse1904windowing != null) {
+                return propertyUse1904windowing;
+            }
         }
-        return new WriteCellData<>(
-                BigDecimal.valueOf(DateUtil.getExcelDate(value.toLocalDateTime(), use1904windowing)));
+        return globalConfiguration.getUse1904windowing();
     }
 }

--- a/fesod-sheet/src/main/java/org/apache/fesod/sheet/converters/offsetdatetime/OffsetDateTimeNumberConverter.java
+++ b/fesod-sheet/src/main/java/org/apache/fesod/sheet/converters/offsetdatetime/OffsetDateTimeNumberConverter.java
@@ -17,12 +17,6 @@
  * under the License.
  */
 
-/*
- * This file is part of the Apache Fesod (Incubating) project, which was derived from Alibaba EasyExcel.
- *
- * Copyright (C) 2018-2024 Alibaba Group Holding Ltd.
- */
-
 package org.apache.fesod.sheet.converters.offsetdatetime;
 
 import java.math.BigDecimal;

--- a/fesod-sheet/src/main/java/org/apache/fesod/sheet/converters/offsetdatetime/OffsetDateTimeNumberConverter.java
+++ b/fesod-sheet/src/main/java/org/apache/fesod/sheet/converters/offsetdatetime/OffsetDateTimeNumberConverter.java
@@ -48,7 +48,7 @@ public class OffsetDateTimeNumberConverter implements Converter<OffsetDateTime> 
     public OffsetDateTime convertToJavaData(
             ReadCellData<?> cellData, ExcelContentProperty contentProperty, GlobalConfiguration globalConfiguration) {
         LocalDateTime localDateTime = DateUtils.getLocalDateTime(
-                cellData.getNumberValue().doubleValue(), resolveUse1904windowing(contentProperty, globalConfiguration));
+                cellData.getNumberValue().doubleValue(), DateUtils.isDate1904(contentProperty, globalConfiguration));
         if (localDateTime == null) {
             return null;
         }
@@ -59,19 +59,6 @@ public class OffsetDateTimeNumberConverter implements Converter<OffsetDateTime> 
     public WriteCellData<?> convertToExcelData(
             OffsetDateTime value, ExcelContentProperty contentProperty, GlobalConfiguration globalConfiguration) {
         return new WriteCellData<>(BigDecimal.valueOf(DateUtil.getExcelDate(
-                value.toLocalDateTime(), resolveUse1904windowing(contentProperty, globalConfiguration))));
-    }
-
-    private boolean resolveUse1904windowing(
-            ExcelContentProperty contentProperty, GlobalConfiguration globalConfiguration) {
-        if (contentProperty != null && contentProperty.getDateTimeFormatProperty() != null) {
-            Boolean propertyUse1904windowing =
-                    contentProperty.getDateTimeFormatProperty().getUse1904windowing();
-            if (propertyUse1904windowing != null) {
-                return propertyUse1904windowing;
-            }
-        }
-        Boolean globalUse1904windowing = globalConfiguration.getUse1904windowing();
-        return globalUse1904windowing != null && globalUse1904windowing;
+                value.toLocalDateTime(), DateUtils.isDate1904(contentProperty, globalConfiguration))));
     }
 }

--- a/fesod-sheet/src/main/java/org/apache/fesod/sheet/converters/offsetdatetime/OffsetDateTimeStringConverter.java
+++ b/fesod-sheet/src/main/java/org/apache/fesod/sheet/converters/offsetdatetime/OffsetDateTimeStringConverter.java
@@ -31,6 +31,8 @@ import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 import java.util.Locale;
+import java.util.Map;
+import org.apache.fesod.common.util.MapUtils;
 import org.apache.fesod.common.util.StringUtils;
 import org.apache.fesod.sheet.converters.Converter;
 import org.apache.fesod.sheet.enums.CellDataTypeEnum;
@@ -42,6 +44,12 @@ import org.apache.fesod.sheet.util.DateUtils;
 
 /** OffsetDateTime and string converter. */
 public class OffsetDateTimeStringConverter implements Converter<OffsetDateTime> {
+    /**
+     * Thread-local cache of {@link DateTimeFormatter} instances, keyed by pattern and locale, so
+     * the per-cell hot path does not rebuild formatters for every conversion.
+     */
+    private static final ThreadLocal<Map<String, DateTimeFormatter>> FORMATTER_CACHE = new ThreadLocal<>();
+
     @Override
     public Class<?> supportJavaTypeKey() {
         return OffsetDateTime.class;
@@ -97,6 +105,14 @@ public class OffsetDateTimeStringConverter implements Converter<OffsetDateTime> 
         if (StringUtils.isEmpty(format)) {
             return DateTimeFormatter.ISO_OFFSET_DATE_TIME;
         }
-        return DateTimeFormatter.ofPattern(format, locale);
+        final String pattern = format;
+        final Locale actualLocale = locale;
+        Map<String, DateTimeFormatter> cache = FORMATTER_CACHE.get();
+        if (cache == null) {
+            cache = MapUtils.newHashMap();
+            FORMATTER_CACHE.set(cache);
+        }
+        return cache.computeIfAbsent(
+                pattern + '\0' + actualLocale, key -> DateTimeFormatter.ofPattern(pattern, actualLocale));
     }
 }

--- a/fesod-sheet/src/main/java/org/apache/fesod/sheet/converters/offsetdatetime/OffsetDateTimeStringConverter.java
+++ b/fesod-sheet/src/main/java/org/apache/fesod/sheet/converters/offsetdatetime/OffsetDateTimeStringConverter.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*
+ * This file is part of the Apache Fesod (Incubating) project, which was derived from Alibaba EasyExcel.
+ *
+ * Copyright (C) 2018-2024 Alibaba Group Holding Ltd.
+ */
+
+package org.apache.fesod.sheet.converters.offsetdatetime;
+
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import java.util.Locale;
+import org.apache.fesod.common.util.StringUtils;
+import org.apache.fesod.sheet.converters.Converter;
+import org.apache.fesod.sheet.enums.CellDataTypeEnum;
+import org.apache.fesod.sheet.metadata.GlobalConfiguration;
+import org.apache.fesod.sheet.metadata.data.ReadCellData;
+import org.apache.fesod.sheet.metadata.data.WriteCellData;
+import org.apache.fesod.sheet.metadata.property.ExcelContentProperty;
+
+/** OffsetDateTime and string converter. */
+public class OffsetDateTimeStringConverter implements Converter<OffsetDateTime> {
+    @Override
+    public Class<?> supportJavaTypeKey() {
+        return OffsetDateTime.class;
+    }
+
+    @Override
+    public CellDataTypeEnum supportExcelTypeKey() {
+        return CellDataTypeEnum.STRING;
+    }
+
+    @Override
+    public OffsetDateTime convertToJavaData(
+            ReadCellData<?> cellData, ExcelContentProperty contentProperty, GlobalConfiguration globalConfiguration) {
+        DateTimeFormatter formatter = formatter(contentProperty, globalConfiguration.getLocale());
+        String stringValue = cellData.getStringValue();
+        try {
+            return OffsetDateTime.parse(stringValue, formatter);
+        } catch (DateTimeParseException e) {
+            LocalDateTime localDateTime;
+            try {
+                localDateTime = LocalDateTime.parse(stringValue, formatter);
+            } catch (DateTimeParseException inner) {
+                localDateTime = LocalDateTime.parse(stringValue, DateTimeFormatter.ISO_LOCAL_DATE_TIME);
+            }
+            return localDateTime.atZone(ZoneId.systemDefault()).toOffsetDateTime();
+        }
+    }
+
+    @Override
+    public WriteCellData<?> convertToExcelData(
+            OffsetDateTime value, ExcelContentProperty contentProperty, GlobalConfiguration globalConfiguration) {
+        return new WriteCellData<>(value.format(formatter(contentProperty, globalConfiguration.getLocale())));
+    }
+
+    private DateTimeFormatter formatter(ExcelContentProperty contentProperty, Locale locale) {
+        if (contentProperty == null
+                || contentProperty.getDateTimeFormatProperty() == null
+                || StringUtils.isEmpty(
+                        contentProperty.getDateTimeFormatProperty().getFormat())) {
+            return DateTimeFormatter.ISO_OFFSET_DATE_TIME;
+        }
+        return DateTimeFormatter.ofPattern(
+                contentProperty.getDateTimeFormatProperty().getFormat(), locale);
+    }
+}

--- a/fesod-sheet/src/main/java/org/apache/fesod/sheet/converters/offsetdatetime/OffsetDateTimeStringConverter.java
+++ b/fesod-sheet/src/main/java/org/apache/fesod/sheet/converters/offsetdatetime/OffsetDateTimeStringConverter.java
@@ -38,6 +38,7 @@ import org.apache.fesod.sheet.metadata.GlobalConfiguration;
 import org.apache.fesod.sheet.metadata.data.ReadCellData;
 import org.apache.fesod.sheet.metadata.data.WriteCellData;
 import org.apache.fesod.sheet.metadata.property.ExcelContentProperty;
+import org.apache.fesod.sheet.util.DateUtils;
 
 /** OffsetDateTime and string converter. */
 public class OffsetDateTimeStringConverter implements Converter<OffsetDateTime> {
@@ -54,18 +55,24 @@ public class OffsetDateTimeStringConverter implements Converter<OffsetDateTime> 
     @Override
     public OffsetDateTime convertToJavaData(
             ReadCellData<?> cellData, ExcelContentProperty contentProperty, GlobalConfiguration globalConfiguration) {
-        DateTimeFormatter formatter = formatter(contentProperty, globalConfiguration.getLocale());
         String stringValue = cellData.getStringValue();
+        String format = format(contentProperty);
+        DateTimeFormatter formatter = formatter(contentProperty, globalConfiguration.getLocale());
         try {
             return OffsetDateTime.parse(stringValue, formatter);
         } catch (DateTimeParseException e) {
-            LocalDateTime localDateTime;
             try {
-                localDateTime = LocalDateTime.parse(stringValue, formatter);
-            } catch (DateTimeParseException inner) {
-                localDateTime = LocalDateTime.parse(stringValue, DateTimeFormatter.ISO_LOCAL_DATE_TIME);
+                return DateUtils.parseLocalDateTime(stringValue, format, globalConfiguration.getLocale())
+                        .atZone(ZoneId.systemDefault())
+                        .toOffsetDateTime();
+            } catch (RuntimeException inner) {
+                if (StringUtils.isEmpty(format)) {
+                    return LocalDateTime.parse(stringValue, DateTimeFormatter.ISO_LOCAL_DATE_TIME)
+                            .atZone(ZoneId.systemDefault())
+                            .toOffsetDateTime();
+                }
+                throw inner;
             }
-            return localDateTime.atZone(ZoneId.systemDefault()).toOffsetDateTime();
         }
     }
 
@@ -75,14 +82,21 @@ public class OffsetDateTimeStringConverter implements Converter<OffsetDateTime> 
         return new WriteCellData<>(value.format(formatter(contentProperty, globalConfiguration.getLocale())));
     }
 
+    private String format(ExcelContentProperty contentProperty) {
+        if (contentProperty == null || contentProperty.getDateTimeFormatProperty() == null) {
+            return null;
+        }
+        return contentProperty.getDateTimeFormatProperty().getFormat();
+    }
+
     private DateTimeFormatter formatter(ExcelContentProperty contentProperty, Locale locale) {
-        if (contentProperty == null
-                || contentProperty.getDateTimeFormatProperty() == null
-                || StringUtils.isEmpty(
-                        contentProperty.getDateTimeFormatProperty().getFormat())) {
+        if (locale == null) {
+            locale = Locale.getDefault();
+        }
+        String format = format(contentProperty);
+        if (StringUtils.isEmpty(format)) {
             return DateTimeFormatter.ISO_OFFSET_DATE_TIME;
         }
-        return DateTimeFormatter.ofPattern(
-                contentProperty.getDateTimeFormatProperty().getFormat(), locale);
+        return DateTimeFormatter.ofPattern(format, locale);
     }
 }

--- a/fesod-sheet/src/main/java/org/apache/fesod/sheet/converters/offsetdatetime/OffsetDateTimeStringConverter.java
+++ b/fesod-sheet/src/main/java/org/apache/fesod/sheet/converters/offsetdatetime/OffsetDateTimeStringConverter.java
@@ -17,12 +17,6 @@
  * under the License.
  */
 
-/*
- * This file is part of the Apache Fesod (Incubating) project, which was derived from Alibaba EasyExcel.
- *
- * Copyright (C) 2018-2024 Alibaba Group Holding Ltd.
- */
-
 package org.apache.fesod.sheet.converters.offsetdatetime;
 
 import java.time.LocalDateTime;

--- a/fesod-sheet/src/main/java/org/apache/fesod/sheet/converters/offsetdatetime/OffsetDateTimeStringConverter.java
+++ b/fesod-sheet/src/main/java/org/apache/fesod/sheet/converters/offsetdatetime/OffsetDateTimeStringConverter.java
@@ -19,15 +19,7 @@
 
 package org.apache.fesod.sheet.converters.offsetdatetime;
 
-import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
-import java.time.ZoneId;
-import java.time.format.DateTimeFormatter;
-import java.time.format.DateTimeParseException;
-import java.util.Locale;
-import java.util.Map;
-import org.apache.fesod.common.util.MapUtils;
-import org.apache.fesod.common.util.StringUtils;
 import org.apache.fesod.sheet.converters.Converter;
 import org.apache.fesod.sheet.enums.CellDataTypeEnum;
 import org.apache.fesod.sheet.metadata.GlobalConfiguration;
@@ -38,12 +30,6 @@ import org.apache.fesod.sheet.util.DateUtils;
 
 /** OffsetDateTime and string converter. */
 public class OffsetDateTimeStringConverter implements Converter<OffsetDateTime> {
-    /**
-     * Thread-local cache of {@link DateTimeFormatter} instances, keyed by pattern and locale, so
-     * the per-cell hot path does not rebuild formatters for every conversion.
-     */
-    private static final ThreadLocal<Map<String, DateTimeFormatter>> FORMATTER_CACHE = new ThreadLocal<>();
-
     @Override
     public Class<?> supportJavaTypeKey() {
         return OffsetDateTime.class;
@@ -57,31 +43,14 @@ public class OffsetDateTimeStringConverter implements Converter<OffsetDateTime> 
     @Override
     public OffsetDateTime convertToJavaData(
             ReadCellData<?> cellData, ExcelContentProperty contentProperty, GlobalConfiguration globalConfiguration) {
-        String stringValue = cellData.getStringValue();
-        String format = format(contentProperty);
-        DateTimeFormatter formatter = formatter(contentProperty, globalConfiguration.getLocale());
-        try {
-            return OffsetDateTime.parse(stringValue, formatter);
-        } catch (DateTimeParseException e) {
-            try {
-                return DateUtils.parseLocalDateTime(stringValue, format, globalConfiguration.getLocale())
-                        .atZone(ZoneId.systemDefault())
-                        .toOffsetDateTime();
-            } catch (RuntimeException inner) {
-                if (StringUtils.isEmpty(format)) {
-                    return LocalDateTime.parse(stringValue, DateTimeFormatter.ISO_LOCAL_DATE_TIME)
-                            .atZone(ZoneId.systemDefault())
-                            .toOffsetDateTime();
-                }
-                throw inner;
-            }
-        }
+        return DateUtils.parseOffsetDateTime(
+                cellData.getStringValue(), format(contentProperty), globalConfiguration.getLocale());
     }
 
     @Override
     public WriteCellData<?> convertToExcelData(
             OffsetDateTime value, ExcelContentProperty contentProperty, GlobalConfiguration globalConfiguration) {
-        return new WriteCellData<>(value.format(formatter(contentProperty, globalConfiguration.getLocale())));
+        return new WriteCellData<>(DateUtils.format(value, format(contentProperty), globalConfiguration.getLocale()));
     }
 
     private String format(ExcelContentProperty contentProperty) {
@@ -89,24 +58,5 @@ public class OffsetDateTimeStringConverter implements Converter<OffsetDateTime> 
             return null;
         }
         return contentProperty.getDateTimeFormatProperty().getFormat();
-    }
-
-    private DateTimeFormatter formatter(ExcelContentProperty contentProperty, Locale locale) {
-        if (locale == null) {
-            locale = Locale.getDefault();
-        }
-        String format = format(contentProperty);
-        if (StringUtils.isEmpty(format)) {
-            return DateTimeFormatter.ISO_OFFSET_DATE_TIME;
-        }
-        final String pattern = format;
-        final Locale actualLocale = locale;
-        Map<String, DateTimeFormatter> cache = FORMATTER_CACHE.get();
-        if (cache == null) {
-            cache = MapUtils.newHashMap();
-            FORMATTER_CACHE.set(cache);
-        }
-        return cache.computeIfAbsent(
-                pattern + '\0' + actualLocale, key -> DateTimeFormatter.ofPattern(pattern, actualLocale));
     }
 }

--- a/fesod-sheet/src/main/java/org/apache/fesod/sheet/util/DateUtils.java
+++ b/fesod-sheet/src/main/java/org/apache/fesod/sheet/util/DateUtils.java
@@ -32,6 +32,7 @@ import java.text.SimpleDateFormat;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.time.OffsetDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Calendar;
 import java.util.Date;
@@ -162,6 +163,21 @@ public class DateUtils {
             timeFormat = switchTimeFormat(timeString);
         }
         return LocalTime.parse(timeString, getCacheDateTimeFormat(timeFormat, local));
+    }
+
+    /**
+     * convert string to date, requiring the string to carry an explicit offset
+     *
+     * @param dateString date string, e.g. 2020-01-02T03:04:05+08:00
+     * @param dateFormat date format, empty means ISO_OFFSET_DATE_TIME
+     * @param local local
+     * @return
+     */
+    public static OffsetDateTime parseOffsetDateTime(String dateString, String dateFormat, Locale local) {
+        if (StringUtils.isEmpty(dateFormat)) {
+            return OffsetDateTime.parse(dateString, DateTimeFormatter.ISO_OFFSET_DATE_TIME);
+        }
+        return OffsetDateTime.parse(dateString, getCacheDateTimeFormat(dateFormat, local));
     }
 
     /**
@@ -326,6 +342,24 @@ public class DateUtils {
             timeFormat = DEFAULT_LOCAL_TIME_FORMAT;
         }
         return time.format(getCacheDateTimeFormat(timeFormat, local));
+    }
+
+    /**
+     * Format date, preserving the offset in the output
+     *
+     * @param date date
+     * @param dateFormat date format, empty means ISO_OFFSET_DATE_TIME
+     * @param local local
+     * @return format string
+     */
+    public static String format(OffsetDateTime date, String dateFormat, Locale local) {
+        if (date == null) {
+            return null;
+        }
+        if (StringUtils.isEmpty(dateFormat)) {
+            return date.format(DateTimeFormatter.ISO_OFFSET_DATE_TIME);
+        }
+        return date.format(getCacheDateTimeFormat(dateFormat, local));
     }
 
     /**

--- a/fesod-sheet/src/test/java/org/apache/fesod/sheet/converter/OffsetDateTimeConverterTest.java
+++ b/fesod-sheet/src/test/java/org/apache/fesod/sheet/converter/OffsetDateTimeConverterTest.java
@@ -1,0 +1,140 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*
+ * This file is part of the Apache Fesod (Incubating) project, which was derived from Alibaba EasyExcel.
+ *
+ * Copyright (C) 2018-2024 Alibaba Group Holding Ltd.
+ */
+
+package org.apache.fesod.sheet.converter;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import org.apache.fesod.sheet.converters.ConverterKeyBuild;
+import org.apache.fesod.sheet.converters.DefaultConverterLoader;
+import org.apache.fesod.sheet.converters.offsetdatetime.OffsetDateTimeDateConverter;
+import org.apache.fesod.sheet.converters.offsetdatetime.OffsetDateTimeNumberConverter;
+import org.apache.fesod.sheet.converters.offsetdatetime.OffsetDateTimeStringConverter;
+import org.apache.fesod.sheet.enums.CellDataTypeEnum;
+import org.apache.fesod.sheet.metadata.GlobalConfiguration;
+import org.apache.fesod.sheet.metadata.data.ReadCellData;
+import org.apache.fesod.sheet.metadata.data.WriteCellData;
+import org.apache.fesod.sheet.metadata.property.DateTimeFormatProperty;
+import org.apache.fesod.sheet.metadata.property.ExcelContentProperty;
+import org.apache.fesod.sheet.testkit.Tags;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+@Tag(Tags.UNIT)
+class OffsetDateTimeConverterTest {
+    private static final OffsetDateTime VALUE = OffsetDateTime.of(2020, 1, 2, 3, 4, 5, 0, ZoneOffset.ofHours(8));
+
+    @Test
+    void dateConverterDropsOffsetWhilePreservingLocalDateTime() throws Exception {
+        WriteCellData<?> result =
+                new OffsetDateTimeDateConverter().convertToExcelData(VALUE, null, new GlobalConfiguration());
+        assertEquals(CellDataTypeEnum.DATE, result.getType());
+        assertEquals(VALUE.toLocalDateTime(), result.getDateValue());
+    }
+
+    @Test
+    void numberConverterDropsOffsetWhilePreservingLocalDateTime() {
+        OffsetDateTimeNumberConverter converter = new OffsetDateTimeNumberConverter();
+        GlobalConfiguration globalConfiguration = new GlobalConfiguration();
+        WriteCellData<?> written = converter.convertToExcelData(VALUE, null, globalConfiguration);
+        OffsetDateTime read =
+                converter.convertToJavaData(new ReadCellData<>(written.getNumberValue()), null, globalConfiguration);
+        assertEquals(VALUE.toLocalDateTime().atZone(ZoneId.systemDefault()).toOffsetDateTime(), read);
+    }
+
+    @Test
+    void stringConverterPreservesOffsetInIsoText() throws Exception {
+        OffsetDateTimeStringConverter converter = new OffsetDateTimeStringConverter();
+        GlobalConfiguration globalConfiguration = new GlobalConfiguration();
+        WriteCellData<?> written = converter.convertToExcelData(VALUE, null, globalConfiguration);
+        assertEquals(
+                VALUE,
+                converter.convertToJavaData(new ReadCellData<>(written.getStringValue()), null, globalConfiguration));
+    }
+
+    @Test
+    void stringConverterUsesConfiguredPattern() throws Exception {
+        OffsetDateTimeStringConverter converter = new OffsetDateTimeStringConverter();
+        ExcelContentProperty property = new ExcelContentProperty();
+        property.setDateTimeFormatProperty(new DateTimeFormatProperty("yyyy-MM-dd HH:mm:ss Z", false));
+        GlobalConfiguration globalConfiguration = new GlobalConfiguration();
+        assertEquals(
+                "2020-01-02 03:04:05 +0800",
+                converter
+                        .convertToExcelData(VALUE, property, globalConfiguration)
+                        .getStringValue());
+    }
+
+    @Test
+    void stringConverterFallsBackToLocalDateTimeWhenOffsetIsMissing() throws Exception {
+        OffsetDateTimeStringConverter converter = new OffsetDateTimeStringConverter();
+        GlobalConfiguration globalConfiguration = new GlobalConfiguration();
+        ReadCellData<String> cellData = new ReadCellData<>("2020-01-02T03:04:05");
+        assertEquals(
+                VALUE.toLocalDateTime().atZone(ZoneId.systemDefault()).toOffsetDateTime(),
+                converter.convertToJavaData(cellData, null, globalConfiguration));
+    }
+
+    @Test
+    void stringConverterWithEmptyOrNullPatternFallsBackToIso() throws Exception {
+        OffsetDateTimeStringConverter converter = new OffsetDateTimeStringConverter();
+        GlobalConfiguration globalConfiguration = new GlobalConfiguration();
+
+        ExcelContentProperty emptyProperty = new ExcelContentProperty();
+        emptyProperty.setDateTimeFormatProperty(new DateTimeFormatProperty("", false));
+        WriteCellData<?> writtenEmpty = converter.convertToExcelData(VALUE, emptyProperty, globalConfiguration);
+        assertEquals(
+                VALUE,
+                converter.convertToJavaData(
+                        new ReadCellData<>(writtenEmpty.getStringValue()), emptyProperty, globalConfiguration));
+
+        ExcelContentProperty nullFormatProperty = new ExcelContentProperty();
+        nullFormatProperty.setDateTimeFormatProperty(new DateTimeFormatProperty(null, false));
+        WriteCellData<?> writtenNullFormat =
+                converter.convertToExcelData(VALUE, nullFormatProperty, globalConfiguration);
+        assertEquals(
+                VALUE,
+                converter.convertToJavaData(
+                        new ReadCellData<>(writtenNullFormat.getStringValue()),
+                        nullFormatProperty,
+                        globalConfiguration));
+    }
+
+    @Test
+    void convertersAreRegisteredForSupportedDirections() {
+        assertEquals(
+                OffsetDateTimeDateConverter.class,
+                DefaultConverterLoader.loadDefaultWriteConverter()
+                        .get(ConverterKeyBuild.buildKey(OffsetDateTime.class))
+                        .getClass());
+        assertEquals(
+                2,
+                DefaultConverterLoader.loadAllConverter().entrySet().stream()
+                        .filter(entry -> entry.getKey().getClazz() == OffsetDateTime.class)
+                        .count());
+    }
+}

--- a/fesod-sheet/src/test/java/org/apache/fesod/sheet/converter/OffsetDateTimeConverterTest.java
+++ b/fesod-sheet/src/test/java/org/apache/fesod/sheet/converter/OffsetDateTimeConverterTest.java
@@ -46,6 +46,7 @@ import org.apache.fesod.sheet.metadata.data.WriteCellData;
 import org.apache.fesod.sheet.metadata.property.DateTimeFormatProperty;
 import org.apache.fesod.sheet.metadata.property.ExcelContentProperty;
 import org.apache.fesod.sheet.testkit.Tags;
+import org.apache.fesod.sheet.util.DateUtils;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
@@ -145,6 +146,17 @@ class OffsetDateTimeConverterTest {
         OffsetDateTimeNumberConverter converter = new OffsetDateTimeNumberConverter();
         GlobalConfiguration globalConfiguration = new GlobalConfiguration();
         assertNull(converter.convertToJavaData(new ReadCellData<>(BigDecimal.valueOf(-1)), null, globalConfiguration));
+    }
+
+    @Test
+    void dateConverterFallsBackToDefaultFormatForEmptyDateTimeFormat() throws Exception {
+        OffsetDateTimeDateConverter converter = new OffsetDateTimeDateConverter();
+        ExcelContentProperty property = new ExcelContentProperty();
+        property.setDateTimeFormatProperty(new DateTimeFormatProperty("", false));
+        WriteCellData<?> result = converter.convertToExcelData(VALUE, property, new GlobalConfiguration());
+        assertEquals(
+                DateUtils.defaultDateFormat,
+                result.getWriteCellStyle().getDataFormatData().getFormat());
     }
 
     @Test

--- a/fesod-sheet/src/test/java/org/apache/fesod/sheet/converter/OffsetDateTimeConverterTest.java
+++ b/fesod-sheet/src/test/java/org/apache/fesod/sheet/converter/OffsetDateTimeConverterTest.java
@@ -26,6 +26,8 @@
 package org.apache.fesod.sheet.converter;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import java.math.BigDecimal;
 import java.time.OffsetDateTime;
@@ -142,9 +144,16 @@ class OffsetDateTimeConverterTest {
     void numberConverterReturnsNullForInvalidExcelDate() {
         OffsetDateTimeNumberConverter converter = new OffsetDateTimeNumberConverter();
         GlobalConfiguration globalConfiguration = new GlobalConfiguration();
-        assertEquals(
-                null,
-                converter.convertToJavaData(new ReadCellData<>(BigDecimal.valueOf(-1)), null, globalConfiguration));
+        assertNull(converter.convertToJavaData(new ReadCellData<>(BigDecimal.valueOf(-1)), null, globalConfiguration));
+    }
+
+    @Test
+    void numberConverterDefaultsNullUse1904windowingToFalse() {
+        OffsetDateTimeNumberConverter converter = new OffsetDateTimeNumberConverter();
+        GlobalConfiguration globalConfiguration = new GlobalConfiguration();
+        globalConfiguration.setUse1904windowing(null);
+        WriteCellData<?> written = converter.convertToExcelData(VALUE, null, globalConfiguration);
+        assertNotNull(written.getNumberValue());
     }
 
     @Test

--- a/fesod-sheet/src/test/java/org/apache/fesod/sheet/converter/OffsetDateTimeConverterTest.java
+++ b/fesod-sheet/src/test/java/org/apache/fesod/sheet/converter/OffsetDateTimeConverterTest.java
@@ -26,9 +26,12 @@
 package org.apache.fesod.sheet.converter;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import java.math.BigDecimal;
 import java.time.OffsetDateTime;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
+import java.time.format.DateTimeParseException;
 import org.apache.fesod.sheet.converters.ConverterKeyBuild;
 import org.apache.fesod.sheet.converters.DefaultConverterLoader;
 import org.apache.fesod.sheet.converters.offsetdatetime.OffsetDateTimeDateConverter;
@@ -97,6 +100,51 @@ class OffsetDateTimeConverterTest {
         assertEquals(
                 VALUE.toLocalDateTime().atZone(ZoneId.systemDefault()).toOffsetDateTime(),
                 converter.convertToJavaData(cellData, null, globalConfiguration));
+    }
+
+    @Test
+    void stringConverterParsesDefaultSpaceSeparatedFormat() throws Exception {
+        OffsetDateTimeStringConverter converter = new OffsetDateTimeStringConverter();
+        GlobalConfiguration globalConfiguration = new GlobalConfiguration();
+        ReadCellData<String> cellData = new ReadCellData<>("2020-01-02 03:04:05");
+        assertEquals(
+                VALUE.toLocalDateTime().atZone(ZoneId.systemDefault()).toOffsetDateTime(),
+                converter.convertToJavaData(cellData, null, globalConfiguration));
+    }
+
+    @Test
+    void stringConverterRejectsTextNotMatchingConfiguredPattern() {
+        OffsetDateTimeStringConverter converter = new OffsetDateTimeStringConverter();
+        ExcelContentProperty property = new ExcelContentProperty();
+        property.setDateTimeFormatProperty(new DateTimeFormatProperty("yyyy/MM/dd HH:mm:ss", false));
+        GlobalConfiguration globalConfiguration = new GlobalConfiguration();
+        ReadCellData<String> cellData = new ReadCellData<>("2020-01-02T03:04:05");
+        assertThrows(
+                DateTimeParseException.class,
+                () -> converter.convertToJavaData(cellData, property, globalConfiguration));
+    }
+
+    @Test
+    void stringConverterUsesDefaultLocaleWhenLocaleIsNull() throws Exception {
+        OffsetDateTimeStringConverter converter = new OffsetDateTimeStringConverter();
+        ExcelContentProperty property = new ExcelContentProperty();
+        property.setDateTimeFormatProperty(new DateTimeFormatProperty("yyyy-MM-dd HH:mm:ss Z", false));
+        GlobalConfiguration globalConfiguration = new GlobalConfiguration();
+        globalConfiguration.setLocale(null);
+        assertEquals(
+                "2020-01-02 03:04:05 +0800",
+                converter
+                        .convertToExcelData(VALUE, property, globalConfiguration)
+                        .getStringValue());
+    }
+
+    @Test
+    void numberConverterReturnsNullForInvalidExcelDate() {
+        OffsetDateTimeNumberConverter converter = new OffsetDateTimeNumberConverter();
+        GlobalConfiguration globalConfiguration = new GlobalConfiguration();
+        assertEquals(
+                null,
+                converter.convertToJavaData(new ReadCellData<>(BigDecimal.valueOf(-1)), null, globalConfiguration));
     }
 
     @Test

--- a/fesod-sheet/src/test/java/org/apache/fesod/sheet/converter/OffsetDateTimeConverterTest.java
+++ b/fesod-sheet/src/test/java/org/apache/fesod/sheet/converter/OffsetDateTimeConverterTest.java
@@ -88,35 +88,39 @@ class OffsetDateTimeConverterTest {
     }
 
     @Test
-    void stringConverterFallsBackToLocalDateTimeWhenOffsetIsMissing() throws Exception {
+    void stringConverterRejectsTextWithoutOffset() {
         OffsetDateTimeStringConverter converter = new OffsetDateTimeStringConverter();
         GlobalConfiguration globalConfiguration = new GlobalConfiguration();
-        ReadCellData<String> cellData = new ReadCellData<>("2020-01-02T03:04:05");
-        Assertions.assertEquals(
-                VALUE.toLocalDateTime().atZone(ZoneId.systemDefault()).toOffsetDateTime(),
-                converter.convertToJavaData(cellData, null, globalConfiguration));
-    }
-
-    @Test
-    void stringConverterParsesDefaultSpaceSeparatedFormat() throws Exception {
-        OffsetDateTimeStringConverter converter = new OffsetDateTimeStringConverter();
-        GlobalConfiguration globalConfiguration = new GlobalConfiguration();
-        ReadCellData<String> cellData = new ReadCellData<>("2020-01-02 03:04:05");
-        Assertions.assertEquals(
-                VALUE.toLocalDateTime().atZone(ZoneId.systemDefault()).toOffsetDateTime(),
-                converter.convertToJavaData(cellData, null, globalConfiguration));
+        Assertions.assertThrows(
+                DateTimeParseException.class,
+                () -> converter.convertToJavaData(
+                        new ReadCellData<>("2020-01-02T03:04:05"), null, globalConfiguration));
+        Assertions.assertThrows(
+                DateTimeParseException.class,
+                () -> converter.convertToJavaData(
+                        new ReadCellData<>("2020-01-02 03:04:05"), null, globalConfiguration));
     }
 
     @Test
     void stringConverterRejectsTextNotMatchingConfiguredPattern() {
         OffsetDateTimeStringConverter converter = new OffsetDateTimeStringConverter();
         ExcelContentProperty property = new ExcelContentProperty();
-        property.setDateTimeFormatProperty(new DateTimeFormatProperty("yyyy/MM/dd HH:mm:ss", false));
+        property.setDateTimeFormatProperty(new DateTimeFormatProperty("yyyy/MM/dd HH:mm:ss XXX", false));
         GlobalConfiguration globalConfiguration = new GlobalConfiguration();
         ReadCellData<String> cellData = new ReadCellData<>("2020-01-02T03:04:05");
         Assertions.assertThrows(
                 DateTimeParseException.class,
                 () -> converter.convertToJavaData(cellData, property, globalConfiguration));
+    }
+
+    @Test
+    void stringConverterReadsBackConfiguredPatternWithOffset() {
+        OffsetDateTimeStringConverter converter = new OffsetDateTimeStringConverter();
+        ExcelContentProperty property = new ExcelContentProperty();
+        property.setDateTimeFormatProperty(new DateTimeFormatProperty("yyyy-MM-dd HH:mm:ss Z", false));
+        GlobalConfiguration globalConfiguration = new GlobalConfiguration();
+        ReadCellData<String> cellData = new ReadCellData<>("2020-01-02 03:04:05 +0800");
+        Assertions.assertEquals(VALUE, converter.convertToJavaData(cellData, property, globalConfiguration));
     }
 
     @Test

--- a/fesod-sheet/src/test/java/org/apache/fesod/sheet/converter/OffsetDateTimeConverterTest.java
+++ b/fesod-sheet/src/test/java/org/apache/fesod/sheet/converter/OffsetDateTimeConverterTest.java
@@ -24,6 +24,7 @@ import java.time.OffsetDateTime;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeParseException;
+import java.util.Locale;
 import org.apache.fesod.sheet.converters.ConverterKeyBuild;
 import org.apache.fesod.sheet.converters.DefaultConverterLoader;
 import org.apache.fesod.sheet.converters.offsetdatetime.OffsetDateTimeDateConverter;
@@ -37,6 +38,7 @@ import org.apache.fesod.sheet.metadata.property.DateTimeFormatProperty;
 import org.apache.fesod.sheet.metadata.property.ExcelContentProperty;
 import org.apache.fesod.sheet.testkit.Tags;
 import org.apache.fesod.sheet.util.DateUtils;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -44,6 +46,11 @@ import org.junit.jupiter.api.Test;
 @Tag(Tags.UNIT)
 class OffsetDateTimeConverterTest {
     private static final OffsetDateTime VALUE = OffsetDateTime.of(2020, 1, 2, 3, 4, 5, 0, ZoneOffset.ofHours(8));
+
+    @AfterEach
+    void tearDown() {
+        DateUtils.removeThreadLocalCache();
+    }
 
     @Test
     void dateConverterDropsOffsetWhilePreservingLocalDateTime() throws Exception {
@@ -135,6 +142,21 @@ class OffsetDateTimeConverterTest {
                 converter
                         .convertToExcelData(VALUE, property, globalConfiguration)
                         .getStringValue());
+    }
+
+    @Test
+    void stringConverterHonoursConfiguredLocale() throws Exception {
+        OffsetDateTimeStringConverter converter = new OffsetDateTimeStringConverter();
+        ExcelContentProperty property = new ExcelContentProperty();
+        property.setDateTimeFormatProperty(new DateTimeFormatProperty("dd MMMM yyyy HH:mm:ss XXX", false));
+        GlobalConfiguration globalConfiguration = new GlobalConfiguration();
+        globalConfiguration.setLocale(Locale.GERMAN);
+        WriteCellData<?> written = converter.convertToExcelData(VALUE, property, globalConfiguration);
+        Assertions.assertEquals("02 Januar 2020 03:04:05 +08:00", written.getStringValue());
+        Assertions.assertEquals(
+                VALUE,
+                converter.convertToJavaData(
+                        new ReadCellData<>(written.getStringValue()), property, globalConfiguration));
     }
 
     @Test

--- a/fesod-sheet/src/test/java/org/apache/fesod/sheet/converter/OffsetDateTimeConverterTest.java
+++ b/fesod-sheet/src/test/java/org/apache/fesod/sheet/converter/OffsetDateTimeConverterTest.java
@@ -19,10 +19,6 @@
 
 package org.apache.fesod.sheet.converter;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import java.math.BigDecimal;
 import java.time.OffsetDateTime;
 import java.time.ZoneId;
@@ -41,6 +37,7 @@ import org.apache.fesod.sheet.metadata.property.DateTimeFormatProperty;
 import org.apache.fesod.sheet.metadata.property.ExcelContentProperty;
 import org.apache.fesod.sheet.testkit.Tags;
 import org.apache.fesod.sheet.util.DateUtils;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
@@ -52,8 +49,8 @@ class OffsetDateTimeConverterTest {
     void dateConverterDropsOffsetWhilePreservingLocalDateTime() throws Exception {
         WriteCellData<?> result =
                 new OffsetDateTimeDateConverter().convertToExcelData(VALUE, null, new GlobalConfiguration());
-        assertEquals(CellDataTypeEnum.DATE, result.getType());
-        assertEquals(VALUE.toLocalDateTime(), result.getDateValue());
+        Assertions.assertEquals(CellDataTypeEnum.DATE, result.getType());
+        Assertions.assertEquals(VALUE.toLocalDateTime(), result.getDateValue());
     }
 
     @Test
@@ -63,7 +60,8 @@ class OffsetDateTimeConverterTest {
         WriteCellData<?> written = converter.convertToExcelData(VALUE, null, globalConfiguration);
         OffsetDateTime read =
                 converter.convertToJavaData(new ReadCellData<>(written.getNumberValue()), null, globalConfiguration);
-        assertEquals(VALUE.toLocalDateTime().atZone(ZoneId.systemDefault()).toOffsetDateTime(), read);
+        Assertions.assertEquals(
+                VALUE.toLocalDateTime().atZone(ZoneId.systemDefault()).toOffsetDateTime(), read);
     }
 
     @Test
@@ -71,7 +69,7 @@ class OffsetDateTimeConverterTest {
         OffsetDateTimeStringConverter converter = new OffsetDateTimeStringConverter();
         GlobalConfiguration globalConfiguration = new GlobalConfiguration();
         WriteCellData<?> written = converter.convertToExcelData(VALUE, null, globalConfiguration);
-        assertEquals(
+        Assertions.assertEquals(
                 VALUE,
                 converter.convertToJavaData(new ReadCellData<>(written.getStringValue()), null, globalConfiguration));
     }
@@ -82,7 +80,7 @@ class OffsetDateTimeConverterTest {
         ExcelContentProperty property = new ExcelContentProperty();
         property.setDateTimeFormatProperty(new DateTimeFormatProperty("yyyy-MM-dd HH:mm:ss Z", false));
         GlobalConfiguration globalConfiguration = new GlobalConfiguration();
-        assertEquals(
+        Assertions.assertEquals(
                 "2020-01-02 03:04:05 +0800",
                 converter
                         .convertToExcelData(VALUE, property, globalConfiguration)
@@ -94,7 +92,7 @@ class OffsetDateTimeConverterTest {
         OffsetDateTimeStringConverter converter = new OffsetDateTimeStringConverter();
         GlobalConfiguration globalConfiguration = new GlobalConfiguration();
         ReadCellData<String> cellData = new ReadCellData<>("2020-01-02T03:04:05");
-        assertEquals(
+        Assertions.assertEquals(
                 VALUE.toLocalDateTime().atZone(ZoneId.systemDefault()).toOffsetDateTime(),
                 converter.convertToJavaData(cellData, null, globalConfiguration));
     }
@@ -104,7 +102,7 @@ class OffsetDateTimeConverterTest {
         OffsetDateTimeStringConverter converter = new OffsetDateTimeStringConverter();
         GlobalConfiguration globalConfiguration = new GlobalConfiguration();
         ReadCellData<String> cellData = new ReadCellData<>("2020-01-02 03:04:05");
-        assertEquals(
+        Assertions.assertEquals(
                 VALUE.toLocalDateTime().atZone(ZoneId.systemDefault()).toOffsetDateTime(),
                 converter.convertToJavaData(cellData, null, globalConfiguration));
     }
@@ -116,7 +114,7 @@ class OffsetDateTimeConverterTest {
         property.setDateTimeFormatProperty(new DateTimeFormatProperty("yyyy/MM/dd HH:mm:ss", false));
         GlobalConfiguration globalConfiguration = new GlobalConfiguration();
         ReadCellData<String> cellData = new ReadCellData<>("2020-01-02T03:04:05");
-        assertThrows(
+        Assertions.assertThrows(
                 DateTimeParseException.class,
                 () -> converter.convertToJavaData(cellData, property, globalConfiguration));
     }
@@ -128,7 +126,7 @@ class OffsetDateTimeConverterTest {
         property.setDateTimeFormatProperty(new DateTimeFormatProperty("yyyy-MM-dd HH:mm:ss Z", false));
         GlobalConfiguration globalConfiguration = new GlobalConfiguration();
         globalConfiguration.setLocale(null);
-        assertEquals(
+        Assertions.assertEquals(
                 "2020-01-02 03:04:05 +0800",
                 converter
                         .convertToExcelData(VALUE, property, globalConfiguration)
@@ -139,7 +137,8 @@ class OffsetDateTimeConverterTest {
     void numberConverterReturnsNullForInvalidExcelDate() {
         OffsetDateTimeNumberConverter converter = new OffsetDateTimeNumberConverter();
         GlobalConfiguration globalConfiguration = new GlobalConfiguration();
-        assertNull(converter.convertToJavaData(new ReadCellData<>(BigDecimal.valueOf(-1)), null, globalConfiguration));
+        Assertions.assertNull(
+                converter.convertToJavaData(new ReadCellData<>(BigDecimal.valueOf(-1)), null, globalConfiguration));
     }
 
     @Test
@@ -148,7 +147,7 @@ class OffsetDateTimeConverterTest {
         ExcelContentProperty property = new ExcelContentProperty();
         property.setDateTimeFormatProperty(new DateTimeFormatProperty("", false));
         WriteCellData<?> result = converter.convertToExcelData(VALUE, property, new GlobalConfiguration());
-        assertEquals(
+        Assertions.assertEquals(
                 DateUtils.defaultDateFormat,
                 result.getWriteCellStyle().getDataFormatData().getFormat());
     }
@@ -159,7 +158,7 @@ class OffsetDateTimeConverterTest {
         GlobalConfiguration globalConfiguration = new GlobalConfiguration();
         globalConfiguration.setUse1904windowing(null);
         WriteCellData<?> written = converter.convertToExcelData(VALUE, null, globalConfiguration);
-        assertNotNull(written.getNumberValue());
+        Assertions.assertNotNull(written.getNumberValue());
     }
 
     @Test
@@ -170,7 +169,7 @@ class OffsetDateTimeConverterTest {
         ExcelContentProperty emptyProperty = new ExcelContentProperty();
         emptyProperty.setDateTimeFormatProperty(new DateTimeFormatProperty("", false));
         WriteCellData<?> writtenEmpty = converter.convertToExcelData(VALUE, emptyProperty, globalConfiguration);
-        assertEquals(
+        Assertions.assertEquals(
                 VALUE,
                 converter.convertToJavaData(
                         new ReadCellData<>(writtenEmpty.getStringValue()), emptyProperty, globalConfiguration));
@@ -179,7 +178,7 @@ class OffsetDateTimeConverterTest {
         nullFormatProperty.setDateTimeFormatProperty(new DateTimeFormatProperty(null, false));
         WriteCellData<?> writtenNullFormat =
                 converter.convertToExcelData(VALUE, nullFormatProperty, globalConfiguration);
-        assertEquals(
+        Assertions.assertEquals(
                 VALUE,
                 converter.convertToJavaData(
                         new ReadCellData<>(writtenNullFormat.getStringValue()),
@@ -189,12 +188,12 @@ class OffsetDateTimeConverterTest {
 
     @Test
     void convertersAreRegisteredForSupportedDirections() {
-        assertEquals(
+        Assertions.assertEquals(
                 OffsetDateTimeDateConverter.class,
                 DefaultConverterLoader.loadDefaultWriteConverter()
                         .get(ConverterKeyBuild.buildKey(OffsetDateTime.class))
                         .getClass());
-        assertEquals(
+        Assertions.assertEquals(
                 2,
                 DefaultConverterLoader.loadAllConverter().entrySet().stream()
                         .filter(entry -> entry.getKey().getClazz() == OffsetDateTime.class)

--- a/fesod-sheet/src/test/java/org/apache/fesod/sheet/converter/OffsetDateTimeConverterTest.java
+++ b/fesod-sheet/src/test/java/org/apache/fesod/sheet/converter/OffsetDateTimeConverterTest.java
@@ -17,12 +17,6 @@
  * under the License.
  */
 
-/*
- * This file is part of the Apache Fesod (Incubating) project, which was derived from Alibaba EasyExcel.
- *
- * Copyright (C) 2018-2024 Alibaba Group Holding Ltd.
- */
-
 package org.apache.fesod.sheet.converter;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/fesod-sheet/src/test/java/org/apache/fesod/sheet/util/DateUtilsTest.java
+++ b/fesod-sheet/src/test/java/org/apache/fesod/sheet/util/DateUtilsTest.java
@@ -26,7 +26,10 @@ import java.text.SimpleDateFormat;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.Locale;
@@ -474,6 +477,30 @@ class DateUtilsTest {
 
         boolean res2 = DateUtils.isADateFormat(formatId, formatStr);
         Assertions.assertTrue(res2);
+    }
+
+    @Test
+    void test_parseOffsetDateTime() {
+        OffsetDateTime expected = OffsetDateTime.of(2020, 1, 2, 3, 4, 5, 0, ZoneOffset.ofHours(8));
+        Assertions.assertEquals(expected, DateUtils.parseOffsetDateTime("2020-01-02T03:04:05+08:00", null, Locale.US));
+        Assertions.assertEquals(expected, DateUtils.parseOffsetDateTime("2020-01-02T03:04:05+08:00", "", Locale.US));
+        Assertions.assertEquals(
+                expected,
+                DateUtils.parseOffsetDateTime(
+                        "02 Januar 2020 03:04:05 +08:00", "dd MMMM yyyy HH:mm:ss XXX", Locale.GERMAN));
+        Assertions.assertThrows(
+                DateTimeParseException.class,
+                () -> DateUtils.parseOffsetDateTime("2020-01-02T03:04:05", null, Locale.US));
+    }
+
+    @Test
+    void test_format_OffsetDateTime() {
+        OffsetDateTime value = OffsetDateTime.of(2020, 1, 2, 3, 4, 5, 0, ZoneOffset.ofHours(8));
+        Assertions.assertNull(DateUtils.format((OffsetDateTime) null, null, Locale.US));
+        Assertions.assertEquals("2020-01-02T03:04:05+08:00", DateUtils.format(value, null, Locale.US));
+        Assertions.assertEquals("2020-01-02T03:04:05+08:00", DateUtils.format(value, "", Locale.US));
+        Assertions.assertEquals(
+                "02 Januar 2020 03:04:05 +08:00", DateUtils.format(value, "dd MMMM yyyy HH:mm:ss XXX", Locale.GERMAN));
     }
 
     @Test


### PR DESCRIPTION
### What and why

Adds a `java.time.OffsetDateTime` converter family for the OffsetDateTime slice of #1017, following the existing `LocalDateTime` / `ZonedDateTime` pattern, so OffsetDateTime fields map to Excel natively instead of falling back to `String`:

- **`OffsetDateTimeDateConverter`** — write-only, emits an Excel `DATE` cell via `toLocalDateTime()`, default format `yyyy-MM-dd HH:mm:ss`
- **`OffsetDateTimeNumberConverter`** — bidirectional `NUMBER` serial, respects `use1904windowing` (property-level first, then a null-safe global default); on read attaches `ZoneId.systemDefault()` to the parsed `LocalDateTime`
- **`OffsetDateTimeStringConverter`** — bidirectional `STRING`, honors `@DateTimeFormat` and the configured `Locale`, defaults to `ISO_OFFSET_DATE_TIME` when no format is set; reads parse strictly and reject offset-less text (fail fast instead of a silent `ZoneId.systemDefault()` interpretation)

Registered in `DefaultConverterLoader.initAllConverter()` / `initDefaultWriteConverter()`.

### Tests

`OffsetDateTimeConverterTest` covers converter keys, DATE/NUMBER/STRING read & write, `@DateTimeFormat` formatting, `use1904windowing` (including the null-safe global default) and round-trip behavior. All tests pass, `spotless:check` is green, and the full local build was verified.

---

Related: #1017 (OffsetDateTime slice).
