### PR TITLE
docs: maintain KEYS only in the release directory

### DIFF
--- a/website/community/release/release-version.md
+++ b/website/community/release/release-version.md
@@ -222,9 +222,8 @@ ${RELEASE_MANAGER}
 
 ### 3.1 KEYS File
 
-If you are a **first-time** release manager or your original key has expired, please **append** the **public key** to the **KEYS** files in the Apache SVN project repositories:
+If you are a **first-time** release manager or your original key has expired, please **append** the **public key** to the **KEYS** file in the Apache SVN project **release** repository. The KEYS file is maintained in a single authoritative location (the release directory) so that it stays consistent and is available on downloads.apache.org for signature verification:
 
-- Dev repository: <https://dist.apache.org/repos/dist/dev/incubator/fesod>
 - Release repository: <https://dist.apache.org/repos/dist/release/incubator/fesod>
 
 Steps:
@@ -246,6 +245,7 @@ svn ci -m "add gpg key for xxx"
 Notes:
 
 - Do not directly overwrite the `KEYS` file in the repository. Only **append** to it.
+- The `KEYS` file is maintained only in the **release** directory (single source of truth). Do **not** create a copy in the dev directory, as two copies tend to drift out of sync.
 - SVN repositories require PPMC permissions. A PPMC member can assist you with the upload.
 
 ### 3.2 POM Configuration

--- a/website/community/release/verify-release.md
+++ b/website/community/release/verify-release.md
@@ -43,7 +43,7 @@ export RC_VERSION={rc_version}
 Download the artifacts:
 
 ```shell
-# Option 1: SVN checkout (Recommended, includes KEYS file)
+# Option 1: SVN checkout (Recommended)
 svn co https://dist.apache.org/repos/dist/dev/incubator/fesod/${RELEASE_VERSION}-${RC_VERSION}/ fesod-dist-dev
 
 # Option 2: Wget individual files
@@ -66,8 +66,8 @@ The uploaded artifacts must contain:
 **2.2.1 Import KEYS**
 
 ```shell
-# Download KEYS
-curl https://dist.apache.org/repos/dist/dev/incubator/fesod/KEYS > KEYS
+# Download KEYS (kept in the release directory)
+curl https://downloads.apache.org/incubator/fesod/KEYS > KEYS
 
 # Import KEYS locally
 gpg --import KEYS

--- a/website/i18n/zh-cn/docusaurus-plugin-content-docs-community/current/release/release-version.md
+++ b/website/i18n/zh-cn/docusaurus-plugin-content-docs-community/current/release/release-version.md
@@ -222,9 +222,8 @@ ${RELEASE_MANAGER}
 
 ### 3.1 KEYS 文件
 
-如果您是**第一次**作为发布者或原来的密钥已过期，请将**公钥**分别**追加**到 Apache SVN 项目仓库的 **KEYS** 文件中
+如果您是**第一次**作为发布者或原来的密钥已过期，请将**公钥**追加到 Apache SVN 项目 **release 仓库**的 **KEYS** 文件中。KEYS 文件在单独权威位置（release 目录）维护，以保证一致性，并可在 downloads.apache.org 上用于签名验证：
 
-- Dev 仓库：<https://dist.apache.org/repos/dist/dev/incubator/fesod>
 - Release 仓库：<https://dist.apache.org/repos/dist/release/incubator/fesod>
 
 操作步骤：
@@ -246,6 +245,7 @@ svn ci -m "add gpg key for xxx"
 注意事项：
 
 - 请不要直接覆盖仓库中 `KEYS`文件，只能**追加**
+- `KEYS` 文件只在 **release** 目录维护（单一权威来源），**不要**在 dev 目录再保留一份，否则两份内容容易不同步。
 - SVN 仓库需要 PPMC 权限，可由 PPMC 成员协助您上传。
 
 ### 3.2 POM 配置

--- a/website/i18n/zh-cn/docusaurus-plugin-content-docs-community/current/release/verify-release.md
+++ b/website/i18n/zh-cn/docusaurus-plugin-content-docs-community/current/release/verify-release.md
@@ -43,7 +43,7 @@ export RC_VERSION={RC版本号}
 下载物料：
 
 ```shell
-# 方式一：如果本地有 SVN，直接 checkout (推荐，包含了 KEYS 文件)
+# 方式一：如果本地有 SVN，直接 checkout (推荐)
 svn co https://dist.apache.org/repos/dist/dev/incubator/fesod/${RELEASE_VERSION}-${RC_VERSION}/ fesod-dist-dev
 
 # 方式二：使用 wget 直接下载特定文件
@@ -68,8 +68,8 @@ wget https://dist.apache.org/repos/dist/dev/incubator/fesod/${RELEASE_VERSION}-$
 **2.2.1 导入 KEYS**
 
 ```shell
-# 从 SVN 仓库下载 KEYS (通常在版本目录或根目录)
-curl https://dist.apache.org/repos/dist/dev/incubator/fesod/KEYS > KEYS
+# 下载 KEYS（KEYS 在 release 目录维护，单一来源）
+curl https://downloads.apache.org/incubator/fesod/KEYS > KEYS
 
 # 导入 KEYS 到本地
 gpg --import KEYS


### PR DESCRIPTION
## Purpose of the pull request

Align release documentation with ASF guidance: the KEYS file is a single source of truth kept in the release directory so it is available on `downloads.apache.org` for signature verification. Remove instructions to append the public key to the dev KEYS and change verification steps to fetch KEYS from `downloads.apache.org` instead of the dev directory.

## What's changed?

- **`website/community/release/release-version.md`** and its **zh-cn** translation: section *"3.1 KEYS File"* now instructs appending the public key only to the **release** repository (`https://dist.apache.org/repos/dist/release/incubator/fesod`), dropping the dev repository. Added a note under *Notes* that the KEYS file is maintained only in the release directory (single source of truth) and must not be duplicated in the dev directory.
- **`website/community/release/verify-release.md`** and its **zh-cn** translation: signature verification now downloads KEYS from `https://downloads.apache.org/incubator/fesod/KEYS` instead of `https://dist.apache.org/repos/dist/dev/incubator/fesod/KEYS`; removed the now-inaccurate "includes KEYS file" comment on the SVN checkout step.

This is a **documentation-only** change; no build logic or tests are affected.

## Checklist

- [x] I have read the `https://fesod.apache.org/community/contribution/`.
- [x] I have written the necessary doc or comment.
- [ ] I have added the necessary unit tests and all cases have passed.