### PR TITLE
fix: fall back to default format index on malformed style index (#355)

### DIFF
--- a/fesod-sheet/src/main/java/org/apache/fesod/sheet/analysis/v07/handlers/CellTagHandler.java
+++ b/fesod-sheet/src/main/java/org/apache/fesod/sheet/analysis/v07/handlers/CellTagHandler.java
@@ -74,7 +74,13 @@ public class CellTagHandler extends AbstractXlsxTagHandler {
         if (StringUtils.isEmpty(dateFormatIndex)) {
             dateFormatIndexInteger = DEFAULT_FORMAT_INDEX;
         } else {
-            dateFormatIndexInteger = Integer.parseInt(dateFormatIndex);
+            try {
+                dateFormatIndexInteger = Integer.parseInt(dateFormatIndex);
+            } catch (NumberFormatException e) {
+                // A malformed style index (e.g. produced by third-party tools) must not abort the
+                // whole file read; fall back to the default format, matching POI's lenient behavior.
+                dateFormatIndexInteger = DEFAULT_FORMAT_INDEX;
+            }
         }
 
         xlsxReadSheetHolder

--- a/fesod-sheet/src/test/java/org/apache/fesod/sheet/analysis/v07/handlers/CellTagHandlerTest.java
+++ b/fesod-sheet/src/test/java/org/apache/fesod/sheet/analysis/v07/handlers/CellTagHandlerTest.java
@@ -20,8 +20,11 @@
 package org.apache.fesod.sheet.analysis.v07.handlers;
 
 import org.apache.fesod.sheet.context.xlsx.XlsxReadContext;
+import org.apache.fesod.sheet.enums.CellDataTypeEnum;
 import org.apache.fesod.sheet.exception.ExcelAnalysisException;
+import org.apache.fesod.sheet.metadata.data.ReadCellData;
 import org.apache.fesod.sheet.read.metadata.holder.xlsx.XlsxReadSheetHolder;
+import org.apache.fesod.sheet.read.metadata.holder.xlsx.XlsxReadWorkbookHolder;
 import org.apache.fesod.sheet.testkit.Tags;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Tag;
@@ -36,6 +39,10 @@ import org.xml.sax.helpers.AttributesImpl;
  * {@code null}, which then tripped the {@code ReadCellData} constructor with a confusing
  * {@code IllegalArgumentException: Type can not be null} that named neither the cell nor the attribute.
  * The handler must instead throw an {@link ExcelAnalysisException} naming the invalid type and its location.
+ *
+ * <p>Also covers <a href="https://github.com/apache/fesod/issues/355">issue #355</a>: a malformed
+ * {@code s} (style index) attribute used to abort the whole file read via a bare
+ * {@code Integer.parseInt}. The handler must fall back to the default format index instead.
  */
 @Tag(Tags.UNIT)
 class CellTagHandlerTest {
@@ -57,5 +64,47 @@ class CellTagHandlerTest {
         String message = exception.getMessage();
         Assertions.assertTrue(message.contains("'unknown'"), "should name the unrecognized type: " + message);
         Assertions.assertTrue(message.contains("B4"), "should name the cell reference: " + message);
+    }
+
+    @Test
+    void startElement_fallsBackToDefaultFormat_forMalformedStyleIndex() {
+        XlsxReadContext context = Mockito.mock(XlsxReadContext.class);
+        XlsxReadSheetHolder sheetHolder = Mockito.mock(XlsxReadSheetHolder.class);
+        XlsxReadWorkbookHolder workbookHolder = Mockito.mock(XlsxReadWorkbookHolder.class);
+        Mockito.when(context.xlsxReadSheetHolder()).thenReturn(sheetHolder);
+        Mockito.when(context.xlsxReadWorkbookHolder()).thenReturn(workbookHolder);
+        Mockito.when(sheetHolder.getTempCellData()).thenReturn(new ReadCellData<>(CellDataTypeEnum.NUMBER));
+
+        AttributesImpl attributes = new AttributesImpl();
+        attributes.addAttribute("", "r", "r", "CDATA", "B4");
+        attributes.addAttribute("", "t", "t", "CDATA", "n");
+        attributes.addAttribute("", "s", "s", "CDATA", "abc");
+
+        Assertions.assertDoesNotThrow(
+                () -> new CellTagHandler().startElement(context, "c", attributes),
+                "a malformed style index must not abort the read");
+
+        // The style lookup must fall back to the default format index (0) instead of parsing "abc".
+        Mockito.verify(workbookHolder).dataFormatData(0);
+    }
+
+    @Test
+    void startElement_usesStyleIndex_whenNumeric() {
+        XlsxReadContext context = Mockito.mock(XlsxReadContext.class);
+        XlsxReadSheetHolder sheetHolder = Mockito.mock(XlsxReadSheetHolder.class);
+        XlsxReadWorkbookHolder workbookHolder = Mockito.mock(XlsxReadWorkbookHolder.class);
+        Mockito.when(context.xlsxReadSheetHolder()).thenReturn(sheetHolder);
+        Mockito.when(context.xlsxReadWorkbookHolder()).thenReturn(workbookHolder);
+        Mockito.when(sheetHolder.getTempCellData()).thenReturn(new ReadCellData<>(CellDataTypeEnum.NUMBER));
+
+        AttributesImpl attributes = new AttributesImpl();
+        attributes.addAttribute("", "r", "r", "CDATA", "B4");
+        attributes.addAttribute("", "t", "t", "CDATA", "n");
+        attributes.addAttribute("", "s", "s", "CDATA", "3");
+
+        Assertions.assertDoesNotThrow(() -> new CellTagHandler().startElement(context, "c", attributes));
+
+        // Numeric style indices keep their exact lookup; the happy path is untouched.
+        Mockito.verify(workbookHolder).dataFormatData(3);
     }
 }

--- a/fesod-sheet/src/test/java/org/apache/fesod/sheet/read/CorruptStyleIndexReadTest.java
+++ b/fesod-sheet/src/test/java/org/apache/fesod/sheet/read/CorruptStyleIndexReadTest.java
@@ -1,0 +1,120 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.fesod.sheet.read;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+import org.apache.fesod.sheet.FesodSheet;
+import org.apache.fesod.sheet.testkit.Tags;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Regression test for <a href="https://github.com/apache/fesod/issues/355">issue #355</a>.
+ *
+ * <p>An xlsx produced by third-party tools may carry a non-numeric {@code s} (style index)
+ * attribute on a cell. Reading such a file used to abort with a {@code NumberFormatException}
+ * at the very first corrupt cell, so nothing after it was read. The handler must fall back to
+ * the default format and keep reading the remaining rows.
+ *
+ * <p>The file below is a minimal hand-built xlsx (no styles.xml on purpose): row 1 and row 3
+ * carry valid style indexes, row 2 carries a corrupt one.
+ */
+@Tag(Tags.READ)
+class CorruptStyleIndexReadTest {
+
+    private static final String CONTENT_TYPES = "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n"
+            + "<Types xmlns=\"http://schemas.openxmlformats.org/package/2006/content-types\">\n"
+            + "  <Default Extension=\"rels\" ContentType=\"application/vnd.openxmlformats-package.relationships+xml\"/>\n"
+            + "  <Default Extension=\"xml\" ContentType=\"application/xml\"/>\n"
+            + "  <Override PartName=\"/xl/workbook.xml\""
+            + " ContentType=\"application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml\"/>\n"
+            + "  <Override PartName=\"/xl/worksheets/sheet1.xml\""
+            + " ContentType=\"application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml\"/>\n"
+            + "</Types>\n";
+
+    private static final String ROOT_RELS = "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n"
+            + "<Relationships xmlns=\"http://schemas.openxmlformats.org/package/2006/relationships\">\n"
+            + "  <Relationship Id=\"rId1\""
+            + " Type=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument\""
+            + " Target=\"xl/workbook.xml\"/>\n"
+            + "</Relationships>\n";
+
+    private static final String WORKBOOK = "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n"
+            + "<workbook xmlns=\"http://schemas.openxmlformats.org/spreadsheetml/2006/main\""
+            + " xmlns:r=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships\">\n"
+            + "  <sheets>\n"
+            + "    <sheet name=\"Sheet1\" sheetId=\"1\" r:id=\"rId1\"/>\n"
+            + "  </sheets>\n"
+            + "</workbook>\n";
+
+    private static final String WORKBOOK_RELS = "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n"
+            + "<Relationships xmlns=\"http://schemas.openxmlformats.org/package/2006/relationships\">\n"
+            + "  <Relationship Id=\"rId1\""
+            + " Type=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet\""
+            + " Target=\"worksheets/sheet1.xml\"/>\n"
+            + "</Relationships>\n";
+
+    private static final String SHEET = "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n"
+            + "<worksheet xmlns=\"http://schemas.openxmlformats.org/spreadsheetml/2006/main\">\n"
+            + "  <sheetData>\n"
+            + "    <row r=\"1\"><c r=\"A1\" t=\"n\" s=\"0\"><v>1</v></c></row>\n"
+            + "    <row r=\"2\"><c r=\"A2\" t=\"n\" s=\"abc\"><v>2</v></c></row>\n"
+            + "    <row r=\"3\"><c r=\"A3\" t=\"n\" s=\"1\"><v>3</v></c></row>\n"
+            + "  </sheetData>\n"
+            + "</worksheet>\n";
+
+    @Test
+    void read_corruptStyleIndex_skipsStyleAndReadsAllRows() throws Exception {
+        File file = buildMinimalXlsx();
+
+        List<Map<Integer, String>> rows =
+                FesodSheet.read(file).sheet().headRowNumber(0).doReadSync();
+
+        Assertions.assertEquals(3, rows.size(), "all rows must be read, none aborted");
+        Assertions.assertEquals("1", rows.get(0).get(0));
+        Assertions.assertEquals("2", rows.get(1).get(0), "row with the corrupt style index must still be read");
+        Assertions.assertEquals("3", rows.get(2).get(0), "rows after the corrupt one must still be read");
+    }
+
+    private File buildMinimalXlsx() throws Exception {
+        File file = File.createTempFile("corrupt-style-index", ".xlsx");
+        try (ZipOutputStream zip = new ZipOutputStream(new FileOutputStream(file))) {
+            addEntry(zip, "[Content_Types].xml", CONTENT_TYPES);
+            addEntry(zip, "_rels/.rels", ROOT_RELS);
+            addEntry(zip, "xl/workbook.xml", WORKBOOK);
+            addEntry(zip, "xl/_rels/workbook.xml.rels", WORKBOOK_RELS);
+            addEntry(zip, "xl/worksheets/sheet1.xml", SHEET);
+        }
+        return file;
+    }
+
+    private void addEntry(ZipOutputStream zip, String name, String content) throws Exception {
+        zip.putNextEntry(new ZipEntry(name));
+        zip.write(content.getBytes(StandardCharsets.UTF_8));
+        zip.closeEntry();
+    }
+}


### PR DESCRIPTION
**Fixes #355**

### What changes were proposed in this pull request?

`CellTagHandler` parses a cell's `s` attribute (style index) with a bare `Integer.parseInt`. A non-numeric value — as produced by some third-party tools — threw `NumberFormatException` and aborted the whole file read at the first corrupt cell (in the report: reading stopped at row 3218 of 3000+ rows).

The parse now falls back to the default format index (`0`) on `NumberFormatException`: a corrupt style index only loses that cell's style info, while the cell value and all subsequent rows are still read. This follows the reporter's suggestion and matches POI's lenient behavior (POI reads the same file completely, with the corrupt cell read as empty).

### How was this patch tested?

- `CellTagHandlerTest` (2 new unit tests): non-numeric `s` falls back to `dataFormatData(0)` without throwing; numeric `s` keeps the exact lookup.
- `CorruptStyleIndexReadTest` (new end-to-end test): a minimal hand-built xlsx whose middle row carries `s="abc"` is read completely — all 3 rows returned.
- Red/green check: on the pre-fix code the e2e test fails with the exact exception from the report (`NumberFormatException: For input string: "abc"`); with the fix it passes.
- Full `fesod-sheet` suite: 915/915 green. `spotless:check` and `javadoc` pass.

### Notes

- Zero impact on valid files: the numeric parse path is untouched.
- No API change, no new dependencies.
