### PR TITLE
chore: prepare 2.1.0-incubating release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,7 +79,7 @@ under the License.
     </modules>
 
     <properties>
-        <revision>2.1.0-SNAPSHOT</revision>
+        <revision>2.1.0-incubating</revision>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <!-- Clear the parent `apache` POM's stale outputTimestamp (2023): apache-jar-resource-bundle derives the JAR
              NOTICE copyright end-year from it, and a stale value yields an inverted "2025-2023" range. An empty value


### PR DESCRIPTION
Release prep for Apache Fesod 2.1.0-incubating.

Ref: https://github.com/apache/fesod/issues/1083

## Changes

### Version bump
- `pom.xml` `<revision>`: `2.1.0-SNAPSHOT` → `2.1.0-incubating`

### Changelog
Covered by the planning issue #1083, which lists 95 merged PRs since `2.0.2-incubating` grouped by category (11 features, 24 bug fixes, 17 documentation, 20 dependencies, 23 other). Fesod does not maintain a standalone changelog file; release notes are published with the site/docs.

### NOTICE/LICENSE
No changes required — upstream NOTICE already carries the Incubating banner (2025-2026) and the EasyExcel attribution ([#1066](https://github.com/apache/fesod/pull/1066)). No Category-X dependencies in the diff.

## Checklist (RM)
- [x] Version bump is correct in all manifest files
- [x] Changelog entry covers the intended scope
- [ ] NOTICE attribution changes are justified
- [x] No Category-X dependency appears in the diff

Generated by `release-prepare` (magpie-release-prepare).