### PR TITLE
fix: finding issues during 2.1.0 RC

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,25 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# Line-ending normalization for release-critical wrapper/scripts.
+# Hermetic building on Linux/macOS requires LF in the source package.
+mvnw text eol=lf
+mvnw.cmd text eol=crlf
+.mvn/wrapper/maven-wrapper.properties text eol=lf
+*.sh text eol=lf
+*.bat text eol=crlf
+*.cmd text eol=crlf

--- a/fesod-sheet/src/test/resources/images/fesod-logo-svg.svg
+++ b/fesod-sheet/src/test/resources/images/fesod-logo-svg.svg
@@ -1,1 +1,19 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="222" height="220" viewBox="0 0 222 220" fill="none"><path     fill="#14824B"  d="M113.324 163.939L81.7664 132.382L81.7664 132.382C85.415 136.03 85.4151 141.946 81.7665 145.595L81.6 145.761L66.2449 161.116C62.066 165.295 62.066 172.071 66.245 176.25L83.6291 193.634C87.8081 197.813 94.5836 197.813 98.7625 193.634L113.324 179.073C117.503 174.894 117.503 168.118 113.324 163.939Z"></path><path   fill-rule="evenodd"  fill="#69CD37"  d="M99.5714 27.1736L174.028 101.63C178.651 106.253 179.009 113.389 174.83 117.567L139.627 152.771C135.448 156.95 128.313 156.592 123.69 151.969L93.2908 121.57C88.6677 116.947 88.3099 109.812 92.4886 105.633L97.7781 100.344C101.297 96.8246 101.297 91.1189 97.7781 87.5998L68.4617 58.2834C63.8388 53.6605 63.4881 46.5177 67.667 42.3387L83.6343 26.3714C87.8133 22.1925 94.9485 22.5507 99.5714 27.1736Z"></path><path     fill="#00B95F"  d="M143.722 133.54L81.1005 70.9178L81.3956 71.2129C85.2449 75.0622 85.2449 81.303 81.3957 85.1522L81.3957 85.1522L65.473 101.075C61.2941 105.254 61.2941 112.029 65.4731 116.208L97.2574 147.993L113.111 163.847C117.374 168.11 117.374 175.021 113.111 179.284L113.111 179.284L143.722 148.673C147.901 144.494 147.901 137.719 143.722 133.54Z"></path></svg>

--- a/fesod-sheet/src/test/resources/junit-platform.properties
+++ b/fesod-sheet/src/test/resources/junit-platform.properties
@@ -1,3 +1,19 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
 # ---------------------------------------------------------------------------
 # JUnit Platform configuration for the fesod-sheet test suite.
 #

--- a/pom.xml
+++ b/pom.xml
@@ -81,9 +81,11 @@ under the License.
     <properties>
         <revision>2.1.0-SNAPSHOT</revision>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <!-- Must dominate the parent `apache` POM's stale 2023 default: apache-jar-resource-bundle derives the
-             JAR NOTICE copyright end-year from this value, and a stale one yields an inverted "2025-2023" range. -->
-        <project.build.outputTimestamp>2026-08-27T07:40:31Z</project.build.outputTimestamp>
+        <!-- Clear the parent `apache` POM's stale outputTimestamp (2023): apache-jar-resource-bundle derives the JAR
+             NOTICE copyright end-year from it, and a stale value yields an inverted "2025-2023" range. An empty value
+             falls back to the current build year, so the NOTICE stays correct without a hardcoded date. For a
+             reproducible release, set this to a fixed ISO-8601 commit timestamp (typically done at release pre). -->
+        <project.build.outputTimestamp></project.build.outputTimestamp>
         <java.version>1.8</java.version>
         <maven.compiler.target>1.8</maven.compiler.target>
         <maven.compiler.source>1.8</maven.compiler.source>

--- a/pom.xml
+++ b/pom.xml
@@ -81,6 +81,9 @@ under the License.
     <properties>
         <revision>2.1.0-SNAPSHOT</revision>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <!-- Must dominate the parent `apache` POM's stale 2023 default: apache-jar-resource-bundle derives the
+             JAR NOTICE copyright end-year from this value, and a stale one yields an inverted "2025-2023" range. -->
+        <project.build.outputTimestamp>2026-08-27T07:40:31Z</project.build.outputTimestamp>
         <java.version>1.8</java.version>
         <maven.compiler.target>1.8</maven.compiler.target>
         <maven.compiler.source>1.8</maven.compiler.source>
@@ -123,7 +126,7 @@ under the License.
     </scm>
 
     <organization>
-        <name>Apache Software Foundation</name>
+        <name>The Apache Software Foundation</name>
         <url>https://www.apache.org</url>
     </organization>
 


### PR DESCRIPTION
<!--
Thanks very much for contributing to Apache Fesod (Incubating)! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:


Related: #ISSUE

-->

## Purpose of the pull request

Closed: #1048

## What's changed?

1. **Dynamic `NOTICE` year** — override the inherited property so the bundle falls back to the current build year:

   ```xml
   <project.build.outputTimestamp></project.build.outputTimestamp>
   ```

   Verified output: `Copyright 2025-2026 The Apache Software Foundation`, and it stays correct across years without a hardcoded date.

2. **Canonical organization name** — `The Apache Software Foundation` (official legal name) in the parent `pom.xml`.

3. **Hermetic source-package line endings** — add `.gitattributes` enforcing `mvnw` / `*.sh` -> `LF` and Windows `*.cmd` / `*.bat` -> `CRLF`, so `git archive` no longer mangles the Unix `mvnw` (the CRLF issue from `RC1`).

4. **RAT compliance** — add ASF license headers to `fesod-sheet` test resources (logo SVG, `junit-platform.properties`) and the new `.gitattributes`.


## Checklist

- [X] I have read the [Contributor Guide](https://fesod.apache.org/community/contribution/).
- [X] I have written the necessary doc or comment.
- [X] I have added the necessary unit tests and all cases have passed.
