### PR TITLE
chore: remove unused mockserver-netty test dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -108,7 +108,6 @@ under the License.
         <jcl-over-slf4j.version>2.0.18</jcl-over-slf4j.version>
         <log4j-over-slf4j.version>2.0.18</log4j-over-slf4j.version>
         <log4j-to-slf4j.version>2.24.3</log4j-to-slf4j.version>
-        <mockserver.version>5.15.0</mockserver.version>
         <jacoco.version>0.8.15</jacoco.version>
         <junit.version>5.13.4</junit.version>
         <mockito.version>4.11.0</mockito.version>
@@ -263,12 +262,6 @@ under the License.
                 <scope>test</scope>
             </dependency>
             <dependency>
-                <groupId>org.mock-server</groupId>
-                <artifactId>mockserver-netty</artifactId>
-                <version>${mockserver.version}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
                 <groupId>org.junit.jupiter</groupId>
                 <artifactId>junit-jupiter</artifactId>
                 <version>${junit.version}</version>
@@ -378,25 +371,6 @@ under the License.
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
             <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.mock-server</groupId>
-            <artifactId>mockserver-netty</artifactId>
-            <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.apache.commons</groupId>
-                    <artifactId>commons-lang3</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>commons-codec</groupId>
-                    <artifactId>commons-codec</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.fasterxml.jackson.core</groupId>
-                    <artifactId>jackson-databind</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>com.code-intelligence</groupId>


### PR DESCRIPTION
## Summary
- Drop unused `org.mock-server:mockserver-netty` 5.15.0 from the parent POM (`mockserver.version`, `dependencyManagement`, and the inherited test dependency).
- The only usage was `WebStreamReadTest`, which mocked a remote `.xlsx` URL. That test and `web/io.xlsx` were removed in #770 when examples were refactored
- This also removes transitive BouncyCastle 1.72 findings: CVE-2024-29857, CVE-2024-30172, CVE-2024-34447, and CVE-2024-30171. MockServer 6+/7.x cannot be used here because it requires Java 17, while this project still tests on JDK 8.