### PR TITLE
fix: make DataFormatter cache configuration-aware

### DIFF
--- a/fesod-sheet/src/main/java/org/apache/fesod/sheet/util/NumberDataFormatterUtils.java
+++ b/fesod-sheet/src/main/java/org/apache/fesod/sheet/util/NumberDataFormatterUtils.java
@@ -108,10 +108,8 @@ public class NumberDataFormatterUtils {
         Locale resolvedLocale = locale == null ? Locale.getDefault() : locale;
         boolean resolvedUseScientificFormat = Boolean.TRUE.equals(useScientificFormat);
         DataFormatterCache cache = DATA_FORMATTER_THREAD_LOCAL.get();
-        if (cache == null
-                || !cache.matches(resolvedUse1904windowing, resolvedLocale, resolvedUseScientificFormat)) {
-            cache = new DataFormatterCache(
-                    resolvedUse1904windowing, resolvedLocale, resolvedUseScientificFormat);
+        if (cache == null || !cache.matches(resolvedUse1904windowing, resolvedLocale, resolvedUseScientificFormat)) {
+            cache = new DataFormatterCache(resolvedUse1904windowing, resolvedLocale, resolvedUseScientificFormat);
             DATA_FORMATTER_THREAD_LOCAL.set(cache);
         }
         return cache.dataFormatter.format(data, dataFormat, dataFormatString);

--- a/fesod-sheet/src/main/java/org/apache/fesod/sheet/util/NumberDataFormatterUtils.java
+++ b/fesod-sheet/src/main/java/org/apache/fesod/sheet/util/NumberDataFormatterUtils.java
@@ -40,7 +40,28 @@ public class NumberDataFormatterUtils {
     /**
      * Cache DataFormatter.
      */
-    private static final ThreadLocal<DataFormatter> DATA_FORMATTER_THREAD_LOCAL = new ThreadLocal<DataFormatter>();
+    private static final ThreadLocal<DataFormatterCache> DATA_FORMATTER_THREAD_LOCAL =
+            new ThreadLocal<DataFormatterCache>();
+
+    private static final class DataFormatterCache {
+        private final boolean use1904windowing;
+        private final Locale locale;
+        private final boolean useScientificFormat;
+        private final DataFormatter dataFormatter;
+
+        private DataFormatterCache(boolean use1904windowing, Locale locale, boolean useScientificFormat) {
+            this.use1904windowing = use1904windowing;
+            this.locale = locale;
+            this.useScientificFormat = useScientificFormat;
+            this.dataFormatter = new DataFormatter(use1904windowing, locale, useScientificFormat);
+        }
+
+        private boolean matches(boolean use1904windowing, Locale locale, boolean useScientificFormat) {
+            return this.use1904windowing == use1904windowing
+                    && this.locale.equals(locale)
+                    && this.useScientificFormat == useScientificFormat;
+        }
+    }
 
     /**
      * Format number data.
@@ -83,12 +104,17 @@ public class NumberDataFormatterUtils {
             Boolean use1904windowing,
             Locale locale,
             Boolean useScientificFormat) {
-        DataFormatter dataFormatter = DATA_FORMATTER_THREAD_LOCAL.get();
-        if (dataFormatter == null) {
-            dataFormatter = new DataFormatter(use1904windowing, locale, useScientificFormat);
-            DATA_FORMATTER_THREAD_LOCAL.set(dataFormatter);
+        boolean resolvedUse1904windowing = Boolean.TRUE.equals(use1904windowing);
+        Locale resolvedLocale = locale == null ? Locale.getDefault() : locale;
+        boolean resolvedUseScientificFormat = Boolean.TRUE.equals(useScientificFormat);
+        DataFormatterCache cache = DATA_FORMATTER_THREAD_LOCAL.get();
+        if (cache == null
+                || !cache.matches(resolvedUse1904windowing, resolvedLocale, resolvedUseScientificFormat)) {
+            cache = new DataFormatterCache(
+                    resolvedUse1904windowing, resolvedLocale, resolvedUseScientificFormat);
+            DATA_FORMATTER_THREAD_LOCAL.set(cache);
         }
-        return dataFormatter.format(data, dataFormat, dataFormatString);
+        return cache.dataFormatter.format(data, dataFormat, dataFormatString);
     }
 
     public static void removeThreadLocalCache() {

--- a/fesod-sheet/src/test/java/org/apache/fesod/sheet/util/NumberDataFormatterUtilsTest.java
+++ b/fesod-sheet/src/test/java/org/apache/fesod/sheet/util/NumberDataFormatterUtilsTest.java
@@ -23,7 +23,6 @@ import java.lang.reflect.Field;
 import java.math.BigDecimal;
 import java.util.Locale;
 import org.apache.fesod.sheet.metadata.GlobalConfiguration;
-import org.apache.fesod.sheet.metadata.format.DataFormatter;
 import org.apache.fesod.sheet.testkit.Tags;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
@@ -89,18 +88,55 @@ class NumberDataFormatterUtilsTest {
     }
 
     @Test
+    void test_format_replacesCachedFormatterWhenLocaleChanges() {
+        Locale defaultLocale = Locale.getDefault();
+        try {
+            Locale.setDefault(Locale.KOREA);
+            String korean = NumberDataFormatterUtils.format(
+                    new BigDecimal("0.75"), (short) 18, "h:mm AM/PM", false, null, false);
+            String chinese = NumberDataFormatterUtils.format(
+                    new BigDecimal("0.75"), (short) 18, "h:mm AM/PM", false, Locale.CHINA, false);
+
+            Assertions.assertTrue(korean.endsWith("오후"));
+            Assertions.assertTrue(chinese.endsWith("下午"));
+        } finally {
+            Locale.setDefault(defaultLocale);
+        }
+    }
+
+    @Test
+    void test_format_replacesCachedFormatterWhenUse1904WindowingChanges() {
+        String date1900 = NumberDataFormatterUtils.format(
+                BigDecimal.ONE, (short) 14, "yyyy-mm-dd", false, Locale.US, false);
+        String date1904 = NumberDataFormatterUtils.format(
+                BigDecimal.ONE, (short) 14, "yyyy-mm-dd", true, Locale.US, false);
+
+        Assertions.assertEquals("1900-01-01", date1900);
+        Assertions.assertEquals("1904-01-02", date1904);
+    }
+
+    @Test
+    void test_format_replacesCachedFormatterWhenScientificFormatChanges() {
+        BigDecimal data = new BigDecimal("100000000000");
+        String plain = NumberDataFormatterUtils.format(data, null, "General", false, Locale.US, false);
+        String scientific = NumberDataFormatterUtils.format(data, null, "General", false, Locale.US, true);
+
+        Assertions.assertEquals("100000000000", plain);
+        Assertions.assertEquals("1E+11", scientific);
+    }
+
+    @Test
     void test_ThreadLocal_Cache_And_Remove() throws NoSuchFieldException, IllegalAccessException {
         Field field = NumberDataFormatterUtils.class.getDeclaredField("DATA_FORMATTER_THREAD_LOCAL");
         field.setAccessible(true);
 
-        @SuppressWarnings("unchecked")
-        ThreadLocal<DataFormatter> threadLocal = (ThreadLocal<DataFormatter>) field.get(null);
+        ThreadLocal<?> threadLocal = (ThreadLocal<?>) field.get(null);
 
         Assertions.assertNull(threadLocal.get());
 
         NumberDataFormatterUtils.format(new BigDecimal("1"), null, "0", false, Locale.US, false);
 
-        DataFormatter cachedFormatter = threadLocal.get();
+        Object cachedFormatter = threadLocal.get();
         Assertions.assertNotNull(cachedFormatter);
 
         NumberDataFormatterUtils.format(new BigDecimal("2"), null, "0", false, Locale.US, false);

--- a/fesod-sheet/src/test/java/org/apache/fesod/sheet/util/NumberDataFormatterUtilsTest.java
+++ b/fesod-sheet/src/test/java/org/apache/fesod/sheet/util/NumberDataFormatterUtilsTest.java
@@ -29,6 +29,8 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.parallel.ResourceLock;
+import org.junit.jupiter.api.parallel.Resources;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -88,6 +90,7 @@ class NumberDataFormatterUtilsTest {
     }
 
     @Test
+    @ResourceLock(Resources.LOCALE)
     void test_format_replacesCachedFormatterWhenLocaleChanges() {
         Locale defaultLocale = Locale.getDefault();
         try {

--- a/fesod-sheet/src/test/java/org/apache/fesod/sheet/util/NumberDataFormatterUtilsTest.java
+++ b/fesod-sheet/src/test/java/org/apache/fesod/sheet/util/NumberDataFormatterUtilsTest.java
@@ -109,10 +109,10 @@ class NumberDataFormatterUtilsTest {
 
     @Test
     void test_format_replacesCachedFormatterWhenUse1904WindowingChanges() {
-        String date1900 = NumberDataFormatterUtils.format(
-                BigDecimal.ONE, (short) 14, "yyyy-mm-dd", false, Locale.US, false);
-        String date1904 = NumberDataFormatterUtils.format(
-                BigDecimal.ONE, (short) 14, "yyyy-mm-dd", true, Locale.US, false);
+        String date1900 =
+                NumberDataFormatterUtils.format(BigDecimal.ONE, (short) 14, "yyyy-mm-dd", false, Locale.US, false);
+        String date1904 =
+                NumberDataFormatterUtils.format(BigDecimal.ONE, (short) 14, "yyyy-mm-dd", true, Locale.US, false);
 
         Assertions.assertEquals("1900-01-01", date1900);
         Assertions.assertEquals("1904-01-02", date1904);


### PR DESCRIPTION
<!--
Thanks very much for contributing to Apache Fesod (Incubating)! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

Closed: #ISSUE
Related: #ISSUE

-->

## Purpose of the pull request

<!-- Describe the purpose of this pull request. For example: Closed: #ISSUE-->

Closed: #1065

`NumberDataFormatterUtils` currently reuses the first `DataFormatter` created on a thread even when a later operation requests a different locale, date windowing mode, or scientific-format setting. This makes formatting order-dependent and can produce output in the wrong locale.

## What's changed?

<!--- Describe the change below, including rationale and design decisions -->

- Cache the `DataFormatter` together with its effective constructor configuration.
- Reuse the cached formatter only when `use1904windowing`, `locale`, and `useScientificFormat` all match; otherwise replace it.
- Add regression tests for sequential locale, 1904-windowing, and scientific-format changes while retaining coverage for cache reuse and explicit removal.
- Protect the test that changes the JVM default locale with JUnit's locale resource lock so it remains isolated under parallel test execution.

Verification:

- `fesod-sheet` test suite with the JVM default locale set to Korean: 897 tests passed.
- Locale-sensitive utility suites with the `parallel-tests` profile: 100 tests passed.
- GitHub Actions passed on JDK 8, 11, 17, 21, and 25, together with Spotless, license, and CodeQL checks.

## Checklist

- [x] I have read the [Contributor Guide](https://fesod.apache.org/community/contribution/).
- [x] I have written the necessary doc or comment.
- [x] I have added the necessary unit tests and all cases have passed.
