### PR TITLE
chore: update gitattributes to exclude non-source files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -26,7 +26,7 @@ mvnw.cmd text eol=crlf
 
 # Exclude non-source artifacts from `git archive`
 .idea/ export-ignore
-.mvn/maven-wrapper.jar export-ignore
+.mvn/wrapper/maven-wrapper.jar export-ignore
 .github/ export-ignore
 .gitattributes export-ignore
 .gitignore export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -23,3 +23,10 @@ mvnw.cmd text eol=crlf
 *.sh text eol=lf
 *.bat text eol=crlf
 *.cmd text eol=crlf
+
+# Exclude non-source artifacts from `git archive`
+.idea/ export-ignore
+.mvn/maven-wrapper.jar export-ignore
+.github/ export-ignore
+.gitattributes export-ignore
+.gitignore export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -28,5 +28,6 @@ mvnw.cmd text eol=crlf
 .idea/ export-ignore
 .mvn/wrapper/maven-wrapper.jar export-ignore
 .github/ export-ignore
+.asf.yaml export-ignore
 .gitattributes export-ignore
 .gitignore export-ignore


### PR DESCRIPTION
## Purpose of the pull request

As title.

## What's changed?

Added `export-ignore` rules to exclude non-source artifacts from git archive.

## Checklist

- [x] I have read the [Contributor Guide](https://fesod.apache.org/community/contribution/).
- [x] I have written the necessary doc or comment.
- [x] I have added the necessary unit tests and all cases have passed.
