### PR TITLE
feat: support Instant string conversion

### DIFF
--- a/fesod-sheet/src/main/java/org/apache/fesod/sheet/converters/DefaultConverterLoader.java
+++ b/fesod-sheet/src/main/java/org/apache/fesod/sheet/converters/DefaultConverterLoader.java
@@ -55,6 +55,7 @@ import org.apache.fesod.sheet.converters.floatconverter.FloatBooleanConverter;
 import org.apache.fesod.sheet.converters.floatconverter.FloatNumberConverter;
 import org.apache.fesod.sheet.converters.floatconverter.FloatStringConverter;
 import org.apache.fesod.sheet.converters.inputstream.InputStreamImageConverter;
+import org.apache.fesod.sheet.converters.instant.InstantStringConverter;
 import org.apache.fesod.sheet.converters.integer.IntegerBooleanConverter;
 import org.apache.fesod.sheet.converters.integer.IntegerNumberConverter;
 import org.apache.fesod.sheet.converters.integer.IntegerStringConverter;
@@ -123,6 +124,8 @@ public class DefaultConverterLoader {
         putAllConverter(new LocalTimeNumberConverter());
         putAllConverter(new LocalTimeStringConverter());
 
+        putAllConverter(new InstantStringConverter());
+
         putAllConverter(new DoubleBooleanConverter());
         putAllConverter(new DoubleNumberConverter());
         putAllConverter(new DoubleStringConverter());
@@ -160,6 +163,7 @@ public class DefaultConverterLoader {
         putWriteConverter(new LocalDateTimeDateConverter());
         putWriteConverter(new LocalDateDateConverter());
         putWriteConverter(new LocalTimeDateConverter());
+        putWriteConverter(new InstantStringConverter());
         putWriteConverter(new DoubleNumberConverter());
         putWriteConverter(new FloatNumberConverter());
         putWriteConverter(new IntegerNumberConverter());
@@ -181,6 +185,7 @@ public class DefaultConverterLoader {
         putWriteStringConverter(new LocalDateStringConverter());
         putWriteStringConverter(new LocalDateTimeStringConverter());
         putWriteStringConverter(new LocalTimeStringConverter());
+        putWriteStringConverter(new InstantStringConverter());
         putWriteStringConverter(new DoubleStringConverter());
         putWriteStringConverter(new FloatStringConverter());
         putWriteStringConverter(new IntegerStringConverter());

--- a/fesod-sheet/src/main/java/org/apache/fesod/sheet/converters/instant/InstantStringConverter.java
+++ b/fesod-sheet/src/main/java/org/apache/fesod/sheet/converters/instant/InstantStringConverter.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.fesod.sheet.converters.instant;
+
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import org.apache.fesod.sheet.converters.Converter;
+import org.apache.fesod.sheet.enums.CellDataTypeEnum;
+import org.apache.fesod.sheet.metadata.GlobalConfiguration;
+import org.apache.fesod.sheet.metadata.data.ReadCellData;
+import org.apache.fesod.sheet.metadata.data.WriteCellData;
+import org.apache.fesod.sheet.metadata.property.ExcelContentProperty;
+
+/**
+ * Instant and ISO-8601 string converter.
+ */
+public class InstantStringConverter implements Converter<Instant> {
+
+    @Override
+    public Class<Instant> supportJavaTypeKey() {
+        return Instant.class;
+    }
+
+    @Override
+    public CellDataTypeEnum supportExcelTypeKey() {
+        return CellDataTypeEnum.STRING;
+    }
+
+    @Override
+    public Instant convertToJavaData(
+            ReadCellData<?> cellData, ExcelContentProperty contentProperty, GlobalConfiguration globalConfiguration) {
+        return OffsetDateTime.parse(cellData.getStringValue()).toInstant();
+    }
+
+    @Override
+    public WriteCellData<?> convertToExcelData(
+            Instant value, ExcelContentProperty contentProperty, GlobalConfiguration globalConfiguration) {
+        return new WriteCellData<>(value.toString());
+    }
+}

--- a/fesod-sheet/src/test/java/org/apache/fesod/sheet/converters/DefaultConverterLoaderTest.java
+++ b/fesod-sheet/src/test/java/org/apache/fesod/sheet/converters/DefaultConverterLoaderTest.java
@@ -19,9 +19,11 @@
 
 package org.apache.fesod.sheet.converters;
 
+import java.time.Instant;
 import java.time.LocalTime;
 import java.util.Map;
 import org.apache.fesod.sheet.converters.ConverterKeyBuild.ConverterKey;
+import org.apache.fesod.sheet.converters.instant.InstantStringConverter;
 import org.apache.fesod.sheet.converters.localtime.LocalTimeDateConverter;
 import org.apache.fesod.sheet.converters.localtime.LocalTimeNumberConverter;
 import org.apache.fesod.sheet.converters.localtime.LocalTimeStringConverter;
@@ -65,6 +67,21 @@ public class DefaultConverterLoaderTest {
         Assertions.assertInstanceOf(
                 LocalTimeStringConverter.class,
                 writeConverter.get(ConverterKeyBuild.buildKey(LocalTime.class, CellDataTypeEnum.STRING)));
+    }
+
+    @Test
+    void loadConvertersRegistersInstantStringConverter() {
+        Map<ConverterKey, Converter<?>> allConverter = DefaultConverterLoader.loadAllConverter();
+        Assertions.assertInstanceOf(
+                InstantStringConverter.class,
+                allConverter.get(ConverterKeyBuild.buildKey(Instant.class, CellDataTypeEnum.STRING)));
+
+        Map<ConverterKey, Converter<?>> writeConverter = DefaultConverterLoader.loadDefaultWriteConverter();
+        Assertions.assertInstanceOf(
+                InstantStringConverter.class, writeConverter.get(ConverterKeyBuild.buildKey(Instant.class)));
+        Assertions.assertInstanceOf(
+                InstantStringConverter.class,
+                writeConverter.get(ConverterKeyBuild.buildKey(Instant.class, CellDataTypeEnum.STRING)));
     }
 
     private static void assertLoadIsImmutableAndCopyIsMutable(

--- a/fesod-sheet/src/test/java/org/apache/fesod/sheet/converters/instant/InstantStringConverterTest.java
+++ b/fesod-sheet/src/test/java/org/apache/fesod/sheet/converters/instant/InstantStringConverterTest.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.fesod.sheet.converters.instant;
+
+import java.time.Instant;
+import java.time.format.DateTimeParseException;
+import org.apache.fesod.sheet.enums.CellDataTypeEnum;
+import org.apache.fesod.sheet.metadata.GlobalConfiguration;
+import org.apache.fesod.sheet.metadata.data.ReadCellData;
+import org.apache.fesod.sheet.metadata.data.WriteCellData;
+import org.apache.fesod.sheet.testkit.Tags;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+/**
+ * Tests {@link InstantStringConverter}.
+ */
+@Tag(Tags.UNIT)
+class InstantStringConverterTest {
+
+    private static final GlobalConfiguration GLOBAL_CONFIGURATION = new GlobalConfiguration();
+    private final InstantStringConverter converter = new InstantStringConverter();
+
+    @Test
+    void supportKeys() {
+        Assertions.assertEquals(Instant.class, converter.supportJavaTypeKey());
+        Assertions.assertEquals(CellDataTypeEnum.STRING, converter.supportExcelTypeKey());
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+        "1970-01-01T00:00:00Z, 1970-01-01T00:00:00Z",
+        "2026-09-08T12:34:56.123456789Z, 2026-09-08T12:34:56.123456789Z",
+        "2026-09-08T20:34:56+08:00, 2026-09-08T12:34:56Z"
+    })
+    void convertToJavaDataParsesIso8601(String value, String expected) {
+        Instant actual = converter.convertToJavaData(new ReadCellData<>(value), null, GLOBAL_CONFIGURATION);
+
+        Assertions.assertEquals(Instant.parse(expected), actual);
+    }
+
+    @Test
+    void convertRoundTripPreservesNanoseconds() {
+        Instant value = Instant.parse("2026-09-08T12:34:56.123456789Z");
+
+        WriteCellData<?> written = converter.convertToExcelData(value, null, GLOBAL_CONFIGURATION);
+        Instant actual =
+                converter.convertToJavaData(new ReadCellData<>(written.getStringValue()), null, GLOBAL_CONFIGURATION);
+
+        Assertions.assertEquals(CellDataTypeEnum.STRING, written.getType());
+        Assertions.assertEquals("2026-09-08T12:34:56.123456789Z", written.getStringValue());
+        Assertions.assertEquals(value, actual);
+    }
+
+    @Test
+    void convertToJavaDataRejectsInvalidInstant() {
+        Assertions.assertThrows(
+                DateTimeParseException.class,
+                () -> converter.convertToJavaData(new ReadCellData<>("not-an-instant"), null, GLOBAL_CONFIGURATION));
+    }
+}


### PR DESCRIPTION
## Purpose of the pull request

Related: #1017

Add JDK 8-compatible support for lossless conversion between `java.time.Instant` and UTC ISO-8601 Excel string cells.

## What's changed?

- Add `InstantStringConverter` using `OffsetDateTime` for UTC-only reads and `Instant.toString()` for canonical writes.
- Register the converter for default writes, explicit string writes, and string reads.
- Reject non-UTC offsets to keep read/write string semantics symmetric.
- Add unit coverage for converter keys, UTC parsing, non-UTC rejection, nanosecond round trips, invalid input, and loader registration.
- Keep the implementation string-only because Excel date/number cells do not preserve timezone/offset semantics.

## Verification

- `mvn clean package -B -Dmaven.test.skip=false -pl fesod-common,fesod-shaded,fesod-sheet`
- `mvn -pl fesod-sheet -DskipTests spotless:check`

Results after syncing current `main` on JDK 21: 924 tests, 0 failures, 0 errors, 0 skipped. The generated Surefire reports include 7 passing `InstantStringConverterTest` cases and 5 passing `DefaultConverterLoaderTest` cases.

## Checklist

- [x] I have read the Contributor Guide.
- [x] I have written the necessary doc or comment.
- [x] I have added the necessary unit tests and all cases have passed.
