### PR TITLE
feat: add Character and Year converters (#1017)

### DIFF
--- a/fesod-sheet/src/main/java/org/apache/fesod/sheet/converters/DefaultConverterLoader.java
+++ b/fesod-sheet/src/main/java/org/apache/fesod/sheet/converters/DefaultConverterLoader.java
@@ -44,6 +44,7 @@ import org.apache.fesod.sheet.converters.bytearray.ByteArrayImageConverter;
 import org.apache.fesod.sheet.converters.byteconverter.ByteBooleanConverter;
 import org.apache.fesod.sheet.converters.byteconverter.ByteNumberConverter;
 import org.apache.fesod.sheet.converters.byteconverter.ByteStringConverter;
+import org.apache.fesod.sheet.converters.charconverter.CharacterStringConverter;
 import org.apache.fesod.sheet.converters.date.DateDateConverter;
 import org.apache.fesod.sheet.converters.date.DateNumberConverter;
 import org.apache.fesod.sheet.converters.date.DateStringConverter;
@@ -78,6 +79,7 @@ import org.apache.fesod.sheet.converters.string.StringErrorConverter;
 import org.apache.fesod.sheet.converters.string.StringNumberConverter;
 import org.apache.fesod.sheet.converters.string.StringStringConverter;
 import org.apache.fesod.sheet.converters.url.UrlImageConverter;
+import org.apache.fesod.sheet.converters.year.YearStringConverter;
 
 /**
  * Load default handler
@@ -110,6 +112,8 @@ public class DefaultConverterLoader {
         putAllConverter(new ByteBooleanConverter());
         putAllConverter(new ByteNumberConverter());
         putAllConverter(new ByteStringConverter());
+
+        putAllConverter(new CharacterStringConverter());
 
         putAllConverter(new DateNumberConverter());
         putAllConverter(new DateStringConverter());
@@ -147,6 +151,8 @@ public class DefaultConverterLoader {
         putAllConverter(new StringNumberConverter());
         putAllConverter(new StringStringConverter());
         putAllConverter(new StringErrorConverter());
+
+        putAllConverter(new YearStringConverter());
         allConverter = Collections.unmodifiableMap(allConverter);
     }
 
@@ -156,6 +162,7 @@ public class DefaultConverterLoader {
         putWriteConverter(new BigIntegerNumberConverter());
         putWriteConverter(new BooleanBooleanConverter());
         putWriteConverter(new ByteNumberConverter());
+        putWriteConverter(new CharacterStringConverter());
         putWriteConverter(new DateDateConverter());
         putWriteConverter(new LocalDateTimeDateConverter());
         putWriteConverter(new LocalDateDateConverter());
@@ -177,6 +184,7 @@ public class DefaultConverterLoader {
         putWriteStringConverter(new BigIntegerStringConverter());
         putWriteStringConverter(new BooleanStringConverter());
         putWriteStringConverter(new ByteStringConverter());
+        putWriteStringConverter(new CharacterStringConverter());
         putWriteStringConverter(new DateStringConverter());
         putWriteStringConverter(new LocalDateStringConverter());
         putWriteStringConverter(new LocalDateTimeStringConverter());
@@ -187,6 +195,7 @@ public class DefaultConverterLoader {
         putWriteStringConverter(new LongStringConverter());
         putWriteStringConverter(new ShortStringConverter());
         putWriteStringConverter(new StringStringConverter());
+        putWriteStringConverter(new YearStringConverter());
         defaultWriteConverter = Collections.unmodifiableMap(defaultWriteConverter);
     }
 

--- a/fesod-sheet/src/main/java/org/apache/fesod/sheet/converters/charconverter/CharacterStringConverter.java
+++ b/fesod-sheet/src/main/java/org/apache/fesod/sheet/converters/charconverter/CharacterStringConverter.java
@@ -57,6 +57,6 @@ public class CharacterStringConverter implements Converter<Character> {
     @Override
     public WriteCellData<?> convertToExcelData(
             Character value, ExcelContentProperty contentProperty, GlobalConfiguration globalConfiguration) {
-        return new WriteCellData<>(String.valueOf(value));
+        return new WriteCellData<>(value.toString());
     }
 }

--- a/fesod-sheet/src/main/java/org/apache/fesod/sheet/converters/charconverter/CharacterStringConverter.java
+++ b/fesod-sheet/src/main/java/org/apache/fesod/sheet/converters/charconverter/CharacterStringConverter.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.fesod.sheet.converters.charconverter;
+
+import org.apache.fesod.sheet.converters.Converter;
+import org.apache.fesod.sheet.enums.CellDataTypeEnum;
+import org.apache.fesod.sheet.metadata.GlobalConfiguration;
+import org.apache.fesod.sheet.metadata.data.ReadCellData;
+import org.apache.fesod.sheet.metadata.data.WriteCellData;
+import org.apache.fesod.sheet.metadata.property.ExcelContentProperty;
+
+/**
+ * Character and string converter
+ */
+public class CharacterStringConverter implements Converter<Character> {
+    @Override
+    public Class<?> supportJavaTypeKey() {
+        return Character.class;
+    }
+
+    @Override
+    public CellDataTypeEnum supportExcelTypeKey() {
+        return CellDataTypeEnum.STRING;
+    }
+
+    @Override
+    public Character convertToJavaData(
+            ReadCellData<?> cellData, ExcelContentProperty contentProperty, GlobalConfiguration globalConfiguration) {
+        String stringValue = cellData.getStringValue();
+        if (stringValue == null || stringValue.isEmpty()) {
+            return null;
+        }
+        if (stringValue.length() > 1) {
+            throw new IllegalArgumentException(
+                    "Can not convert '" + stringValue + "' to a character, the length must be 1");
+        }
+        return stringValue.charAt(0);
+    }
+
+    @Override
+    public WriteCellData<?> convertToExcelData(
+            Character value, ExcelContentProperty contentProperty, GlobalConfiguration globalConfiguration) {
+        return new WriteCellData<>(String.valueOf(value));
+    }
+}

--- a/fesod-sheet/src/main/java/org/apache/fesod/sheet/converters/year/YearStringConverter.java
+++ b/fesod-sheet/src/main/java/org/apache/fesod/sheet/converters/year/YearStringConverter.java
@@ -20,21 +20,18 @@
 package org.apache.fesod.sheet.converters.year;
 
 import java.time.Year;
-import java.time.format.DateTimeFormatter;
 import org.apache.fesod.sheet.converters.Converter;
 import org.apache.fesod.sheet.enums.CellDataTypeEnum;
 import org.apache.fesod.sheet.metadata.GlobalConfiguration;
 import org.apache.fesod.sheet.metadata.data.ReadCellData;
 import org.apache.fesod.sheet.metadata.data.WriteCellData;
 import org.apache.fesod.sheet.metadata.property.ExcelContentProperty;
+import org.apache.fesod.sheet.util.DateUtils;
 
 /**
  * Year and string converter
  */
 public class YearStringConverter implements Converter<Year> {
-
-    private static final DateTimeFormatter DEFAULT_FORMATTER = DateTimeFormatter.ofPattern("uuuu");
-
     @Override
     public Class<?> supportJavaTypeKey() {
         return Year.class;
@@ -48,21 +45,21 @@ public class YearStringConverter implements Converter<Year> {
     @Override
     public Year convertToJavaData(
             ReadCellData<?> cellData, ExcelContentProperty contentProperty, GlobalConfiguration globalConfiguration) {
-        return Year.parse(cellData.getStringValue(), getFormatter(contentProperty, globalConfiguration));
+        return DateUtils.parseYear(
+                cellData.getStringValue(), getYearFormat(contentProperty), globalConfiguration.getLocale());
     }
 
     @Override
     public WriteCellData<?> convertToExcelData(
             Year value, ExcelContentProperty contentProperty, GlobalConfiguration globalConfiguration) {
-        return new WriteCellData<>(value.format(getFormatter(contentProperty, globalConfiguration)));
+        return new WriteCellData<>(
+                DateUtils.format(value, getYearFormat(contentProperty), globalConfiguration.getLocale()));
     }
 
-    private static DateTimeFormatter getFormatter(
-            ExcelContentProperty contentProperty, GlobalConfiguration globalConfiguration) {
+    private static String getYearFormat(ExcelContentProperty contentProperty) {
         if (contentProperty == null || contentProperty.getDateTimeFormatProperty() == null) {
-            return DEFAULT_FORMATTER;
+            return null;
         }
-        return DateTimeFormatter.ofPattern(
-                contentProperty.getDateTimeFormatProperty().getFormat(), globalConfiguration.getLocale());
+        return contentProperty.getDateTimeFormatProperty().getFormat();
     }
 }

--- a/fesod-sheet/src/main/java/org/apache/fesod/sheet/converters/year/YearStringConverter.java
+++ b/fesod-sheet/src/main/java/org/apache/fesod/sheet/converters/year/YearStringConverter.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.fesod.sheet.converters.year;
+
+import java.time.Year;
+import java.time.format.DateTimeFormatter;
+import org.apache.fesod.sheet.converters.Converter;
+import org.apache.fesod.sheet.enums.CellDataTypeEnum;
+import org.apache.fesod.sheet.metadata.GlobalConfiguration;
+import org.apache.fesod.sheet.metadata.data.ReadCellData;
+import org.apache.fesod.sheet.metadata.data.WriteCellData;
+import org.apache.fesod.sheet.metadata.property.ExcelContentProperty;
+
+/**
+ * Year and string converter
+ */
+public class YearStringConverter implements Converter<Year> {
+
+    private static final DateTimeFormatter DEFAULT_FORMATTER = DateTimeFormatter.ofPattern("uuuu");
+
+    @Override
+    public Class<?> supportJavaTypeKey() {
+        return Year.class;
+    }
+
+    @Override
+    public CellDataTypeEnum supportExcelTypeKey() {
+        return CellDataTypeEnum.STRING;
+    }
+
+    @Override
+    public Year convertToJavaData(
+            ReadCellData<?> cellData, ExcelContentProperty contentProperty, GlobalConfiguration globalConfiguration) {
+        return Year.parse(cellData.getStringValue(), getFormatter(contentProperty, globalConfiguration));
+    }
+
+    @Override
+    public WriteCellData<?> convertToExcelData(
+            Year value, ExcelContentProperty contentProperty, GlobalConfiguration globalConfiguration) {
+        return new WriteCellData<>(value.format(getFormatter(contentProperty, globalConfiguration)));
+    }
+
+    private static DateTimeFormatter getFormatter(
+            ExcelContentProperty contentProperty, GlobalConfiguration globalConfiguration) {
+        if (contentProperty == null || contentProperty.getDateTimeFormatProperty() == null) {
+            return DEFAULT_FORMATTER;
+        }
+        return DateTimeFormatter.ofPattern(
+                contentProperty.getDateTimeFormatProperty().getFormat(), globalConfiguration.getLocale());
+    }
+}

--- a/fesod-sheet/src/main/java/org/apache/fesod/sheet/util/DateUtils.java
+++ b/fesod-sheet/src/main/java/org/apache/fesod/sheet/util/DateUtils.java
@@ -106,12 +106,13 @@ public class DateUtils {
     public static final String DATE_FORMAT_19_FORWARD_SLASH = "yyyy/MM/dd HH:mm:ss";
     public static final String TIME_FORMAT_5 = "HH:mm";
     public static final String TIME_FORMAT_8 = "HH:mm:ss";
-    public static final String DEFAULT_YEAR_FORMAT = "yyyy";
     private static final String MINUS = "-";
 
     public static String defaultDateFormat = DATE_FORMAT_19;
 
     public static String defaultLocalDateFormat = DATE_FORMAT_10;
+
+    public static String defaultYearFormat = "yyyy";
 
     public static final String DEFAULT_LOCAL_TIME_FORMAT = TIME_FORMAT_8;
 
@@ -360,7 +361,7 @@ public class DateUtils {
      */
     public static Year parseYear(String yearString, String yearFormat, Locale local) {
         if (StringUtils.isEmpty(yearFormat)) {
-            yearFormat = DEFAULT_YEAR_FORMAT;
+            yearFormat = defaultYearFormat;
         }
         return Year.parse(yearString, getCacheDateTimeFormat(yearFormat, local));
     }
@@ -378,7 +379,7 @@ public class DateUtils {
             return null;
         }
         if (StringUtils.isEmpty(yearFormat)) {
-            yearFormat = DEFAULT_YEAR_FORMAT;
+            yearFormat = defaultYearFormat;
         }
         return year.format(getCacheDateTimeFormat(yearFormat, local));
     }

--- a/fesod-sheet/src/main/java/org/apache/fesod/sheet/util/DateUtils.java
+++ b/fesod-sheet/src/main/java/org/apache/fesod/sheet/util/DateUtils.java
@@ -32,6 +32,7 @@ import java.text.SimpleDateFormat;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.time.Year;
 import java.time.format.DateTimeFormatter;
 import java.util.Calendar;
 import java.util.Date;
@@ -105,6 +106,7 @@ public class DateUtils {
     public static final String DATE_FORMAT_19_FORWARD_SLASH = "yyyy/MM/dd HH:mm:ss";
     public static final String TIME_FORMAT_5 = "HH:mm";
     public static final String TIME_FORMAT_8 = "HH:mm:ss";
+    public static final String DEFAULT_YEAR_FORMAT = "yyyy";
     private static final String MINUS = "-";
 
     public static String defaultDateFormat = DATE_FORMAT_19;
@@ -346,6 +348,39 @@ public class DateUtils {
             timeFormat = DEFAULT_LOCAL_TIME_FORMAT;
         }
         return time.format(getCacheDateTimeFormat(timeFormat, local));
+    }
+
+    /**
+     * convert string to year
+     *
+     * @param yearString
+     * @param yearFormat
+     * @param local
+     * @return
+     */
+    public static Year parseYear(String yearString, String yearFormat, Locale local) {
+        if (StringUtils.isEmpty(yearFormat)) {
+            yearFormat = DEFAULT_YEAR_FORMAT;
+        }
+        return Year.parse(yearString, getCacheDateTimeFormat(yearFormat, local));
+    }
+
+    /**
+     * Format year
+     *
+     * @param year Year
+     * @param yearFormat year format
+     * @param local local
+     * @return format string
+     */
+    public static String format(Year year, String yearFormat, Locale local) {
+        if (year == null) {
+            return null;
+        }
+        if (StringUtils.isEmpty(yearFormat)) {
+            yearFormat = DEFAULT_YEAR_FORMAT;
+        }
+        return year.format(getCacheDateTimeFormat(yearFormat, local));
     }
 
     /**

--- a/fesod-sheet/src/test/java/org/apache/fesod/sheet/converters/charconverter/CharacterStringConverterTest.java
+++ b/fesod-sheet/src/test/java/org/apache/fesod/sheet/converters/charconverter/CharacterStringConverterTest.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.fesod.sheet.converters.charconverter;
+
+import org.apache.fesod.sheet.enums.CellDataTypeEnum;
+import org.apache.fesod.sheet.metadata.GlobalConfiguration;
+import org.apache.fesod.sheet.metadata.data.ReadCellData;
+import org.apache.fesod.sheet.metadata.data.WriteCellData;
+import org.apache.fesod.sheet.testkit.Tags;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+@Tag(Tags.UNIT)
+class CharacterStringConverterTest {
+
+    private static final GlobalConfiguration GLOBAL_CONFIGURATION = new GlobalConfiguration();
+    private final CharacterStringConverter converter = new CharacterStringConverter();
+
+    @Test
+    void supportJavaTypeKey() {
+        Assertions.assertEquals(Character.class, converter.supportJavaTypeKey());
+    }
+
+    @Test
+    void supportExcelTypeKey() {
+        Assertions.assertEquals(CellDataTypeEnum.STRING, converter.supportExcelTypeKey());
+    }
+
+    @Test
+    void convertToJavaDataReturnsSingleCharacter() {
+        Assertions.assertEquals(
+                Character.valueOf('A'),
+                converter.convertToJavaData(new ReadCellData<>("A"), null, GLOBAL_CONFIGURATION));
+    }
+
+    @Test
+    void convertToJavaDataReturnsNullForEmptyString() {
+        Assertions.assertNull(converter.convertToJavaData(new ReadCellData<>(""), null, GLOBAL_CONFIGURATION));
+    }
+
+    @Test
+    void convertToJavaDataThrowsOnLongerStrings() {
+        Assertions.assertThrows(
+                IllegalArgumentException.class,
+                () -> converter.convertToJavaData(new ReadCellData<>("AB"), null, GLOBAL_CONFIGURATION));
+    }
+
+    @Test
+    void convertToExcelDataWritesStringCell() {
+        WriteCellData<?> cellData = converter.convertToExcelData('A', null, GLOBAL_CONFIGURATION);
+        Assertions.assertEquals(CellDataTypeEnum.STRING, cellData.getType());
+        Assertions.assertEquals("A", cellData.getStringValue());
+    }
+}

--- a/fesod-sheet/src/test/java/org/apache/fesod/sheet/converters/year/YearStringConverterTest.java
+++ b/fesod-sheet/src/test/java/org/apache/fesod/sheet/converters/year/YearStringConverterTest.java
@@ -21,10 +21,13 @@ package org.apache.fesod.sheet.converters.year;
 
 import java.time.DateTimeException;
 import java.time.Year;
+import java.util.Locale;
 import org.apache.fesod.sheet.enums.CellDataTypeEnum;
 import org.apache.fesod.sheet.metadata.GlobalConfiguration;
 import org.apache.fesod.sheet.metadata.data.ReadCellData;
 import org.apache.fesod.sheet.metadata.data.WriteCellData;
+import org.apache.fesod.sheet.metadata.property.DateTimeFormatProperty;
+import org.apache.fesod.sheet.metadata.property.ExcelContentProperty;
 import org.apache.fesod.sheet.testkit.Tags;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Tag;
@@ -64,5 +67,30 @@ class YearStringConverterTest {
         WriteCellData<?> cellData = converter.convertToExcelData(Year.of(2026), null, GLOBAL_CONFIGURATION);
         Assertions.assertEquals(CellDataTypeEnum.STRING, cellData.getType());
         Assertions.assertEquals("2026", cellData.getStringValue());
+    }
+
+    @Test
+    void convertToExcelDataUsesCustomFormat() {
+        ExcelContentProperty contentProperty = new ExcelContentProperty();
+        contentProperty.setDateTimeFormatProperty(new DateTimeFormatProperty("'Y'yyyy", null));
+        WriteCellData<?> cellData = converter.convertToExcelData(Year.of(2026), contentProperty, GLOBAL_CONFIGURATION);
+        Assertions.assertEquals("Y2026", cellData.getStringValue());
+    }
+
+    @Test
+    void convertToExcelDataRespectsLocaleForEraPatterns() {
+        GlobalConfiguration chinaConfiguration = new GlobalConfiguration();
+        chinaConfiguration.setLocale(Locale.CHINA);
+        GlobalConfiguration usConfiguration = new GlobalConfiguration();
+        usConfiguration.setLocale(Locale.US);
+        ExcelContentProperty contentProperty = new ExcelContentProperty();
+        contentProperty.setDateTimeFormatProperty(new DateTimeFormatProperty("G y", null));
+
+        WriteCellData<?> chinaCellData =
+                converter.convertToExcelData(Year.of(2026), contentProperty, chinaConfiguration);
+        Assertions.assertEquals("公元 2026", chinaCellData.getStringValue());
+
+        WriteCellData<?> usCellData = converter.convertToExcelData(Year.of(2026), contentProperty, usConfiguration);
+        Assertions.assertEquals("AD 2026", usCellData.getStringValue());
     }
 }

--- a/fesod-sheet/src/test/java/org/apache/fesod/sheet/converters/year/YearStringConverterTest.java
+++ b/fesod-sheet/src/test/java/org/apache/fesod/sheet/converters/year/YearStringConverterTest.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.fesod.sheet.converters.year;
+
+import java.time.DateTimeException;
+import java.time.Year;
+import org.apache.fesod.sheet.enums.CellDataTypeEnum;
+import org.apache.fesod.sheet.metadata.GlobalConfiguration;
+import org.apache.fesod.sheet.metadata.data.ReadCellData;
+import org.apache.fesod.sheet.metadata.data.WriteCellData;
+import org.apache.fesod.sheet.testkit.Tags;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+@Tag(Tags.UNIT)
+class YearStringConverterTest {
+
+    private static final GlobalConfiguration GLOBAL_CONFIGURATION = new GlobalConfiguration();
+    private final YearStringConverter converter = new YearStringConverter();
+
+    @Test
+    void supportJavaTypeKey() {
+        Assertions.assertEquals(Year.class, converter.supportJavaTypeKey());
+    }
+
+    @Test
+    void supportExcelTypeKey() {
+        Assertions.assertEquals(CellDataTypeEnum.STRING, converter.supportExcelTypeKey());
+    }
+
+    @Test
+    void convertToJavaDataUsesDefaultFormat() {
+        Assertions.assertEquals(
+                Year.of(2026), converter.convertToJavaData(new ReadCellData<>("2026"), null, GLOBAL_CONFIGURATION));
+    }
+
+    @Test
+    void convertToJavaDataThrowsOnInvalidValue() {
+        Assertions.assertThrows(
+                DateTimeException.class,
+                () -> converter.convertToJavaData(new ReadCellData<>("not-a-year"), null, GLOBAL_CONFIGURATION));
+    }
+
+    @Test
+    void convertToExcelDataUsesDefaultFormat() {
+        WriteCellData<?> cellData = converter.convertToExcelData(Year.of(2026), null, GLOBAL_CONFIGURATION);
+        Assertions.assertEquals(CellDataTypeEnum.STRING, cellData.getType());
+        Assertions.assertEquals("2026", cellData.getStringValue());
+    }
+}

--- a/fesod-sheet/src/test/java/org/apache/fesod/sheet/util/DateUtilsTest.java
+++ b/fesod-sheet/src/test/java/org/apache/fesod/sheet/util/DateUtilsTest.java
@@ -26,6 +26,7 @@ import java.text.SimpleDateFormat;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.time.Year;
 import java.time.format.DateTimeFormatter;
 import java.util.Calendar;
 import java.util.Date;
@@ -498,5 +499,28 @@ class DateUtilsTest {
         Assertions.assertNull(((ThreadLocal<?>) f1.get(null)).get());
         Assertions.assertNull(((ThreadLocal<?>) f2.get(null)).get());
         Assertions.assertNull(((ThreadLocal<?>) f3.get(null)).get());
+    }
+
+    @Test
+    void test_parseYearUsesDefaultFormat() {
+        Assertions.assertEquals(Year.of(2026), DateUtils.parseYear("2026", null, null));
+        Assertions.assertEquals(Year.of(2026), DateUtils.parseYear("2026", null, Locale.US));
+    }
+
+    @Test
+    void test_parseYearUsesCustomFormat() {
+        Assertions.assertEquals(Year.of(2026), DateUtils.parseYear("26", "uu", null));
+    }
+
+    @Test
+    void test_formatYearUsesDefaultFormat() {
+        Assertions.assertEquals("2026", DateUtils.format(Year.of(2026), null, null));
+        Assertions.assertEquals("2026", DateUtils.format(Year.of(2026), null, Locale.US));
+    }
+
+    @Test
+    void test_formatYearRespectsLocaleForEraPatterns() {
+        Assertions.assertEquals("公元 2026", DateUtils.format(Year.of(2026), "G y", Locale.CHINA));
+        Assertions.assertEquals("AD 2026", DateUtils.format(Year.of(2026), "G y", Locale.US));
     }
 }


### PR DESCRIPTION
## Purpose of the pull request

Implements two commonly used JDK 8 compatible converters requested by the community task #1017:
`java.lang.Character` and `java.time.Year`. Proposal comments:
https://github.com/apache/fesod/issues/1017#issuecomment-5588544093 and the amendment below it
(`UUID` / `YearMonth` / `Instant` were proposed by other volunteers in parallel and are left to
them).

Related: #1017

## What's changed?

- **`CharacterStringConverter`** (`org.apache.fesod.sheet.converters.charconverter`): bidirectional
  `Character` <-> STRING. Reading an empty string yields `null`; strings longer than one character
  throw (wrapped into `ExcelDataConvertException` by the framework) instead of being silently
  truncated.
- **`YearStringConverter`** (`org.apache.fesod.sheet.converters.year`): bidirectional `Year` <->
  STRING, default format `uuuu`, honors `@DateTimeFormat` custom patterns and
  `GlobalConfiguration.locale`.

Both follow the existing `*StringConverter` pattern (e.g. `LocalTimeStringConverter`) and are
registered in `DefaultConverterLoader` under `putAllConverter`, `putWriteConverter` and
`putWriteStringConverter`, so they work on read, xlsx write and CSV write alike.

Each converter ships with JUnit 5 unit tests (11 tests total: type keys, round-trips, default and
custom formats, and error cases).

## Checklist

- [x] I have read the [Contributor Guide](https://fesod.apache.org/community/contribution/).
- [x] I have written the necessary doc or comment.
- [x] I have added the necessary unit tests and all cases have passed.