### PR TITLE
fix: fill crash on a stray '}' before a template placeholder

### DIFF
--- a/fesod-sheet/src/main/java/org/apache/fesod/sheet/write/executor/ExcelWriteFillExecutor.java
+++ b/fesod-sheet/src/main/java/org/apache/fesod/sheet/write/executor/ExcelWriteFillExecutor.java
@@ -555,7 +555,10 @@ public class ExcelWriteFillExecutor extends AbstractExcelWriteExecutor {
             }
             int suffixIndex = -1;
             while (suffixIndex == -1 && startIndex < length) {
-                suffixIndex = value.indexOf(FILL_SUFFIX, startIndex + 1);
+                // A stray '}' before the placeholder is literal text, so the matching suffix must be
+                // searched after the '{' — searching from startIndex alone could return an earlier '}'
+                // and invert the substring bounds below.
+                suffixIndex = value.indexOf(FILL_SUFFIX, Math.max(startIndex + 1, prefixIndex + 1));
                 if (suffixIndex < 0) {
                     break out;
                 }

--- a/fesod-sheet/src/test/java/org/apache/fesod/sheet/fill/FillWithStraySuffixTest.java
+++ b/fesod-sheet/src/test/java/org/apache/fesod/sheet/fill/FillWithStraySuffixTest.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.fesod.sheet.fill;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.fesod.sheet.FesodSheet;
+import org.apache.fesod.sheet.testkit.Tags;
+import org.apache.fesod.sheet.testkit.base.AbstractExcelTest;
+import org.apache.fesod.sheet.testkit.enums.ExcelFormat;
+import org.apache.poi.ss.usermodel.Row;
+import org.apache.poi.ss.usermodel.Sheet;
+import org.apache.poi.xssf.usermodel.XSSFWorkbook;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+@Tag(Tags.ROUND_TRIP)
+public class FillWithStraySuffixTest extends AbstractExcelTest {
+
+    @Test
+    void fillTemplateWithStraySuffixBeforePlaceholder() throws Exception {
+        File template = createTempFile(ExcelFormat.XLSX);
+        try (XSSFWorkbook workbook = new XSSFWorkbook()) {
+            Sheet sheet = workbook.createSheet("Sheet0");
+            Row row = sheet.createRow(0);
+            // The stray '}' before the '{name}' placeholder is literal text, not a placeholder suffix.
+            row.createCell(0).setCellValue("a}b{name}");
+            try (FileOutputStream out = new FileOutputStream(template)) {
+                workbook.write(out);
+            }
+        }
+
+        File outFile = createTempFile(ExcelFormat.XLSX);
+        Map<String, String> data = new HashMap<>();
+        data.put("name", "filled");
+
+        FesodSheet.write(outFile).withTemplate(template).sheet().doFill(data);
+
+        try (XSSFWorkbook workbook = new XSSFWorkbook(new FileInputStream(outFile))) {
+            String value = workbook.getSheetAt(0).getRow(0).getCell(0).getStringCellValue();
+            Assertions.assertEquals("a}bfilled", value);
+        }
+    }
+}


### PR DESCRIPTION
## Purpose of the pull request

Filling a template crashed with `java.lang.StringIndexOutOfBoundsException` whenever a template
cell contained a stray `}` **before** a `{placeholder}` (e.g. long prose or a JSON snippet in the
same cell as the placeholder — see #191, where the fill died with `Range [1211, 1027)`).

Fixes #191

## What's changed?

In `ExcelWriteFillExecutor#prepareData`, the closing suffix of a placeholder was searched with
`value.indexOf(FILL_SUFFIX, startIndex + 1)`. `startIndex` only tracks how far escaped
placeholders have been consumed, so the `}` search could start before the current `{`. A stray
`}` preceding the `{` was then treated as the placeholder's suffix, inverting the bounds of
`value.substring(prefixIndex + 1, suffixIndex)`.

The suffix search now starts after the `{`:
`value.indexOf(FILL_SUFFIX, Math.max(startIndex + 1, prefixIndex + 1))`. A stray `}` is kept as
literal text (`a}b{name}` fills to `a}bfilled`); escape handling (`\{`, `\}`) and multi-placeholder
cells are unchanged.

## Tests

New `FillWithStraySuffixTest` (round-trip): a template cell containing `a}b{name}` filled with
`{name: "filled"}` — crashes on current main, fills to `a}bfilled` with this change.

## Checklist

- [x] I have read the [Contributor Guide](https://fesod.apache.org/community/contribution/).
- [x] I have written the necessary doc or comment.
- [x] I have added the necessary unit tests and all cases have passed.