### PR TITLE
fix: throw exception when headClazz has no valid fields

### DIFF
--- a/fesod-sheet/src/main/java/org/apache/fesod/sheet/metadata/property/ExcelHeadProperty.java
+++ b/fesod-sheet/src/main/java/org/apache/fesod/sheet/metadata/property/ExcelHeadProperty.java
@@ -34,6 +34,7 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.collections4.MapUtils;
 import org.apache.fesod.common.util.StringUtils;
 import org.apache.fesod.sheet.enums.HeadKindEnum;
 import org.apache.fesod.sheet.metadata.ConfigurationHolder;
@@ -122,6 +123,11 @@ public class ExcelHeadProperty {
             return;
         }
         FieldCache fieldCache = ClassUtils.declaredFields(headClazz, configurationHolder);
+
+        if (MapUtils.isEmpty(fieldCache.getSortedFieldMap())) {
+            throw new IllegalArgumentException(
+                    "The head class " + headClazz.getName() + " does not contain any valid fields");
+        }
 
         for (Map.Entry<Integer, FieldWrapper> entry :
                 fieldCache.getSortedFieldMap().entrySet()) {

--- a/fesod-sheet/src/test/java/org/apache/fesod/sheet/write/HeadClassNoValidFieldWriteTest.java
+++ b/fesod-sheet/src/test/java/org/apache/fesod/sheet/write/HeadClassNoValidFieldWriteTest.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.fesod.sheet.write;
+
+import java.io.File;
+import java.util.Collections;
+import lombok.Getter;
+import lombok.Setter;
+import org.apache.fesod.sheet.FesodSheet;
+import org.apache.fesod.sheet.annotation.ExcelIgnoreUnannotated;
+import org.apache.fesod.sheet.testkit.Tags;
+import org.apache.fesod.sheet.testkit.base.AbstractExcelTest;
+import org.apache.fesod.sheet.testkit.enums.ExcelFormat;
+import org.apache.fesod.sheet.testkit.params.ExcelFormatSource;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.params.ParameterizedTest;
+
+/**
+ * Writing with a head-class that resolves to {@code 0} fields must fail-fast.
+ */
+@Tag(Tags.WRITE)
+class HeadClassNoValidFieldWriteTest extends AbstractExcelTest {
+
+    static class NoFieldData {}
+
+    @Getter
+    @Setter
+    @ExcelIgnoreUnannotated
+    static class UnannotatedOnlyData {
+        private String name;
+    }
+
+    interface GetterOnlyModel {
+        String getName();
+    }
+
+    @ParameterizedTest
+    @ExcelFormatSource
+    void shouldFailFastWhenHeadClassHasNoFields(ExcelFormat format) throws Exception {
+        File file = createTempFile(format);
+
+        IllegalArgumentException exception =
+                Assertions.assertThrows(IllegalArgumentException.class, () -> FesodSheet.write(file, NoFieldData.class)
+                        .sheet()
+                        .doWrite(Collections.singletonList(new NoFieldData())));
+
+        Assertions.assertTrue(exception.getMessage().contains(NoFieldData.class.getName()));
+    }
+
+    @ParameterizedTest
+    @ExcelFormatSource
+    void shouldFailFastWhenAllHeadClassFieldsAreIgnored(ExcelFormat format) throws Exception {
+        File file = createTempFile(format);
+
+        IllegalArgumentException exception = Assertions.assertThrows(
+                IllegalArgumentException.class, () -> FesodSheet.write(file, UnannotatedOnlyData.class)
+                        .sheet()
+                        .doWrite(Collections.singletonList(new UnannotatedOnlyData())));
+
+        Assertions.assertTrue(exception.getMessage().contains(UnannotatedOnlyData.class.getName()));
+    }
+
+    @ParameterizedTest
+    @ExcelFormatSource
+    void shouldFailFastWhenHeadClassIsGetterOnlyInterface(ExcelFormat format) throws Exception {
+        File file = createTempFile(format);
+
+        IllegalArgumentException exception = Assertions.assertThrows(
+                IllegalArgumentException.class,
+                () -> FesodSheet.write(file, GetterOnlyModel.class).sheet().doWrite(Collections.emptyList()));
+
+        Assertions.assertTrue(exception.getMessage().contains(GetterOnlyModel.class.getName()));
+    }
+}


### PR DESCRIPTION
## Purpose of the pull request


## What's changed?

Added validation in `initColumnProperties` to throw an exception when `headClazz` has no valid fields (fail-fast).

## Checklist

- [x] I have read the [Contributor Guide](https://fesod.apache.org/community/contribution/).
- [x] I have written the necessary doc or comment.
- [x] I have added the necessary unit tests and all cases have passed.
