### PR TITLE
chore: add .mailmap to unify author identities

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,5 @@
+# Canonical author identities for Apache Fesod (Incubating).
+# Maps personal addresses used in earlier commits onto the corresponding
+# ASF identity. See gitmailmap(5); applies to git log / shortlog / blame
+# and to the GitHub contributors view. No history is rewritten.
+Zhang Zhe <zhangzhe@apache.org> ian zhang <ian.zhangzhe@gmail.com>


### PR DESCRIPTION
## What

Adds a repository-root `.mailmap` that maps a personal address used in some earlier commits onto the corresponding ASF identity:

```
Zhang Zhe <zhangzhe@apache.org> ian zhang <ian.zhangzhe@gmail.com>
```

## Why

A few commits (for example the RC6 release commit `8f1e1e1`) were authored under a personal address, while the release itself is signed and published under the ASF identity `zhangzhe@apache.org`. `.mailmap` canonicalizes the author identity for `git log` / `git shortlog` / `git blame` and for the GitHub contributors view, so the public history is attributed consistently.

## Scope and safety

- Display-level only: no history rewrite, no force-push. All existing SHAs, PR links and signed tags stay valid.
- Does not touch any already-staged release artifact, the `2.1.0-incubating-rc6` tag, or `dist/dev`.
- Single added file; no build or runtime impact.

## Verification

```
$ git shortlog -sne HEAD | grep 'Zhang Zhe'
    56  Zhang Zhe <zhangzhe@apache.org>

$ git log --use-mailmap --author='ian.zhangzhe'
(no output - all such commits are folded onto the ASF identity)
```
