### PR TITLE
build: set fixed project.build.outputTimestamp for reproducible builds

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,11 +81,11 @@ under the License.
     <properties>
         <revision>2.1.0-incubating</revision>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <!-- Clear the parent `apache` POM's stale outputTimestamp (2023): apache-jar-resource-bundle derives the JAR
-             NOTICE copyright end-year from it, and a stale value yields an inverted "2025-2023" range. An empty value
-             falls back to the current build year, so the NOTICE stays correct without a hardcoded date. For a
-             reproducible release, set this to a fixed ISO-8601 commit timestamp (typically done at release pre). -->
-        <project.build.outputTimestamp></project.build.outputTimestamp>
+        <!-- Fixed build timestamp for reproducible builds (see https://maven.org.cn/guides/mini/guide-reproducible-builds.html).
+             apache-jar-resource-bundle derives the JAR NOTICE copyright end-year from this value; keep it in the same
+             year range as the release so the NOTICE shows a correct, non-inverted range (e.g. "2025-2026"). Update it
+             to the current release branch's creation time in every release so each build produces identical artifacts. -->
+        <project.build.outputTimestamp>2026-09-10T00:00:00Z</project.build.outputTimestamp>
         <java.version>1.8</java.version>
         <maven.compiler.target>1.8</maven.compiler.target>
         <maven.compiler.source>1.8</maven.compiler.source>

--- a/website/community/release/release-version.md
+++ b/website/community/release/release-version.md
@@ -316,6 +316,7 @@ For example, to release version `2.0.0-incubating`, follow these steps:
 
 - Create a new branch `2.0.0-incubating` as the release branch.
 - Update the version number in `pom.xml` to `2.0.0-incubating`.
+- Set the `project.build.outputTimestamp` in `pom.xml` to a fixed ISO-8601 timestamp (e.g., the release branch creation time) to ensure [reproducible builds](https://maven.org.cn/guides/mini/guide-reproducible-builds.html). If it is left empty, every build records a different timestamp, which does not satisfy reproducible-build requirements.
 - Push the RC (Release Candidate) version tag.
 
 ```bash
@@ -327,6 +328,15 @@ git tag -s 2.0.0-incubating-rc1 -m "release: release for 2.0.0-incubating RC1"
 
 # Push the tag to the remote repository
 git push origin 2.0.0-incubating-rc1
+```
+
+When the version is updated, also set a fixed build timestamp:
+
+```bash
+# Set a fixed build timestamp so every build produces identical artifacts
+mvn versions:set-property -Dproperty=project.build.outputTimestamp -DnewVersion=2026-09-10T00:00:00Z
+# Or edit pom.xml directly:
+#   <project.build.outputTimestamp>2026-09-10T00:00:00Z</project.build.outputTimestamp>
 ```
 
 #### 3.3.2 Push Binary Packages

--- a/website/i18n/zh-cn/docusaurus-plugin-content-docs-community/current/release/release-version.md
+++ b/website/i18n/zh-cn/docusaurus-plugin-content-docs-community/current/release/release-version.md
@@ -316,6 +316,7 @@ svn ci -m "add gpg key for xxx"
 
 - 创建一个新分支`2.0.0-incubating`作为发布分支
 - 修改 `pom.xml` 中的版本号为 `2.0.0-incubating`
+- 将 `pom.xml` 中的 `project.build.outputTimestamp` 设置为固定的 ISO-8601 时间戳（例如发布分支的创建时间），以保证[可复现构建](https://maven.org.cn/guides/mini/guide-reproducible-builds.html)。如果留空，每次构建的时间戳都会不同，不满足可复现构建的要求
 - 推送 RC(Release Candidates) 版本标签
 
 ```bash
@@ -327,6 +328,15 @@ git tag -s 2.0.0-incubating-rc1 -m "release: release for 2.0.0-incubating RC1"
 
 # 推送 Tag 到远程仓库
 git push origin 2.0.0-incubating-rc1
+```
+
+同时设置固定的构建时间戳：
+
+```bash
+# 设置固定构建时间戳，保证每次构建产物一致
+mvn versions:set-property -Dproperty=project.build.outputTimestamp -DnewVersion=2026-09-10T00:00:00Z
+# 或直接在 pom.xml 中设置：
+#   <project.build.outputTimestamp>2026-09-10T00:00:00Z</project.build.outputTimestamp>
 ```
 
 #### 3.3.2 推送二进制包


### PR DESCRIPTION
## Summary

Sets a fixed ISO-8601 \project.build.outputTimestamp\ in \pom.xml\ so every build of a release produces identical artifacts, satisfying [reproducible-build](https://maven.org.cn/guides/mini/guide-reproducible-builds.html) requirements.

If the value is left empty, each build records a different timestamp and the resulting JARs are not reproducible.

Also documents this step in the community release guide (EN + zh-cn) so future releases remember to pin the timestamp to the release branch creation time.

## Changes
- \pom.xml\: set \project.build.outputTimestamp\ to \2026-09-10T00:00:00Z\ (fixed value) and clarify the comment.
- \website/community/release/release-version.md\: add reproducible-build step under section 3.3.1.
- \website/i18n/zh-cn/.../release-version.md\: same, in Chinese.

## Test Plan
- n/a (config + docs only).