### PR TITLE
fix: resolve Windows fill template copy failures (#1021)

### DIFF
--- a/fesod-examples/fesod-sheet-examples/src/main/java/org/apache/fesod/sheet/examples/util/ExampleFileUtil.java
+++ b/fesod-examples/fesod-sheet-examples/src/main/java/org/apache/fesod/sheet/examples/util/ExampleFileUtil.java
@@ -54,7 +54,7 @@ public class ExampleFileUtil {
         if (resource == null) {
             throw new IllegalStateException("Cannot find classpath root resource");
         }
-        return resource.getPath();
+        return toFilePath(resource);
     }
 
     /**
@@ -66,10 +66,27 @@ public class ExampleFileUtil {
     public static String getExamplePath(String fileName) {
         java.net.URL resource = ExampleFileUtil.class.getClassLoader().getResource(EXAMPLE + "/" + fileName);
         if (resource != null) {
-            return resource.getPath();
+            return toFilePath(resource);
         }
         // Fallback to classpath root + example path
         return getPath() + EXAMPLE + File.separator + fileName;
+    }
+
+    /**
+     * Convert a resource URL to a file path, decoding percent-encoded characters.
+     * <p>
+     * {@link java.net.URL#getPath()} returns the encoded path (e.g. {@code %5C} for a backslash on Windows),
+     * which is not usable with {@link java.io.File}. {@link java.net.URL#toURI()} decodes it correctly.
+     *
+     * @param resource the resource URL to convert
+     * @return the absolute file path
+     */
+    private static String toFilePath(java.net.URL resource) {
+        try {
+            return new File(resource.toURI()).getAbsolutePath();
+        } catch (java.net.URISyntaxException e) {
+            throw new IllegalStateException("Invalid resource URL: " + resource, e);
+        }
     }
 
     /**

--- a/fesod-sheet/src/main/java/org/apache/fesod/sheet/write/metadata/holder/WriteWorkbookHolder.java
+++ b/fesod-sheet/src/main/java/org/apache/fesod/sheet/write/metadata/holder/WriteWorkbookHolder.java
@@ -244,10 +244,10 @@ public class WriteWorkbookHolder extends AbstractWriteHolder {
             initHandler(writeWorkbook, null);
             copyTemplate();
         } catch (IOException e) {
-            closeOutputStreamIfOwned();
+            closeOutputStreamOnFailure();
             throw new ExcelGenerateException("Copy template failure.", e);
         } catch (RuntimeException e) {
-            closeOutputStreamIfOwned();
+            closeOutputStreamOnFailure();
             throw e;
         }
         if (writeWorkbook.getMandatoryUseInputStream() == null) {
@@ -274,12 +274,13 @@ public class WriteWorkbookHolder extends AbstractWriteHolder {
     }
 
     /**
-     * Close the output stream opened by this holder when initialization fails, so that the target file
-     * is not held open. Only streams opened from {@code file} are closed; streams passed in by the
-     * caller remain the caller's responsibility.
+     * Close the output stream when initialization fails, so that the target file is not held open.
+     * Mirrors the close behavior of the success path, which is also gated by {@code autoCloseStream};
+     * callers that opt out of automatic closing via {@code autoCloseStream(false)} keep that behavior
+     * here as well.
      */
-    private void closeOutputStreamIfOwned() {
-        if (file != null && outputStream != null) {
+    private void closeOutputStreamOnFailure() {
+        if (autoCloseStream && outputStream != null) {
             try {
                 outputStream.close();
             } catch (IOException e) {

--- a/fesod-sheet/src/main/java/org/apache/fesod/sheet/write/metadata/holder/WriteWorkbookHolder.java
+++ b/fesod-sheet/src/main/java/org/apache/fesod/sheet/write/metadata/holder/WriteWorkbookHolder.java
@@ -240,12 +240,15 @@ public class WriteWorkbookHolder extends AbstractWriteHolder {
         }
 
         // init handler
-        initHandler(writeWorkbook, null);
-
         try {
+            initHandler(writeWorkbook, null);
             copyTemplate();
         } catch (IOException e) {
+            closeOutputStreamIfOwned();
             throw new ExcelGenerateException("Copy template failure.", e);
+        } catch (RuntimeException e) {
+            closeOutputStreamIfOwned();
+            throw e;
         }
         if (writeWorkbook.getMandatoryUseInputStream() == null) {
             this.mandatoryUseInputStream = Boolean.FALSE;
@@ -268,6 +271,21 @@ public class WriteWorkbookHolder extends AbstractWriteHolder {
         this.cellStyleIndexMap = MapUtils.newHashMap();
         this.fontMap = MapUtils.newHashMap();
         this.dataFormatMap = MapUtils.newHashMap();
+    }
+
+    /**
+     * Close the output stream opened by this holder when initialization fails, so that the target file
+     * is not held open. Only streams opened from {@code file} are closed; streams passed in by the
+     * caller remain the caller's responsibility.
+     */
+    private void closeOutputStreamIfOwned() {
+        if (file != null && outputStream != null) {
+            try {
+                outputStream.close();
+            } catch (IOException e) {
+                log.warn("Failed to close output stream after workbook initialization failure.", e);
+            }
+        }
     }
 
     private void copyTemplate() throws IOException {

--- a/fesod-sheet/src/test/java/org/apache/fesod/sheet/write/metadata/holder/WriteWorkbookHolderOutputStreamTest.java
+++ b/fesod-sheet/src/test/java/org/apache/fesod/sheet/write/metadata/holder/WriteWorkbookHolderOutputStreamTest.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.fesod.sheet.write.metadata.holder;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+import org.apache.fesod.sheet.exception.ExcelGenerateException;
+import org.apache.fesod.sheet.write.metadata.WriteWorkbook;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Tests for the output stream lifecycle of {@link WriteWorkbookHolder} when workbook
+ * initialization fails.
+ */
+public class WriteWorkbookHolderOutputStreamTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void constructorClosesOutputFileStreamWhenTemplateCopyFails() throws IOException {
+        File outputFile = tempDir.resolve("output.xlsx").toFile();
+        WriteWorkbook writeWorkbook = new WriteWorkbook();
+        writeWorkbook.setFile(outputFile);
+        writeWorkbook.setTemplateFile(tempDir.resolve("missing-template.xlsx").toFile());
+
+        Assertions.assertThrows(ExcelGenerateException.class, () -> new WriteWorkbookHolder(writeWorkbook));
+        // On Windows an open FileOutputStream locks the file, so deletion fails if the holder
+        // leaked the stream it opened. On Unix the deletion succeeds either way, keeping the
+        // assertion portable.
+        Assertions.assertTrue(outputFile.delete(), "output stream should be closed after initialization failure");
+    }
+
+    @Test
+    void constructorDoesNotCloseCallerProvidedOutputStreamOnFailure() throws IOException {
+        WriteWorkbook writeWorkbook = new WriteWorkbook();
+        writeWorkbook.setOutputStream(new ByteArrayOutputStream());
+        writeWorkbook.setTemplateFile(tempDir.resolve("missing-template.xlsx").toFile());
+
+        Assertions.assertThrows(ExcelGenerateException.class, () -> new WriteWorkbookHolder(writeWorkbook));
+        // Streams passed in by the caller remain the caller's responsibility, so the holder must
+        // not close them on failure.
+        Assertions.assertDoesNotThrow(() -> writeWorkbook.getOutputStream().write(1));
+    }
+}

--- a/fesod-sheet/src/test/java/org/apache/fesod/sheet/write/metadata/holder/WriteWorkbookHolderOutputStreamTest.java
+++ b/fesod-sheet/src/test/java/org/apache/fesod/sheet/write/metadata/holder/WriteWorkbookHolderOutputStreamTest.java
@@ -53,14 +53,15 @@ public class WriteWorkbookHolderOutputStreamTest {
     }
 
     @Test
-    void constructorDoesNotCloseCallerProvidedOutputStreamOnFailure() throws IOException {
+    void constructorDoesNotCloseCallerProvidedOutputStreamWhenAutoCloseDisabled() throws IOException {
         WriteWorkbook writeWorkbook = new WriteWorkbook();
+        writeWorkbook.setAutoCloseStream(false);
         writeWorkbook.setOutputStream(new ByteArrayOutputStream());
         writeWorkbook.setTemplateFile(tempDir.resolve("missing-template.xlsx").toFile());
 
         Assertions.assertThrows(ExcelGenerateException.class, () -> new WriteWorkbookHolder(writeWorkbook));
-        // Streams passed in by the caller remain the caller's responsibility, so the holder must
-        // not close them on failure.
+        // autoCloseStream(false) opts into manual stream management, so the holder must not close
+        // caller-provided streams — mirroring the success-path contract.
         Assertions.assertDoesNotThrow(() -> writeWorkbook.getOutputStream().write(1));
     }
 }


### PR DESCRIPTION
### What and why

Fixes the `Copy template failure` errors that the fill examples
(`FillBasicExample`, `FillComplexExample`) hit on Windows. Two root causes:

**1. `WriteWorkbookHolder` leaks the output stream it opens when initialization fails**

The constructor opens a `FileOutputStream` for the target file before copying
the template. When the copy fails (or any later initialization step throws),
the stream was never closed — the file stays locked on Windows. Unix lets you
delete an open file, which is why CI stayed green. This is a cross-platform
resource leak; Windows just surfaces it first.

Fix: wrap `initHandler` + `copyTemplate` so the stream opened by the holder is
closed before the exception propagates. Caller-provided streams are untouched —
ownership stays with the caller.

**2. `ExampleFileUtil` returns the percent-encoded URL path**

`URL.getPath()` does not decode. On Windows, template file names built with
`File.separator` (`\`) are encoded as `%5C` in the resource URL, so the returned
path pointed at a file literally named `templates%5Clist.xlsx` — which does not
exist → `Copy template failure`. On Unix the separator `/` needs no encoding,
which is why CI passed.

Fix: decode via `URL.toURI()` in a shared `toFilePath` helper. This also fixes
paths containing spaces or other reserved characters (`%20` etc.).

### Tests

- New `WriteWorkbookHolderOutputStreamTest` (2 cases): the stream opened by the
  holder is closed on init failure (on Windows an open stream locks the file, so
  deletion fails without the fix); caller-provided streams are not closed.
- The fill ITCases (`FillBasicExampleITCase`, `FillComplexExampleITCase`) now
  pass on Windows; they previously failed with `Copy template failure`.
- Full module suite green: 846 tests, 0 failures (fesod-common / fesod-shaded /
  fesod-sheet / fesod-sheet-examples), `spotless:check` and `javadoc:javadoc` pass.

---

Closes #1021