### PR TITLE
fix: bundle Incubating NOTICE with EasyExcel attribution in jars

### DIFF
--- a/fesod-common/src/main/resources/META-INF/NOTICE
+++ b/fesod-common/src/main/resources/META-INF/NOTICE
@@ -1,0 +1,11 @@
+Apache Fesod (Incubating) Common
+Copyright 2025-2026 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+This product contains significant parts that were originally based on software
+from Alibaba Group (EasyExcel <https://github.com/alibaba/easyexcel>) under
+the Apache License, Version 2.0 License.
+
+Copyright (C) 2022-2024 Alibaba Group Holding Ltd.

--- a/fesod-sheet/src/main/resources/META-INF/NOTICE
+++ b/fesod-sheet/src/main/resources/META-INF/NOTICE
@@ -1,0 +1,11 @@
+Apache Fesod (Incubating) Spreadsheet
+Copyright 2025-2026 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+This product contains significant parts that were originally based on software
+from Alibaba Group (EasyExcel <https://github.com/alibaba/easyexcel>) under
+the Apache License, Version 2.0 License.
+
+Copyright (C) 2022-2024 Alibaba Group Holding Ltd.


### PR DESCRIPTION
## Summary

- Add module-level `src/main/resources/META-INF/NOTICE` files for `fesod-common` and `fesod-sheet` so the jar NOTICE carries the "(Incubating)" marker and the Alibaba EasyExcel attribution.

The jar NOTICE files currently come from `apache-jar-resource-bundle` (inherited via the `org.apache:apache:31` parent), whose template only renders the module name and the ASF boilerplate. As a result, the NOTICE inside the `fesod-common` / `fesod-sheet` jars was missing both the "(Incubating)" marker and the Alibaba EasyExcel attribution that the repository root NOTICE carries. Module-authored `META-INF/NOTICE` resources override the generated ones - the same pattern `fesod-shaded` already uses.

Found during the 2.1.0-incubating RC3 review.

Fixes #1064

## Test plan

- [x] `mvn -pl fesod-common,fesod-sheet -am clean install` passes on current `main`
- [x] `unzip -p fesod-common/target/fesod-common-*.jar META-INF/NOTICE` shows "(Incubating) Common" and the Alibaba attribution
- [x] `unzip -p fesod-sheet/target/fesod-sheet-*.jar META-INF/NOTICE` shows "(Incubating) Spreadsheet" and the Alibaba attribution