### PR TITLE
fix: default null scientific format option to false

### DIFF
--- a/fesod-sheet/src/main/java/org/apache/fesod/sheet/metadata/format/DataFormatter.java
+++ b/fesod-sheet/src/main/java/org/apache/fesod/sheet/metadata/format/DataFormatter.java
@@ -187,7 +187,7 @@ public class DataFormatter {
             this.locale = locale;
         }
 
-        if (use1904windowing == null) {
+        if (useScientificFormat == null) {
             this.useScientificFormat = Boolean.FALSE;
         } else {
             this.useScientificFormat = useScientificFormat;

--- a/fesod-sheet/src/test/java/org/apache/fesod/sheet/metadata/format/DataFormatterTest.java
+++ b/fesod-sheet/src/test/java/org/apache/fesod/sheet/metadata/format/DataFormatterTest.java
@@ -24,37 +24,24 @@ import java.util.Locale;
 import org.apache.fesod.sheet.testkit.Tags;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
 @Tag(Tags.UNIT)
 class DataFormatterTest {
 
     private static final BigDecimal LARGE_NUMBER = new BigDecimal("100000000000");
 
-    @Test
-    void test_format_defaultsNullScientificFormatToFalse() {
-        DataFormatter formatter = new DataFormatter(false, Locale.US, null);
+    @ParameterizedTest(name = "windowing={0}, scientific={1} -> {2}")
+    @CsvSource(
+            nullValues = "null",
+            value = {"false, null, 100000000000", "null, true, 1E+11", "null, false, 100000000000"})
+    void test_format_honorsScientificFormatWithNullableOptions(
+            Boolean use1904windowing, Boolean useScientificFormat, String expected) {
+        DataFormatter formatter = new DataFormatter(use1904windowing, Locale.US, useScientificFormat);
 
         String result = formatter.format(LARGE_NUMBER, null, "General");
 
-        Assertions.assertEquals("100000000000", result);
-    }
-
-    @Test
-    void test_format_honorsScientificFormatWhenWindowingIsNull() {
-        DataFormatter formatter = new DataFormatter(null, Locale.US, true);
-
-        String result = formatter.format(LARGE_NUMBER, null, "General");
-
-        Assertions.assertEquals("1E+11", result);
-    }
-
-    @Test
-    void test_format_honorsDisabledScientificFormatWhenWindowingIsNull() {
-        DataFormatter formatter = new DataFormatter(null, Locale.US, false);
-
-        String result = formatter.format(LARGE_NUMBER, null, "General");
-
-        Assertions.assertEquals("100000000000", result);
+        Assertions.assertEquals(expected, result);
     }
 }

--- a/fesod-sheet/src/test/java/org/apache/fesod/sheet/metadata/format/DataFormatterTest.java
+++ b/fesod-sheet/src/test/java/org/apache/fesod/sheet/metadata/format/DataFormatterTest.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.fesod.sheet.metadata.format;
+
+import java.math.BigDecimal;
+import java.util.Locale;
+import org.apache.fesod.sheet.testkit.Tags;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+@Tag(Tags.UNIT)
+class DataFormatterTest {
+
+    private static final BigDecimal LARGE_NUMBER = new BigDecimal("100000000000");
+
+    @Test
+    void test_format_defaultsNullScientificFormatToFalse() {
+        DataFormatter formatter = new DataFormatter(false, Locale.US, null);
+
+        String result = formatter.format(LARGE_NUMBER, null, "General");
+
+        Assertions.assertEquals("100000000000", result);
+    }
+
+    @Test
+    void test_format_honorsScientificFormatWhenWindowingIsNull() {
+        DataFormatter formatter = new DataFormatter(null, Locale.US, true);
+
+        String result = formatter.format(LARGE_NUMBER, null, "General");
+
+        Assertions.assertEquals("1E+11", result);
+    }
+
+    @Test
+    void test_format_honorsDisabledScientificFormatWhenWindowingIsNull() {
+        DataFormatter formatter = new DataFormatter(null, Locale.US, false);
+
+        String result = formatter.format(LARGE_NUMBER, null, "General");
+
+        Assertions.assertEquals("100000000000", result);
+    }
+}


### PR DESCRIPTION
<!--
Thanks very much for contributing to Apache Fesod (Incubating)! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

Closed: #ISSUE
Related: #ISSUE

-->

## Purpose of the pull request

<!-- Describe the purpose of this pull request. For example: Closed: #ISSUE-->

While reviewing my formatter cache changes in #1068, I noticed a bug in the `DataFormatter` constructor when either formatting option is null.

For example, `new DataFormatter(false, Locale.US, null)` should use the default of `false` for scientific notation. Before this fix, formatting `100000000000` with the `General` format throws a `NullPointerException`. After this fix, it returns `100000000000` as expected.

Another example is `new DataFormatter(null, Locale.US, true)`. Before this fix, formatting the same number returns `100000000000`, even though scientific notation is enabled. After this fix, it returns `1E+11`.

The constructor was checking `use1904windowing` instead of `useScientificFormat` when applying the scientific-notation default. This PR changes that one condition. The examples call the constructor directly because `NumberDataFormatterUtils` already converts null options to their defaults after #1068.

## What's changed?

<!--- Describe the change below, including rationale and design decisions -->

- Fix the condition to check `useScientificFormat`, preserving its documented default of `false`.
- Add a parameterized constructor regression test covering null, enabled, and disabled scientific-format options, including null date-windowing options.

Verification:

All 919 `fesod-sheet` tests passed on JDK 11 with the default locale set to Korean, and the build completed successfully.

## Checklist

- [x] I have read the [Contributor Guide](https://fesod.apache.org/community/contribution/).
- [x] I have written the necessary doc or comment.
- [x] I have added the necessary unit tests and all cases have passed.
