### PR TITLE
fix: copy sheet-level read params to sheet holder

### DIFF
--- a/fesod-sheet/src/main/java/org/apache/fesod/sheet/read/metadata/ReadSheet.java
+++ b/fesod-sheet/src/main/java/org/apache/fesod/sheet/read/metadata/ReadSheet.java
@@ -148,6 +148,9 @@ public class ReadSheet extends ReadBasicParameter {
         this.setAutoTrim(other.getAutoTrim());
         this.setAutoStrip(other.getAutoStrip());
         this.setUse1904windowing(other.getUse1904windowing());
+        this.setLocale(other.getLocale());
+        this.setUseScientificFormat(other.getUseScientificFormat());
+        this.setFiledCacheLocation(other.getFiledCacheLocation());
         this.setNumRows(other.getNumRows());
         this.setHidden(other.isHidden());
         this.setVeryHidden(other.isVeryHidden());


### PR DESCRIPTION
Closed: #1051

## Purpose of the pull request

`ReadSheet.copyBasicParameter` copied 12 of the 15 read parameters - `locale`, `useScientificFormat` and `filedCacheLocation` were missing, so a value set after `.sheet(...)` was dropped and the workbook-level value was silently applied instead

## What's changed?

This adds the three missing copies, so all three now behave like `autoTrim`, `autoStrip`, `use1904windowing` and `headRowNumber`, which were already copied.

## Checklist

- [x] I have read the [Contributor Guide](https://fesod.apache.org/community/contribution/).
- [x] I have written the necessary doc or comment.
- [ ] I have added the necessary unit tests and all cases have passed.
