### PR TITLE
build: drop repetitive comment on project.build.outputTimestamp

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,10 +81,6 @@ under the License.
     <properties>
         <revision>2.1.0-incubating</revision>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <!-- Fixed build timestamp for reproducible builds (see https://maven.org.cn/guides/mini/guide-reproducible-builds.html).
-             apache-jar-resource-bundle derives the JAR NOTICE copyright end-year from this value; keep it in the same
-             year range as the release so the NOTICE shows a correct, non-inverted range (e.g. "2025-2026"). Update it
-             to the current release branch's creation time in every release so each build produces identical artifacts. -->
         <project.build.outputTimestamp>2026-09-10T00:00:00Z</project.build.outputTimestamp>
         <java.version>1.8</java.version>
         <maven.compiler.target>1.8</maven.compiler.target>

--- a/website/community/release/release-version.md
+++ b/website/community/release/release-version.md
@@ -316,7 +316,7 @@ For example, to release version `2.0.0-incubating`, follow these steps:
 
 - Create a new branch `2.0.0-incubating` as the release branch.
 - Update the version number in `pom.xml` to `2.0.0-incubating`.
-- Set the `project.build.outputTimestamp` in `pom.xml` to a fixed ISO-8601 timestamp (e.g., the release branch creation time) to ensure [reproducible builds](https://maven.org.cn/guides/mini/guide-reproducible-builds.html). If it is left empty, every build records a different timestamp, which does not satisfy reproducible-build requirements.
+- Set a fixed `project.build.outputTimestamp` in `pom.xml` to ensure [reproducible builds](https://maven.org.cn/guides/mini/guide-reproducible-builds.html).
 - Push the RC (Release Candidate) version tag.
 
 ```bash

--- a/website/community/release/release-version.md
+++ b/website/community/release/release-version.md
@@ -316,7 +316,7 @@ For example, to release version `2.0.0-incubating`, follow these steps:
 
 - Create a new branch `2.0.0-incubating` as the release branch.
 - Update the version number in `pom.xml` to `2.0.0-incubating`.
-- Set a fixed `project.build.outputTimestamp` in `pom.xml` to ensure [reproducible builds](https://maven.org.cn/guides/mini/guide-reproducible-builds.html).
+- Set a fixed `project.build.outputTimestamp` in `pom.xml` to ensure [reproducible builds](https://maven.apache.org/guides/mini/guide-reproducible-builds.html).
 - Push the RC (Release Candidate) version tag.
 
 ```bash

--- a/website/i18n/zh-cn/docusaurus-plugin-content-docs-community/current/release/release-version.md
+++ b/website/i18n/zh-cn/docusaurus-plugin-content-docs-community/current/release/release-version.md
@@ -316,7 +316,7 @@ svn ci -m "add gpg key for xxx"
 
 - 创建一个新分支`2.0.0-incubating`作为发布分支
 - 修改 `pom.xml` 中的版本号为 `2.0.0-incubating`
-- 在 `pom.xml` 中设置固定的 `project.build.outputTimestamp`，以保证[可复现构建](https://maven.org.cn/guides/mini/guide-reproducible-builds.html)
+- 在 `pom.xml` 中设置固定的 `project.build.outputTimestamp`，以保证[可复现构建](https://maven.apache.org/guides/mini/guide-reproducible-builds.html)
 - 推送 RC(Release Candidates) 版本标签
 
 ```bash

--- a/website/i18n/zh-cn/docusaurus-plugin-content-docs-community/current/release/release-version.md
+++ b/website/i18n/zh-cn/docusaurus-plugin-content-docs-community/current/release/release-version.md
@@ -316,7 +316,7 @@ svn ci -m "add gpg key for xxx"
 
 - 创建一个新分支`2.0.0-incubating`作为发布分支
 - 修改 `pom.xml` 中的版本号为 `2.0.0-incubating`
-- 将 `pom.xml` 中的 `project.build.outputTimestamp` 设置为固定的 ISO-8601 时间戳（例如发布分支的创建时间），以保证[可复现构建](https://maven.org.cn/guides/mini/guide-reproducible-builds.html)。如果留空，每次构建的时间戳都会不同，不满足可复现构建的要求
+- 在 `pom.xml` 中设置固定的 `project.build.outputTimestamp`，以保证[可复现构建](https://maven.org.cn/guides/mini/guide-reproducible-builds.html)
 - 推送 RC(Release Candidates) 版本标签
 
 ```bash


### PR DESCRIPTION
The project.build.outputTimestamp property kept an inline comment block
(#1094) that is not part of the Apache pom convention. This change keeps
the fixed reproducible-build timestamp but drops the repetitive comment so
the pom stays minimal and consistent with the standard boilerplate.

No functional change: only the comment lines are removed.