### PR TITLE
refactor: add ReadCache no-op defaults and unit tests

### DIFF
--- a/fesod-sheet/src/main/java/org/apache/fesod/sheet/cache/MapCache.java
+++ b/fesod-sheet/src/main/java/org/apache/fesod/sheet/cache/MapCache.java
@@ -27,7 +27,6 @@ package org.apache.fesod.sheet.cache;
 
 import java.util.ArrayList;
 import java.util.List;
-import org.apache.fesod.sheet.context.AnalysisContext;
 
 /**
  * Putting temporary data directly into a map is a little more efficient but very memory intensive
@@ -36,9 +35,6 @@ import org.apache.fesod.sheet.context.AnalysisContext;
  */
 public class MapCache implements ReadCache {
     private final List<String> cache = new ArrayList<>();
-
-    @Override
-    public void init(AnalysisContext analysisContext) {}
 
     @Override
     public void put(String value) {
@@ -52,10 +48,4 @@ public class MapCache implements ReadCache {
         }
         return cache.get(key);
     }
-
-    @Override
-    public void putFinished() {}
-
-    @Override
-    public void destroy() {}
 }

--- a/fesod-sheet/src/main/java/org/apache/fesod/sheet/cache/ReadCache.java
+++ b/fesod-sheet/src/main/java/org/apache/fesod/sheet/cache/ReadCache.java
@@ -28,9 +28,11 @@ package org.apache.fesod.sheet.cache;
 import org.apache.fesod.sheet.context.AnalysisContext;
 
 /**
- * Read cache
+ * Shared-string (and similar) read cache.
  *
- *
+ * <p>{@link #get(Integer)} is the only required method. Lifecycle hooks and {@link #put(String)}
+ * default to no-ops so implementations that wrap an existing store (for example {@link XlsCache})
+ * do not need empty method bodies.
  */
 public interface ReadCache {
 
@@ -40,7 +42,7 @@ public interface ReadCache {
      * @param analysisContext
      *            A context is the main anchorage point of a excel reader.
      */
-    void init(AnalysisContext analysisContext);
+    default void init(AnalysisContext analysisContext) {}
 
     /**
      * Automatically generate the key and put it in the cache.Key start from 0
@@ -48,7 +50,7 @@ public interface ReadCache {
      * @param value
      *            Cache value
      */
-    void put(String value);
+    default void put(String value) {}
 
     /**
      * Get value
@@ -62,10 +64,10 @@ public interface ReadCache {
     /**
      * It's called when all the values are put in
      */
-    void putFinished();
+    default void putFinished() {}
 
     /**
-     * Called when the excel read is complete
+     * Called when the Excel read is complete
      */
-    void destroy();
+    default void destroy() {}
 }

--- a/fesod-sheet/src/main/java/org/apache/fesod/sheet/cache/XlsCache.java
+++ b/fesod-sheet/src/main/java/org/apache/fesod/sheet/cache/XlsCache.java
@@ -25,7 +25,6 @@
 
 package org.apache.fesod.sheet.cache;
 
-import org.apache.fesod.sheet.context.AnalysisContext;
 import org.apache.poi.hssf.record.SSTRecord;
 
 /**
@@ -42,19 +41,7 @@ public class XlsCache implements ReadCache {
     }
 
     @Override
-    public void init(AnalysisContext analysisContext) {}
-
-    @Override
-    public void put(String value) {}
-
-    @Override
     public String get(Integer key) {
         return sstRecord.getString(key).toString();
     }
-
-    @Override
-    public void putFinished() {}
-
-    @Override
-    public void destroy() {}
 }

--- a/fesod-sheet/src/test/java/org/apache/fesod/sheet/cache/EhcacheTest.java
+++ b/fesod-sheet/src/test/java/org/apache/fesod/sheet/cache/EhcacheTest.java
@@ -87,7 +87,7 @@ class EhcacheTest {
 
     @Test
     void readsAcrossBatchesAfterCacheMiss() {
-        cache = new Ehcache(null, 5);
+        cache = new Ehcache(null, 1);
         cache.init(null);
         int total = Ehcache.BATCH_COUNT + 25;
         for (int i = 0; i < total; i++) {
@@ -98,16 +98,6 @@ class EhcacheTest {
         Assertions.assertEquals("v0", cache.get(0));
         Assertions.assertEquals("v100", cache.get(Ehcache.BATCH_COUNT));
         Assertions.assertEquals("v124", cache.get(total - 1));
-    }
-
-    @Test
-    void deprecatedSizeConstructorStillWorks() {
-        cache = new Ehcache(1, 1);
-        cache.init(null);
-        cache.put("alpha");
-        cache.putFinished();
-
-        Assertions.assertEquals("alpha", cache.get(0));
     }
 
     @Test

--- a/fesod-sheet/src/test/java/org/apache/fesod/sheet/cache/EhcacheTest.java
+++ b/fesod-sheet/src/test/java/org/apache/fesod/sheet/cache/EhcacheTest.java
@@ -87,7 +87,7 @@ class EhcacheTest {
 
     @Test
     void readsAcrossBatchesAfterCacheMiss() {
-        cache = new Ehcache(null, 1);
+        cache = new Ehcache(null, 5);
         cache.init(null);
         int total = Ehcache.BATCH_COUNT + 25;
         for (int i = 0; i < total; i++) {

--- a/fesod-sheet/src/test/java/org/apache/fesod/sheet/cache/EhcacheTest.java
+++ b/fesod-sheet/src/test/java/org/apache/fesod/sheet/cache/EhcacheTest.java
@@ -1,0 +1,135 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.fesod.sheet.cache;
+
+import org.apache.fesod.sheet.testkit.Tags;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for {@link Ehcache}.
+ */
+@Tag(Tags.UNIT)
+class EhcacheTest {
+
+    private Ehcache cache;
+
+    @AfterEach
+    void tearDown() {
+        if (cache != null) {
+            cache.destroy();
+            cache = null;
+        }
+    }
+
+    @Test
+    void storesRemainderAfterPutFinished() {
+        cache = newCache();
+        cache.put("alpha");
+        cache.put("beta");
+        cache.putFinished();
+
+        Assertions.assertEquals("alpha", cache.get(0));
+        Assertions.assertEquals("beta", cache.get(1));
+    }
+
+    @Test
+    void storesNullAndEmptyString() {
+        cache = newCache();
+        cache.put(null);
+        cache.put("");
+        cache.putFinished();
+
+        Assertions.assertNull(cache.get(0));
+        Assertions.assertEquals("", cache.get(1));
+    }
+
+    @Test
+    void getReturnsNullForNullOrNegativeKey() {
+        cache = newCache();
+        cache.put("alpha");
+        cache.putFinished();
+
+        Assertions.assertNull(cache.get(null));
+        Assertions.assertNull(cache.get(-1));
+    }
+
+    @Test
+    void flushesAutomaticallyAtBatchBoundary() {
+        cache = newCache();
+        for (int i = 0; i < Ehcache.BATCH_COUNT; i++) {
+            cache.put("v" + i);
+        }
+
+        Assertions.assertEquals("v0", cache.get(0));
+        Assertions.assertEquals("v99", cache.get(Ehcache.BATCH_COUNT - 1));
+        Assertions.assertDoesNotThrow(() -> cache.putFinished());
+    }
+
+    @Test
+    void readsAcrossBatchesAfterCacheMiss() {
+        cache = new Ehcache(null, 1);
+        cache.init(null);
+        int total = Ehcache.BATCH_COUNT + 25;
+        for (int i = 0; i < total; i++) {
+            cache.put("v" + i);
+        }
+        cache.putFinished();
+
+        Assertions.assertEquals("v0", cache.get(0));
+        Assertions.assertEquals("v100", cache.get(Ehcache.BATCH_COUNT));
+        Assertions.assertEquals("v124", cache.get(total - 1));
+    }
+
+    @Test
+    void deprecatedSizeConstructorStillWorks() {
+        cache = new Ehcache(1, 1);
+        cache.init(null);
+        cache.put("alpha");
+        cache.putFinished();
+
+        Assertions.assertEquals("alpha", cache.get(0));
+    }
+
+    @Test
+    void instancesDoNotShareEntries() {
+        cache = newCache();
+        Ehcache second = newCache();
+        try {
+            cache.put("first");
+            cache.putFinished();
+            second.put("second");
+            second.putFinished();
+
+            Assertions.assertEquals("first", cache.get(0));
+            Assertions.assertEquals("second", second.get(0));
+        } finally {
+            second.destroy();
+        }
+    }
+
+    private Ehcache newCache() {
+        Ehcache created = new Ehcache(null, 20);
+        created.init(null);
+        return created;
+    }
+}

--- a/fesod-sheet/src/test/java/org/apache/fesod/sheet/cache/MapCacheTest.java
+++ b/fesod-sheet/src/test/java/org/apache/fesod/sheet/cache/MapCacheTest.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.fesod.sheet.cache;
+
+import org.apache.fesod.sheet.testkit.Tags;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for {@link MapCache}.
+ */
+@Tag(Tags.UNIT)
+class MapCacheTest {
+
+    @Test
+    void storesValuesByInsertionOrder() {
+        MapCache cache = new MapCache();
+        cache.init(null);
+        cache.put("alpha");
+        cache.put("beta");
+        cache.putFinished();
+
+        Assertions.assertEquals("alpha", cache.get(0));
+        Assertions.assertEquals("beta", cache.get(1));
+        Assertions.assertDoesNotThrow(cache::destroy);
+    }
+
+    @Test
+    void storesNullAndEmptyString() {
+        MapCache cache = new MapCache();
+        cache.put(null);
+        cache.put("");
+
+        Assertions.assertNull(cache.get(0));
+        Assertions.assertEquals("", cache.get(1));
+    }
+
+    @Test
+    void getReturnsNullForNullOrNegativeKey() {
+        MapCache cache = new MapCache();
+        cache.put("alpha");
+
+        Assertions.assertNull(cache.get(null));
+        Assertions.assertNull(cache.get(-1));
+    }
+
+    @Test
+    void getThrowsWhenKeyIsOutOfRange() {
+        MapCache cache = new MapCache();
+
+        Assertions.assertThrows(IndexOutOfBoundsException.class, () -> cache.get(0));
+
+        cache.put("alpha");
+        Assertions.assertThrows(IndexOutOfBoundsException.class, () -> cache.get(1));
+    }
+}

--- a/fesod-sheet/src/test/java/org/apache/fesod/sheet/cache/ReadCacheTest.java
+++ b/fesod-sheet/src/test/java/org/apache/fesod/sheet/cache/ReadCacheTest.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.fesod.sheet.cache;
+
+import org.apache.fesod.sheet.testkit.Tags;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for {@link ReadCache} default methods.
+ */
+@Tag(Tags.UNIT)
+class ReadCacheTest {
+
+    @Test
+    void defaultLifecycleMethodsAreNoOps() {
+        ReadCache cache = key -> "value-" + key;
+
+        Assertions.assertDoesNotThrow(() -> cache.init(null));
+        Assertions.assertDoesNotThrow(() -> cache.put("ignored"));
+        Assertions.assertDoesNotThrow(cache::putFinished);
+        Assertions.assertDoesNotThrow(cache::destroy);
+        Assertions.assertEquals("value-0", cache.get(0));
+    }
+
+    @Test
+    void getIsTheOnlyRequiredMethod() {
+        ReadCache cache = key -> null;
+
+        Assertions.assertNull(cache.get(1));
+        Assertions.assertDoesNotThrow(() -> cache.init(null));
+        Assertions.assertDoesNotThrow(() -> cache.put(null));
+        Assertions.assertDoesNotThrow(cache::putFinished);
+        Assertions.assertDoesNotThrow(cache::destroy);
+    }
+}

--- a/fesod-sheet/src/test/java/org/apache/fesod/sheet/cache/XlsCacheTest.java
+++ b/fesod-sheet/src/test/java/org/apache/fesod/sheet/cache/XlsCacheTest.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.fesod.sheet.cache;
+
+import org.apache.fesod.sheet.testkit.Tags;
+import org.apache.poi.hssf.record.SSTRecord;
+import org.apache.poi.hssf.record.common.UnicodeString;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for {@link XlsCache}.
+ */
+@Tag(Tags.UNIT)
+class XlsCacheTest {
+
+    @Test
+    void getReturnsSstStringByIndex() {
+        SSTRecord sstRecord = new SSTRecord();
+        int first = sstRecord.addString(new UnicodeString("alpha"));
+        int second = sstRecord.addString(new UnicodeString("beta"));
+        XlsCache cache = new XlsCache(sstRecord);
+
+        Assertions.assertEquals("alpha", cache.get(first));
+        Assertions.assertEquals("beta", cache.get(second));
+    }
+
+    @Test
+    void defaultMethodsDoNotChangeSstContents() {
+        SSTRecord sstRecord = new SSTRecord();
+        sstRecord.addString(new UnicodeString("original"));
+        XlsCache cache = new XlsCache(sstRecord);
+
+        cache.init(null);
+        cache.put("ignored");
+        cache.putFinished();
+        cache.destroy();
+
+        Assertions.assertEquals("original", cache.get(0));
+    }
+
+    @Test
+    void getReturnsUnicodeContent() {
+        SSTRecord sstRecord = new SSTRecord();
+        sstRecord.addString(new UnicodeString("中文"));
+        XlsCache cache = new XlsCache(sstRecord);
+
+        Assertions.assertEquals("中文", cache.get(0));
+    }
+}


### PR DESCRIPTION
## Purpose of the pull request

Give `ReadCache` no-op `default` methods so implementations that do not need lifecycle hooks (or `put`) no longer have to ship empty method bodies, and add unit coverage for the interface and all built-in implementations.


## What's changed?

`get(Integer)` stays abstract. The other methods default to no-ops:

| Method | Default | Still overridden by |
|---|---|---|
| `init` | no-op | `Ehcache` |
| `put` | no-op | `MapCache`, `Ehcache` |
| `get` | required | all implementations |
| `putFinished` | no-op | `Ehcache` |
| `destroy` | no-op | `Ehcache` |

Call sites are unchanged: xlsx still calls `init` / `put` / `putFinished` / `destroy`; xls `XlsCache` only needs `get` because the SST record is already populated.

Subclass surface after this change:

- `XlsCache` — `get` only
- `MapCache` — `put` + `get`
- `Ehcache` — unchanged; it still implements the full contract

Binary compatible for existing custom `ReadCache` implementations. Empty overrides can be removed, but they still compile if left in place.

Added `@Tag(unit)` tests:

- `ReadCacheTest` — a get-only implementation can rely on the default no-ops
- `MapCacheTest` — insertion order, `null`/empty values, negative keys, out-of-range `get`
- `XlsCacheTest` — SST index lookup, Unicode content, defaults do not mutate SST
- `EhcacheTest` — remainder flush, batch boundary, cross-batch cache miss, deprecated constructor, isolated instances; `destroy()` in `@AfterEach`