### PR TITLE
refactor: split ClassUtils into metadata resolvers

### DIFF
--- a/fesod-sheet/src/main/java/org/apache/fesod/sheet/util/ClassUtils.java
+++ b/fesod-sheet/src/main/java/org/apache/fesod/sheet/util/ClassUtils.java
@@ -25,46 +25,21 @@
 
 package org.apache.fesod.sheet.util;
 
-import java.lang.reflect.Field;
-import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
-import java.util.TreeMap;
 import java.util.concurrent.ConcurrentHashMap;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
-import org.apache.commons.collections4.CollectionUtils;
-import org.apache.fesod.common.util.ListUtils;
-import org.apache.fesod.common.util.MapUtils;
-import org.apache.fesod.shaded.cglib.beans.BeanMap;
-import org.apache.fesod.sheet.annotation.ExcelIgnore;
-import org.apache.fesod.sheet.annotation.ExcelIgnoreUnannotated;
-import org.apache.fesod.sheet.annotation.ExcelProperty;
-import org.apache.fesod.sheet.annotation.format.DateTimeFormat;
-import org.apache.fesod.sheet.annotation.format.NumberFormat;
-import org.apache.fesod.sheet.annotation.write.style.ContentFontStyle;
-import org.apache.fesod.sheet.annotation.write.style.ContentStyle;
-import org.apache.fesod.sheet.converters.AutoConverter;
-import org.apache.fesod.sheet.converters.Converter;
-import org.apache.fesod.sheet.exception.ExcelCommonException;
 import org.apache.fesod.sheet.metadata.ConfigurationHolder;
 import org.apache.fesod.sheet.metadata.FieldCache;
-import org.apache.fesod.sheet.metadata.FieldWrapper;
-import org.apache.fesod.sheet.metadata.property.DateTimeFormatProperty;
 import org.apache.fesod.sheet.metadata.property.ExcelContentProperty;
-import org.apache.fesod.sheet.metadata.property.FontProperty;
-import org.apache.fesod.sheet.metadata.property.NumberFormatProperty;
-import org.apache.fesod.sheet.metadata.property.StyleProperty;
 import org.apache.fesod.sheet.write.metadata.holder.WriteHolder;
 
 public class ClassUtils {
@@ -73,10 +48,6 @@ public class ClassUtils {
      * memory cache
      */
     public static final Map<FieldCacheKey, FieldCache> FIELD_CACHE = new ConcurrentHashMap<>();
-    /**
-     * thread local cache
-     */
-    private static final ThreadLocal<Map<FieldCacheKey, FieldCache>> FIELD_THREAD_LOCAL = new ThreadLocal<>();
 
     /**
      * The cache configuration information for each of the class
@@ -87,20 +58,8 @@ public class ClassUtils {
     /**
      * The cache configuration information for each of the class
      */
-    private static final ThreadLocal<Map<Class<?>, Map<String, ExcelContentProperty>>> CLASS_CONTENT_THREAD_LOCAL =
-            new ThreadLocal<>();
-
-    /**
-     * The cache configuration information for each of the class
-     */
     public static final ConcurrentHashMap<ContentPropertyKey, ExcelContentProperty> CONTENT_CACHE =
             new ConcurrentHashMap<>();
-
-    /**
-     * The cache configuration information for each of the class
-     */
-    private static final ThreadLocal<Map<ContentPropertyKey, ExcelContentProperty>> CONTENT_THREAD_LOCAL =
-            new ThreadLocal<>();
 
     /**
      * Calculate the configuration information for the class
@@ -112,161 +71,12 @@ public class ClassUtils {
      */
     public static ExcelContentProperty declaredExcelContentProperty(
             Map<?, ?> dataMap, Class<?> headClazz, String fieldName, ConfigurationHolder configurationHolder) {
-        Class<?> clazz = null;
-        if (dataMap instanceof BeanMap) {
-            Object bean = ((BeanMap) dataMap).getBean();
-            if (bean != null) {
-                clazz = bean.getClass();
-            }
-        }
-        return getExcelContentProperty(clazz, headClazz, fieldName, configurationHolder);
-    }
-
-    private static ExcelContentProperty getExcelContentProperty(
-            Class<?> clazz, Class<?> headClass, String fieldName, ConfigurationHolder configurationHolder) {
-        switch (configurationHolder.globalConfiguration().getFiledCacheLocation()) {
-            case THREAD_LOCAL:
-                Map<ContentPropertyKey, ExcelContentProperty> contentCacheMap = CONTENT_THREAD_LOCAL.get();
-                if (contentCacheMap == null) {
-                    contentCacheMap = MapUtils.newHashMap();
-                    CONTENT_THREAD_LOCAL.set(contentCacheMap);
-                }
-                return contentCacheMap.computeIfAbsent(buildKey(clazz, headClass, fieldName), key -> {
-                    return doGetExcelContentProperty(clazz, headClass, fieldName, configurationHolder);
-                });
-            case MEMORY:
-                return CONTENT_CACHE.computeIfAbsent(buildKey(clazz, headClass, fieldName), key -> {
-                    return doGetExcelContentProperty(clazz, headClass, fieldName, configurationHolder);
-                });
-            case NONE:
-                return doGetExcelContentProperty(clazz, headClass, fieldName, configurationHolder);
-            default:
-                throw new UnsupportedOperationException("unsupported enum");
-        }
-    }
-
-    private static ExcelContentProperty doGetExcelContentProperty(
-            Class<?> clazz, Class<?> headClass, String fieldName, ConfigurationHolder configurationHolder) {
-        ExcelContentProperty excelContentProperty = Optional.ofNullable(
-                        declaredFieldContentMap(clazz, configurationHolder))
-                .map(map -> map.get(fieldName))
-                .orElse(null);
-        ExcelContentProperty headExcelContentProperty = Optional.ofNullable(
-                        declaredFieldContentMap(headClass, configurationHolder))
-                .map(map -> map.get(fieldName))
-                .orElse(null);
-        ExcelContentProperty combineExcelContentProperty = new ExcelContentProperty();
-
-        combineExcelContentProperty(combineExcelContentProperty, headExcelContentProperty);
-        if (clazz != headClass) {
-            combineExcelContentProperty(combineExcelContentProperty, excelContentProperty);
-        }
-        return combineExcelContentProperty;
+        return SheetContentPropertyResolver.resolve(dataMap, headClazz, fieldName, configurationHolder);
     }
 
     public static void combineExcelContentProperty(
             ExcelContentProperty combineExcelContentProperty, ExcelContentProperty excelContentProperty) {
-        if (excelContentProperty == null) {
-            return;
-        }
-        if (excelContentProperty.getField() != null) {
-            combineExcelContentProperty.setField(excelContentProperty.getField());
-        }
-        if (excelContentProperty.getConverter() != null) {
-            combineExcelContentProperty.setConverter(excelContentProperty.getConverter());
-        }
-        if (excelContentProperty.getDateTimeFormatProperty() != null) {
-            combineExcelContentProperty.setDateTimeFormatProperty(excelContentProperty.getDateTimeFormatProperty());
-        }
-        if (excelContentProperty.getNumberFormatProperty() != null) {
-            combineExcelContentProperty.setNumberFormatProperty(excelContentProperty.getNumberFormatProperty());
-        }
-        if (excelContentProperty.getContentStyleProperty() != null) {
-            combineExcelContentProperty.setContentStyleProperty(excelContentProperty.getContentStyleProperty());
-        }
-        if (excelContentProperty.getContentFontProperty() != null) {
-            combineExcelContentProperty.setContentFontProperty(excelContentProperty.getContentFontProperty());
-        }
-    }
-
-    private static ContentPropertyKey buildKey(Class<?> clazz, Class<?> headClass, String fieldName) {
-        return new ContentPropertyKey(clazz, headClass, fieldName);
-    }
-
-    private static Map<String, ExcelContentProperty> declaredFieldContentMap(
-            Class<?> clazz, ConfigurationHolder configurationHolder) {
-        if (clazz == null) {
-            return null;
-        }
-        switch (configurationHolder.globalConfiguration().getFiledCacheLocation()) {
-            case THREAD_LOCAL:
-                Map<Class<?>, Map<String, ExcelContentProperty>> classContentCacheMap =
-                        CLASS_CONTENT_THREAD_LOCAL.get();
-                if (classContentCacheMap == null) {
-                    classContentCacheMap = MapUtils.newHashMap();
-                    CLASS_CONTENT_THREAD_LOCAL.set(classContentCacheMap);
-                }
-                return classContentCacheMap.computeIfAbsent(clazz, key -> {
-                    return doDeclaredFieldContentMap(clazz);
-                });
-            case MEMORY:
-                return CLASS_CONTENT_CACHE.computeIfAbsent(clazz, key -> {
-                    return doDeclaredFieldContentMap(clazz);
-                });
-            case NONE:
-                return doDeclaredFieldContentMap(clazz);
-            default:
-                throw new UnsupportedOperationException("unsupported enum");
-        }
-    }
-
-    private static Map<String, ExcelContentProperty> doDeclaredFieldContentMap(Class<?> clazz) {
-        if (clazz == null) {
-            return null;
-        }
-        List<Field> tempFieldList = FieldUtils.resolveAllFields(clazz);
-
-        ContentStyle parentContentStyle = clazz.getAnnotation(ContentStyle.class);
-        ContentFontStyle parentContentFontStyle = clazz.getAnnotation(ContentFontStyle.class);
-        Map<String, ExcelContentProperty> fieldContentMap = MapUtils.newHashMapWithExpectedSize(tempFieldList.size());
-        for (Field field : tempFieldList) {
-            ExcelContentProperty excelContentProperty = new ExcelContentProperty();
-            excelContentProperty.setField(field);
-
-            ExcelProperty excelProperty = field.getAnnotation(ExcelProperty.class);
-            if (excelProperty != null) {
-                Class<? extends Converter<?>> convertClazz = excelProperty.converter();
-                if (convertClazz != AutoConverter.class) {
-                    try {
-                        Converter<?> converter =
-                                convertClazz.getDeclaredConstructor().newInstance();
-                        excelContentProperty.setConverter(converter);
-                    } catch (Exception e) {
-                        throw new ExcelCommonException("Can not instance custom converter:" + convertClazz.getName());
-                    }
-                }
-            }
-
-            ContentStyle contentStyle = field.getAnnotation(ContentStyle.class);
-            if (contentStyle == null) {
-                contentStyle = parentContentStyle;
-            }
-            excelContentProperty.setContentStyleProperty(StyleProperty.build(contentStyle));
-
-            ContentFontStyle contentFontStyle = field.getAnnotation(ContentFontStyle.class);
-            if (contentFontStyle == null) {
-                contentFontStyle = parentContentFontStyle;
-            }
-            excelContentProperty.setContentFontProperty(FontProperty.build(contentFontStyle));
-
-            excelContentProperty.setDateTimeFormatProperty(
-                    DateTimeFormatProperty.build(field.getAnnotation(DateTimeFormat.class)));
-            excelContentProperty.setNumberFormatProperty(
-                    NumberFormatProperty.build(field.getAnnotation(NumberFormat.class)));
-
-            fieldContentMap.put(field.getName(), excelContentProperty);
-        }
-        return fieldContentMap;
+        SheetContentPropertyResolver.combineExcelContentProperty(combineExcelContentProperty, excelContentProperty);
     }
 
     /**
@@ -276,227 +86,7 @@ public class ClassUtils {
      * @param configurationHolder configuration
      */
     public static FieldCache declaredFields(Class<?> clazz, ConfigurationHolder configurationHolder) {
-        switch (configurationHolder.globalConfiguration().getFiledCacheLocation()) {
-            case THREAD_LOCAL:
-                Map<FieldCacheKey, FieldCache> fieldCacheMap = FIELD_THREAD_LOCAL.get();
-                if (fieldCacheMap == null) {
-                    fieldCacheMap = MapUtils.newHashMap();
-                    FIELD_THREAD_LOCAL.set(fieldCacheMap);
-                }
-                return fieldCacheMap.computeIfAbsent(new FieldCacheKey(clazz, configurationHolder), key -> {
-                    return doDeclaredFields(clazz, configurationHolder);
-                });
-            case MEMORY:
-                return FIELD_CACHE.computeIfAbsent(new FieldCacheKey(clazz, configurationHolder), key -> {
-                    return doDeclaredFields(clazz, configurationHolder);
-                });
-            case NONE:
-                return doDeclaredFields(clazz, configurationHolder);
-            default:
-                throw new UnsupportedOperationException("unsupported enum");
-        }
-    }
-
-    private static FieldCache doDeclaredFields(Class<?> clazz, ConfigurationHolder configurationHolder) {
-        List<Field> tempFieldList = FieldUtils.resolveAllFields(clazz);
-
-        ExcelIgnoreUnannotated excelIgnoreUnannotated = clazz.getAnnotation(ExcelIgnoreUnannotated.class);
-        Set<String> ignoreSet = new HashSet<>();
-        // First collect all field names annotated with ExcelIgnore (including subclass overrides)
-        for (Field field : tempFieldList) {
-            if (field.getAnnotation(ExcelIgnore.class) != null) {
-                ignoreSet.add(FieldUtils.resolveCglibFieldName(field));
-            }
-        }
-        Map<Integer, List<FieldWrapper>> orderFieldMap = new TreeMap<>();
-        Map<Integer, FieldWrapper> indexFieldMap = new TreeMap<>();
-        for (Field field : tempFieldList) {
-            String fieldName = FieldUtils.resolveCglibFieldName(field);
-            // Skip if ignored
-            if (ignoreSet.contains(fieldName)) {
-                continue;
-            }
-            declaredOneField(field, orderFieldMap, indexFieldMap, ignoreSet, excelIgnoreUnannotated);
-        }
-        Map<Integer, FieldWrapper> sortedFieldMap = buildSortedAllFieldMap(orderFieldMap, indexFieldMap);
-        FieldCache fieldCache = new FieldCache(sortedFieldMap, indexFieldMap);
-
-        if (!(configurationHolder instanceof WriteHolder)) {
-            return fieldCache;
-        }
-
-        WriteHolder writeHolder = (WriteHolder) configurationHolder;
-
-        boolean needIgnore = !CollectionUtils.isEmpty(writeHolder.excludeColumnFieldNames())
-                || !CollectionUtils.isEmpty(writeHolder.excludeColumnIndexes())
-                || !CollectionUtils.isEmpty(writeHolder.includeColumnFieldNames())
-                || !CollectionUtils.isEmpty(writeHolder.includeColumnIndexes());
-
-        if (!needIgnore) {
-            return fieldCache;
-        }
-        // ignore filed
-        Map<Integer, FieldWrapper> tempSortedFieldMap = MapUtils.newHashMap();
-        int index = 0;
-        for (Map.Entry<Integer, FieldWrapper> entry : sortedFieldMap.entrySet()) {
-            Integer key = entry.getKey();
-            FieldWrapper field = entry.getValue();
-
-            // The current field needs to be ignored
-            if (writeHolder.ignore(field.getFieldName(), entry.getKey())) {
-                ignoreSet.add(field.getFieldName());
-                // indexFieldMap is keyed by the field's explicit @ExcelProperty(index), which for
-                // explicit-index fields equals the sortedFieldMap position (entry.getKey()); remove
-                // by that key, not the running counter, otherwise an unrelated explicit-index entry
-                // is dropped and the ignored field's entry may survive.
-                indexFieldMap.remove(key);
-            } else {
-                // Mandatory sorted fields
-                if (indexFieldMap.containsKey(key)) {
-                    tempSortedFieldMap.put(key, field);
-                } else {
-                    // Need to reorder automatically
-                    // Check whether the current key is already in use
-                    while (tempSortedFieldMap.containsKey(index)) {
-                        index++;
-                    }
-                    tempSortedFieldMap.put(index++, field);
-                }
-            }
-        }
-        fieldCache.setSortedFieldMap(tempSortedFieldMap);
-
-        // resort field
-        resortField(writeHolder, fieldCache);
-        return fieldCache;
-    }
-
-    /**
-     * it only works when {@link WriteHolder#includeColumnFieldNames()}  or
-     * {@link WriteHolder#includeColumnIndexes()}  has value
-     * and {@link WriteHolder#orderByIncludeColumn()}  is true
-     **/
-    private static void resortField(WriteHolder writeHolder, FieldCache fieldCache) {
-        if (!writeHolder.orderByIncludeColumn()) {
-            return;
-        }
-        Map<Integer, FieldWrapper> indexFieldMap = fieldCache.getIndexFieldMap();
-
-        Collection<String> includeColumnFieldNames = writeHolder.includeColumnFieldNames();
-        if (!CollectionUtils.isEmpty(includeColumnFieldNames)) {
-            // Field sorted map
-            Map<String, Integer> filedIndexMap = MapUtils.newHashMap();
-            int fieldIndex = 0;
-            for (String includeColumnFieldName : includeColumnFieldNames) {
-                filedIndexMap.put(includeColumnFieldName, fieldIndex++);
-            }
-
-            // rebuild sortedFieldMap
-            Map<Integer, FieldWrapper> tempSortedFieldMap = MapUtils.newHashMap();
-            fieldCache.getSortedFieldMap().forEach((index, field) -> {
-                Integer tempFieldIndex = filedIndexMap.get(field.getFieldName());
-                if (tempFieldIndex != null) {
-                    tempSortedFieldMap.put(tempFieldIndex, field);
-
-                    //  The user has redefined the ordering and the ordering of annotations needs to be invalidated
-                    if (!tempFieldIndex.equals(index)) {
-                        indexFieldMap.remove(index);
-                    }
-                }
-            });
-            fieldCache.setSortedFieldMap(tempSortedFieldMap);
-            return;
-        }
-
-        Collection<Integer> includeColumnIndexes = writeHolder.includeColumnIndexes();
-        if (!CollectionUtils.isEmpty(includeColumnIndexes)) {
-            // Index sorted map
-            Map<Integer, Integer> filedIndexMap = MapUtils.newHashMap();
-            int fieldIndex = 0;
-            for (Integer includeColumnIndex : includeColumnIndexes) {
-                filedIndexMap.put(includeColumnIndex, fieldIndex++);
-            }
-
-            // rebuild sortedFieldMap
-            Map<Integer, FieldWrapper> tempSortedFieldMap = MapUtils.newHashMap();
-            fieldCache.getSortedFieldMap().forEach((index, field) -> {
-                Integer tempFieldIndex = filedIndexMap.get(index);
-
-                //  The user has redefined the ordering and the ordering of annotations needs to be invalidated
-                if (tempFieldIndex != null) {
-                    tempSortedFieldMap.put(tempFieldIndex, field);
-                }
-            });
-            fieldCache.setSortedFieldMap(tempSortedFieldMap);
-        }
-    }
-
-    private static Map<Integer, FieldWrapper> buildSortedAllFieldMap(
-            Map<Integer, List<FieldWrapper>> orderFieldMap, Map<Integer, FieldWrapper> indexFieldMap) {
-
-        Map<Integer, FieldWrapper> sortedAllFieldMap =
-                new HashMap<>((orderFieldMap.size() + indexFieldMap.size()) * 4 / 3 + 1);
-
-        Map<Integer, FieldWrapper> tempIndexFieldMap = new HashMap<>(indexFieldMap);
-        int index = 0;
-        for (List<FieldWrapper> fieldList : orderFieldMap.values()) {
-            for (FieldWrapper field : fieldList) {
-                while (tempIndexFieldMap.containsKey(index)) {
-                    sortedAllFieldMap.put(index, tempIndexFieldMap.get(index));
-                    tempIndexFieldMap.remove(index);
-                    index++;
-                }
-                sortedAllFieldMap.put(index, field);
-                index++;
-            }
-        }
-        sortedAllFieldMap.putAll(tempIndexFieldMap);
-        return sortedAllFieldMap;
-    }
-
-    private static void declaredOneField(
-            Field field,
-            Map<Integer, List<FieldWrapper>> orderFieldMap,
-            Map<Integer, FieldWrapper> indexFieldMap,
-            Set<String> ignoreSet,
-            ExcelIgnoreUnannotated excelIgnoreUnannotated) {
-        String fieldName = FieldUtils.resolveCglibFieldName(field);
-        // skip if the field is in ignoreSet
-        if (ignoreSet.contains(fieldName)) {
-            return;
-        }
-        FieldWrapper fieldWrapper = new FieldWrapper();
-        fieldWrapper.setField(field);
-        fieldWrapper.setFieldName(fieldName);
-
-        ExcelProperty excelProperty = field.getAnnotation(ExcelProperty.class);
-        boolean noExcelProperty = excelProperty == null && excelIgnoreUnannotated != null;
-        boolean isStaticFinalOrTransient =
-                (Modifier.isStatic(field.getModifiers()) && Modifier.isFinal(field.getModifiers()))
-                        || Modifier.isTransient(field.getModifiers());
-        if (noExcelProperty || (excelProperty == null && isStaticFinalOrTransient)) {
-            ignoreSet.add(fieldName);
-            return;
-        }
-        // set heads
-        if (excelProperty != null) {
-            fieldWrapper.setHeads(excelProperty.value());
-        }
-        if (excelProperty != null && excelProperty.index() >= 0) {
-            if (indexFieldMap.containsKey(excelProperty.index())) {
-                throw new ExcelCommonException("The index of '"
-                        + indexFieldMap.get(excelProperty.index()).getFieldName() + "' and '" + field.getName()
-                        + "' must be inconsistent");
-            }
-            indexFieldMap.put(excelProperty.index(), fieldWrapper);
-            return;
-        }
-        int order = Integer.MAX_VALUE;
-        if (excelProperty != null) {
-            order = excelProperty.order();
-        }
-        List<FieldWrapper> orderFieldList = orderFieldMap.computeIfAbsent(order, key -> ListUtils.newArrayList());
-        orderFieldList.add(fieldWrapper);
+        return SheetHeadFieldResolver.resolve(clazz, configurationHolder);
     }
 
     /**
@@ -574,8 +164,7 @@ public class ClassUtils {
     }
 
     public static void removeThreadLocalCache() {
-        FIELD_THREAD_LOCAL.remove();
-        CLASS_CONTENT_THREAD_LOCAL.remove();
-        CONTENT_THREAD_LOCAL.remove();
+        SheetHeadFieldResolver.removeThreadLocalCache();
+        SheetContentPropertyResolver.removeThreadLocalCache();
     }
 }

--- a/fesod-sheet/src/main/java/org/apache/fesod/sheet/util/ClassUtils.java
+++ b/fesod-sheet/src/main/java/org/apache/fesod/sheet/util/ClassUtils.java
@@ -27,6 +27,7 @@ package org.apache.fesod.sheet.util;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -46,20 +47,57 @@ public class ClassUtils {
 
     /**
      * memory cache
+     * This field is deprecated; use {@link #getFieldCache()} and {@link #removeInMemoryCache()} instead.
+     * <p>
+     * This field will be removed in future versions.
+     * </p>
      */
-    public static final Map<FieldCacheKey, FieldCache> FIELD_CACHE = new ConcurrentHashMap<>();
+    @Deprecated
+    public static final Map<FieldCacheKey, FieldCache> FIELD_CACHE = SheetHeadFieldResolver.fieldCache();
 
     /**
      * The cache configuration information for each of the class
+     * This field is deprecated; use {@link #getClassContentCache()} and {@link #removeInMemoryCache()}
+     * instead.
+     * <p>
+     * This field will be removed in future versions.
+     * </p>
      */
+    @Deprecated
     public static final ConcurrentHashMap<Class<?>, Map<String, ExcelContentProperty>> CLASS_CONTENT_CACHE =
-            new ConcurrentHashMap<>();
+            SheetContentPropertyResolver.classContentCache();
 
     /**
      * The cache configuration information for each of the class
+     * This field is deprecated; use {@link #getContentCache()} and {@link #removeInMemoryCache()} instead.
+     * <p>
+     * This field will be removed in future versions.
+     * </p>
      */
+    @Deprecated
     public static final ConcurrentHashMap<ContentPropertyKey, ExcelContentProperty> CONTENT_CACHE =
-            new ConcurrentHashMap<>();
+            SheetContentPropertyResolver.contentCache();
+
+    /**
+     * An immutable view of the memory cache of parsed fields.
+     */
+    public static Map<FieldCacheKey, FieldCache> getFieldCache() {
+        return Collections.unmodifiableMap(SheetHeadFieldResolver.fieldCache());
+    }
+
+    /**
+     * An immutable view of the memory cache of the configuration information for each of the class.
+     */
+    public static Map<Class<?>, Map<String, ExcelContentProperty>> getClassContentCache() {
+        return Collections.unmodifiableMap(SheetContentPropertyResolver.classContentCache());
+    }
+
+    /**
+     * An immutable view of the memory cache of the configuration information for each of the field.
+     */
+    public static Map<ContentPropertyKey, ExcelContentProperty> getContentCache() {
+        return Collections.unmodifiableMap(SheetContentPropertyResolver.contentCache());
+    }
 
     /**
      * Calculate the configuration information for the class
@@ -164,7 +202,12 @@ public class ClassUtils {
     }
 
     public static void removeThreadLocalCache() {
-        SheetHeadFieldResolver.removeThreadLocalCache();
-        SheetContentPropertyResolver.removeThreadLocalCache();
+        SheetHeadFieldResolver.clearThreadLocalCache();
+        SheetContentPropertyResolver.clearThreadLocalCache();
+    }
+
+    public static void removeInMemoryCache() {
+        SheetHeadFieldResolver.clearInMemoryCache();
+        SheetContentPropertyResolver.clearInMemoryCache();
     }
 }

--- a/fesod-sheet/src/main/java/org/apache/fesod/sheet/util/MetadataCacheStrategy.java
+++ b/fesod-sheet/src/main/java/org/apache/fesod/sheet/util/MetadataCacheStrategy.java
@@ -27,7 +27,11 @@ import org.apache.fesod.common.util.MapUtils;
 import org.apache.fesod.sheet.enums.CacheLocationEnum;
 
 /**
- * Where one kind of metadata is cached, one implementation per {@link CacheLocationEnum} constant.
+ * Internal helper used by {@link SheetHeadFieldResolver} and {@link SheetContentPropertyResolver} for
+ * caching resolved metadata, one implementation per {@link CacheLocationEnum} constant.
+ * <p>
+ * Not intended for direct use; use {@link ClassUtils} as the primary entry point instead.
+ * </p>
  *
  * @param <K> the cache key
  * @param <V> the cached metadata

--- a/fesod-sheet/src/main/java/org/apache/fesod/sheet/util/MetadataCacheStrategy.java
+++ b/fesod-sheet/src/main/java/org/apache/fesod/sheet/util/MetadataCacheStrategy.java
@@ -39,6 +39,13 @@ interface MetadataCacheStrategy<K, V> {
     V get(K key, Function<K, V> mappingFunction);
 
     /**
+     * Drops the cached entries. {@code ThreadLocal}-backed implementations must detach the entry from
+     * the thread ({@link ThreadLocal#remove()}) rather than merely empty the map they hold, otherwise
+     * pooled threads keep the entry forever.
+     */
+    void clear();
+
+    /**
      * The cache will not be cleared unless the app is stopped.
      */
     class InMemoryCache<K, V> implements MetadataCacheStrategy<K, V> {
@@ -52,6 +59,11 @@ interface MetadataCacheStrategy<K, V> {
         @Override
         public V get(K key, Function<K, V> mappingFunction) {
             return cache.computeIfAbsent(key, mappingFunction);
+        }
+
+        @Override
+        public void clear() {
+            cache.clear();
         }
     }
 
@@ -76,6 +88,11 @@ interface MetadataCacheStrategy<K, V> {
             }
             return cacheMap.computeIfAbsent(key, mappingFunction);
         }
+
+        @Override
+        public void clear() {
+            cache.remove();
+        }
     }
 
     /**
@@ -86,6 +103,11 @@ interface MetadataCacheStrategy<K, V> {
         @Override
         public V get(K key, Function<K, V> mappingFunction) {
             return mappingFunction.apply(key);
+        }
+
+        @Override
+        public void clear() {
+            // nothing is cached
         }
     }
 }

--- a/fesod-sheet/src/main/java/org/apache/fesod/sheet/util/MetadataCacheStrategy.java
+++ b/fesod-sheet/src/main/java/org/apache/fesod/sheet/util/MetadataCacheStrategy.java
@@ -46,7 +46,7 @@ interface MetadataCacheStrategy<K, V> {
     static <K, V> Map<CacheLocationEnum, MetadataCacheStrategy<K, V>> byLocation(
             Map<K, V> memoryCache, ThreadLocal<Map<K, V>> threadLocalCache) {
         Map<CacheLocationEnum, MetadataCacheStrategy<K, V>> strategies = new EnumMap<>(CacheLocationEnum.class);
-        strategies.put(CacheLocationEnum.MEMORY, new MemoryCache<>(memoryCache));
+        strategies.put(CacheLocationEnum.MEMORY, new InMemoryCache<>(memoryCache));
         strategies.put(CacheLocationEnum.THREAD_LOCAL, new ThreadLocalCache<>(threadLocalCache));
         strategies.put(CacheLocationEnum.NONE, new NoOpCache<>());
         return Collections.unmodifiableMap(strategies);
@@ -68,11 +68,11 @@ interface MetadataCacheStrategy<K, V> {
     /**
      * The cache will not be cleared unless the app is stopped.
      */
-    class MemoryCache<K, V> implements MetadataCacheStrategy<K, V> {
+    class InMemoryCache<K, V> implements MetadataCacheStrategy<K, V> {
 
         private final Map<K, V> cache;
 
-        MemoryCache(Map<K, V> cache) {
+        InMemoryCache(Map<K, V> cache) {
             this.cache = cache;
         }
 

--- a/fesod-sheet/src/main/java/org/apache/fesod/sheet/util/MetadataCacheStrategy.java
+++ b/fesod-sheet/src/main/java/org/apache/fesod/sheet/util/MetadataCacheStrategy.java
@@ -19,16 +19,14 @@
 
 package org.apache.fesod.sheet.util;
 
-import java.util.Collections;
-import java.util.EnumMap;
 import java.util.Map;
 import java.util.function.Function;
 import org.apache.fesod.common.util.MapUtils;
 import org.apache.fesod.sheet.enums.CacheLocationEnum;
 
 /**
- * Internal helper used by {@link SheetHeadFieldResolver} and {@link SheetContentPropertyResolver} for
- * caching resolved metadata, one implementation per {@link CacheLocationEnum} constant.
+ * Internal helper used by {@link MetadataCaches} for caching resolved metadata, one implementation per
+ * {@link CacheLocationEnum} constant.
  * <p>
  * Not intended for direct use; use {@link ClassUtils} as the primary entry point instead.
  * </p>
@@ -39,31 +37,6 @@ import org.apache.fesod.sheet.enums.CacheLocationEnum;
 interface MetadataCacheStrategy<K, V> {
 
     V get(K key, Function<K, V> mappingFunction);
-
-    /**
-     * The strategy for every {@link CacheLocationEnum} constant, over the two caches that back them.
-     */
-    static <K, V> Map<CacheLocationEnum, MetadataCacheStrategy<K, V>> byLocation(
-            Map<K, V> memoryCache, ThreadLocal<Map<K, V>> threadLocalCache) {
-        Map<CacheLocationEnum, MetadataCacheStrategy<K, V>> strategies = new EnumMap<>(CacheLocationEnum.class);
-        strategies.put(CacheLocationEnum.MEMORY, new InMemoryCache<>(memoryCache));
-        strategies.put(CacheLocationEnum.THREAD_LOCAL, new ThreadLocalCache<>(threadLocalCache));
-        strategies.put(CacheLocationEnum.NONE, new NoOpCache<>());
-        return Collections.unmodifiableMap(strategies);
-    }
-
-    /**
-     * Looks up the strategy configured for {@code cacheLocation}, failing loudly when a
-     * {@link CacheLocationEnum} constant has no strategy registered for it.
-     */
-    static <K, V> MetadataCacheStrategy<K, V> select(
-            Map<CacheLocationEnum, MetadataCacheStrategy<K, V>> strategies, CacheLocationEnum cacheLocation) {
-        MetadataCacheStrategy<K, V> strategy = strategies.get(cacheLocation);
-        if (strategy == null) {
-            throw new UnsupportedOperationException("unsupported enum");
-        }
-        return strategy;
-    }
 
     /**
      * The cache will not be cleared unless the app is stopped.

--- a/fesod-sheet/src/main/java/org/apache/fesod/sheet/util/MetadataCacheStrategy.java
+++ b/fesod-sheet/src/main/java/org/apache/fesod/sheet/util/MetadataCacheStrategy.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.fesod.sheet.util;
+
+import java.util.Collections;
+import java.util.EnumMap;
+import java.util.Map;
+import java.util.function.Function;
+import org.apache.fesod.common.util.MapUtils;
+import org.apache.fesod.sheet.enums.CacheLocationEnum;
+
+/**
+ * Where one kind of metadata is cached, one implementation per {@link CacheLocationEnum} constant.
+ *
+ * @param <K> the cache key
+ * @param <V> the cached metadata
+ */
+interface MetadataCacheStrategy<K, V> {
+
+    V get(K key, Function<K, V> mappingFunction);
+
+    /**
+     * The strategy for every {@link CacheLocationEnum} constant, over the two caches that back them.
+     */
+    static <K, V> Map<CacheLocationEnum, MetadataCacheStrategy<K, V>> byLocation(
+            Map<K, V> memoryCache, ThreadLocal<Map<K, V>> threadLocalCache) {
+        Map<CacheLocationEnum, MetadataCacheStrategy<K, V>> strategies = new EnumMap<>(CacheLocationEnum.class);
+        strategies.put(CacheLocationEnum.MEMORY, new MemoryCache<>(memoryCache));
+        strategies.put(CacheLocationEnum.THREAD_LOCAL, new ThreadLocalCache<>(threadLocalCache));
+        strategies.put(CacheLocationEnum.NONE, new NoOpCache<>());
+        return Collections.unmodifiableMap(strategies);
+    }
+
+    /**
+     * Looks up the strategy configured for {@code cacheLocation}, failing loudly when a
+     * {@link CacheLocationEnum} constant has no strategy registered for it.
+     */
+    static <K, V> MetadataCacheStrategy<K, V> select(
+            Map<CacheLocationEnum, MetadataCacheStrategy<K, V>> strategies, CacheLocationEnum cacheLocation) {
+        MetadataCacheStrategy<K, V> strategy = strategies.get(cacheLocation);
+        if (strategy == null) {
+            throw new UnsupportedOperationException("unsupported enum");
+        }
+        return strategy;
+    }
+
+    /**
+     * The cache will not be cleared unless the app is stopped.
+     */
+    class MemoryCache<K, V> implements MetadataCacheStrategy<K, V> {
+
+        private final Map<K, V> cache;
+
+        MemoryCache(Map<K, V> cache) {
+            this.cache = cache;
+        }
+
+        @Override
+        public V get(K key, Function<K, V> mappingFunction) {
+            return cache.computeIfAbsent(key, mappingFunction);
+        }
+    }
+
+    /**
+     * The cache will be stored in {@code ThreadLocal}, and will be cleared when the excel read and
+     * write is completed.
+     */
+    class ThreadLocalCache<K, V> implements MetadataCacheStrategy<K, V> {
+
+        private final ThreadLocal<Map<K, V>> cache;
+
+        ThreadLocalCache(ThreadLocal<Map<K, V>> cache) {
+            this.cache = cache;
+        }
+
+        @Override
+        public V get(K key, Function<K, V> mappingFunction) {
+            Map<K, V> cacheMap = cache.get();
+            if (cacheMap == null) {
+                cacheMap = MapUtils.newHashMap();
+                cache.set(cacheMap);
+            }
+            return cacheMap.computeIfAbsent(key, mappingFunction);
+        }
+    }
+
+    /**
+     * No caching.It may lose some of performance.
+     */
+    class NoOpCache<K, V> implements MetadataCacheStrategy<K, V> {
+
+        @Override
+        public V get(K key, Function<K, V> mappingFunction) {
+            return mappingFunction.apply(key);
+        }
+    }
+}

--- a/fesod-sheet/src/main/java/org/apache/fesod/sheet/util/MetadataCaches.java
+++ b/fesod-sheet/src/main/java/org/apache/fesod/sheet/util/MetadataCaches.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.fesod.sheet.util;
+
+import java.util.Collections;
+import java.util.EnumMap;
+import java.util.Map;
+import java.util.function.Function;
+import org.apache.fesod.sheet.enums.CacheLocationEnum;
+import org.apache.fesod.sheet.metadata.ConfigurationHolder;
+
+/**
+ * Internal helper used by {@link SheetHeadFieldResolver} and {@link SheetContentPropertyResolver} for
+ * caching resolved metadata in the tier the current read or write is configured for.
+ * <p>
+ * Not intended for direct use; use {@link ClassUtils} as the primary entry point instead.
+ * </p>
+ *
+ * @param <K> the cache key
+ * @param <V> the cached metadata
+ */
+final class MetadataCaches<K, V> {
+
+    private final Map<CacheLocationEnum, MetadataCacheStrategy<K, V>> byLocation;
+
+    MetadataCaches(Map<K, V> memoryCache, ThreadLocal<Map<K, V>> threadLocalCache) {
+        Map<CacheLocationEnum, MetadataCacheStrategy<K, V>> strategies = new EnumMap<>(CacheLocationEnum.class);
+        strategies.put(CacheLocationEnum.MEMORY, new MetadataCacheStrategy.InMemoryCache<>(memoryCache));
+        strategies.put(CacheLocationEnum.THREAD_LOCAL, new MetadataCacheStrategy.ThreadLocalCache<>(threadLocalCache));
+        strategies.put(CacheLocationEnum.NONE, new MetadataCacheStrategy.NoOpCache<>());
+        this.byLocation = Collections.unmodifiableMap(strategies);
+    }
+
+    /**
+     * Caches in the tier {@code configurationHolder} is configured for, failing loudly when a
+     * {@link CacheLocationEnum} constant has no strategy registered for it.
+     */
+    V get(ConfigurationHolder configurationHolder, K key, Function<K, V> mappingFunction) {
+        CacheLocationEnum cacheLocation =
+                configurationHolder.globalConfiguration().getFiledCacheLocation();
+        MetadataCacheStrategy<K, V> strategy = byLocation.get(cacheLocation);
+        if (strategy == null) {
+            throw new UnsupportedOperationException("unsupported enum");
+        }
+        return strategy.get(key, mappingFunction);
+    }
+}

--- a/fesod-sheet/src/main/java/org/apache/fesod/sheet/util/MetadataCaches.java
+++ b/fesod-sheet/src/main/java/org/apache/fesod/sheet/util/MetadataCaches.java
@@ -22,6 +22,7 @@ package org.apache.fesod.sheet.util;
 import java.util.Collections;
 import java.util.EnumMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
 import org.apache.fesod.sheet.enums.CacheLocationEnum;
 import org.apache.fesod.sheet.metadata.ConfigurationHolder;
@@ -38,9 +39,13 @@ import org.apache.fesod.sheet.metadata.ConfigurationHolder;
  */
 final class MetadataCaches<K, V> {
 
+    private final ConcurrentHashMap<K, V> memoryCache = new ConcurrentHashMap<>();
+
+    private final ThreadLocal<Map<K, V>> threadLocalCache = new ThreadLocal<>();
+
     private final Map<CacheLocationEnum, MetadataCacheStrategy<K, V>> byLocation;
 
-    MetadataCaches(Map<K, V> memoryCache, ThreadLocal<Map<K, V>> threadLocalCache) {
+    MetadataCaches() {
         Map<CacheLocationEnum, MetadataCacheStrategy<K, V>> strategies = new EnumMap<>(CacheLocationEnum.class);
         strategies.put(CacheLocationEnum.MEMORY, new MetadataCacheStrategy.InMemoryCache<>(memoryCache));
         strategies.put(CacheLocationEnum.THREAD_LOCAL, new MetadataCacheStrategy.ThreadLocalCache<>(threadLocalCache));
@@ -49,16 +54,39 @@ final class MetadataCaches<K, V> {
     }
 
     /**
-     * Caches in the tier {@code configurationHolder} is configured for, failing loudly when a
-     * {@link CacheLocationEnum} constant has no strategy registered for it.
+     * The map backing {@link CacheLocationEnum#MEMORY}, so {@link ClassUtils} can keep publishing it
+     * without owning it.
+     */
+    ConcurrentHashMap<K, V> memoryCache() {
+        return memoryCache;
+    }
+
+    /**
+     * Caches in the tier {@code configurationHolder} is configured for.
      */
     V get(ConfigurationHolder configurationHolder, K key, Function<K, V> mappingFunction) {
         CacheLocationEnum cacheLocation =
                 configurationHolder.globalConfiguration().getFiledCacheLocation();
+        return at(cacheLocation).get(key, mappingFunction);
+    }
+
+    void clearThreadLocal() {
+        at(CacheLocationEnum.THREAD_LOCAL).clear();
+    }
+
+    void clearInMemory() {
+        at(CacheLocationEnum.MEMORY).clear();
+    }
+
+    /**
+     * Looks up the strategy configured for {@code cacheLocation}, failing loudly when a
+     * {@link CacheLocationEnum} constant has no strategy registered for it.
+     */
+    private MetadataCacheStrategy<K, V> at(CacheLocationEnum cacheLocation) {
         MetadataCacheStrategy<K, V> strategy = byLocation.get(cacheLocation);
         if (strategy == null) {
             throw new UnsupportedOperationException("unsupported enum");
         }
-        return strategy.get(key, mappingFunction);
+        return strategy;
     }
 }

--- a/fesod-sheet/src/main/java/org/apache/fesod/sheet/util/SheetContentPropertyResolver.java
+++ b/fesod-sheet/src/main/java/org/apache/fesod/sheet/util/SheetContentPropertyResolver.java
@@ -23,6 +23,7 @@ import java.lang.reflect.Field;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
 import org.apache.fesod.common.util.MapUtils;
 import org.apache.fesod.shaded.cglib.beans.BeanMap;
 import org.apache.fesod.sheet.annotation.ExcelProperty;
@@ -50,23 +51,11 @@ import org.apache.fesod.sheet.util.ClassUtils.ContentPropertyKey;
  */
 final class SheetContentPropertyResolver {
 
-    /**
-     * The cache configuration information for each of the class
-     */
-    private static final ThreadLocal<Map<Class<?>, Map<String, ExcelContentProperty>>> CLASS_CONTENT_THREAD_LOCAL =
-            new ThreadLocal<>();
-
-    /**
-     * The cache configuration information for each of the class
-     */
-    private static final ThreadLocal<Map<ContentPropertyKey, ExcelContentProperty>> CONTENT_THREAD_LOCAL =
-            new ThreadLocal<>();
-
     private static final MetadataCaches<ContentPropertyKey, ExcelContentProperty> CONTENT_CACHES =
-            new MetadataCaches<>(ClassUtils.CONTENT_CACHE, CONTENT_THREAD_LOCAL);
+            new MetadataCaches<>();
 
     private static final MetadataCaches<Class<?>, Map<String, ExcelContentProperty>> CLASS_CONTENT_CACHES =
-            new MetadataCaches<>(ClassUtils.CLASS_CONTENT_CACHE, CLASS_CONTENT_THREAD_LOCAL);
+            new MetadataCaches<>();
 
     private SheetContentPropertyResolver() {}
 
@@ -90,9 +79,22 @@ final class SheetContentPropertyResolver {
         return getExcelContentProperty(clazz, headClazz, fieldName, configurationHolder);
     }
 
-    static void removeThreadLocalCache() {
-        CLASS_CONTENT_THREAD_LOCAL.remove();
-        CONTENT_THREAD_LOCAL.remove();
+    static ConcurrentHashMap<ContentPropertyKey, ExcelContentProperty> contentCache() {
+        return CONTENT_CACHES.memoryCache();
+    }
+
+    static ConcurrentHashMap<Class<?>, Map<String, ExcelContentProperty>> classContentCache() {
+        return CLASS_CONTENT_CACHES.memoryCache();
+    }
+
+    static void clearThreadLocalCache() {
+        CLASS_CONTENT_CACHES.clearThreadLocal();
+        CONTENT_CACHES.clearThreadLocal();
+    }
+
+    static void clearInMemoryCache() {
+        CLASS_CONTENT_CACHES.clearInMemory();
+        CONTENT_CACHES.clearInMemory();
     }
 
     private static ExcelContentProperty getExcelContentProperty(

--- a/fesod-sheet/src/main/java/org/apache/fesod/sheet/util/SheetContentPropertyResolver.java
+++ b/fesod-sheet/src/main/java/org/apache/fesod/sheet/util/SheetContentPropertyResolver.java
@@ -32,7 +32,6 @@ import org.apache.fesod.sheet.annotation.write.style.ContentFontStyle;
 import org.apache.fesod.sheet.annotation.write.style.ContentStyle;
 import org.apache.fesod.sheet.converters.AutoConverter;
 import org.apache.fesod.sheet.converters.Converter;
-import org.apache.fesod.sheet.enums.CacheLocationEnum;
 import org.apache.fesod.sheet.exception.ExcelCommonException;
 import org.apache.fesod.sheet.metadata.ConfigurationHolder;
 import org.apache.fesod.sheet.metadata.property.DateTimeFormatProperty;
@@ -63,12 +62,11 @@ final class SheetContentPropertyResolver {
     private static final ThreadLocal<Map<ContentPropertyKey, ExcelContentProperty>> CONTENT_THREAD_LOCAL =
             new ThreadLocal<>();
 
-    private static final Map<CacheLocationEnum, MetadataCacheStrategy<ContentPropertyKey, ExcelContentProperty>>
-            CONTENT_STRATEGIES = MetadataCacheStrategy.byLocation(ClassUtils.CONTENT_CACHE, CONTENT_THREAD_LOCAL);
+    private static final MetadataCaches<ContentPropertyKey, ExcelContentProperty> CONTENT_CACHES =
+            new MetadataCaches<>(ClassUtils.CONTENT_CACHE, CONTENT_THREAD_LOCAL);
 
-    private static final Map<CacheLocationEnum, MetadataCacheStrategy<Class<?>, Map<String, ExcelContentProperty>>>
-            CLASS_CONTENT_STRATEGIES =
-                    MetadataCacheStrategy.byLocation(ClassUtils.CLASS_CONTENT_CACHE, CLASS_CONTENT_THREAD_LOCAL);
+    private static final MetadataCaches<Class<?>, Map<String, ExcelContentProperty>> CLASS_CONTENT_CACHES =
+            new MetadataCaches<>(ClassUtils.CLASS_CONTENT_CACHE, CLASS_CONTENT_THREAD_LOCAL);
 
     private SheetContentPropertyResolver() {}
 
@@ -99,12 +97,10 @@ final class SheetContentPropertyResolver {
 
     private static ExcelContentProperty getExcelContentProperty(
             Class<?> clazz, Class<?> headClass, String fieldName, ConfigurationHolder configurationHolder) {
-        return MetadataCacheStrategy.select(
-                        CONTENT_STRATEGIES,
-                        configurationHolder.globalConfiguration().getFiledCacheLocation())
-                .get(
-                        buildKey(clazz, headClass, fieldName),
-                        key -> doGetExcelContentProperty(clazz, headClass, fieldName, configurationHolder));
+        return CONTENT_CACHES.get(
+                configurationHolder,
+                buildKey(clazz, headClass, fieldName),
+                key -> doGetExcelContentProperty(clazz, headClass, fieldName, configurationHolder));
     }
 
     private static ExcelContentProperty doGetExcelContentProperty(
@@ -160,10 +156,7 @@ final class SheetContentPropertyResolver {
         if (clazz == null) {
             return null;
         }
-        return MetadataCacheStrategy.select(
-                        CLASS_CONTENT_STRATEGIES,
-                        configurationHolder.globalConfiguration().getFiledCacheLocation())
-                .get(clazz, key -> doDeclaredFieldContentMap(clazz));
+        return CLASS_CONTENT_CACHES.get(configurationHolder, clazz, key -> doDeclaredFieldContentMap(clazz));
     }
 
     private static Map<String, ExcelContentProperty> doDeclaredFieldContentMap(Class<?> clazz) {

--- a/fesod-sheet/src/main/java/org/apache/fesod/sheet/util/SheetContentPropertyResolver.java
+++ b/fesod-sheet/src/main/java/org/apache/fesod/sheet/util/SheetContentPropertyResolver.java
@@ -43,8 +43,11 @@ import org.apache.fesod.sheet.metadata.property.StyleProperty;
 import org.apache.fesod.sheet.util.ClassUtils.ContentPropertyKey;
 
 /**
- * Resolves the converter, format and style of a single field, merged from the head class and the
- * runtime class of the data.
+ * Internal helper used by {@link ClassUtils} for resolving the converter, format and style of a
+ * single field, merged from the head class and the runtime class of the data.
+ * <p>
+ * Not intended for direct use; use {@link ClassUtils} as the primary entry point instead.
+ * </p>
  */
 final class SheetContentPropertyResolver {
 

--- a/fesod-sheet/src/main/java/org/apache/fesod/sheet/util/SheetContentPropertyResolver.java
+++ b/fesod-sheet/src/main/java/org/apache/fesod/sheet/util/SheetContentPropertyResolver.java
@@ -1,0 +1,214 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.fesod.sheet.util;
+
+import java.lang.reflect.Field;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.apache.fesod.common.util.MapUtils;
+import org.apache.fesod.shaded.cglib.beans.BeanMap;
+import org.apache.fesod.sheet.annotation.ExcelProperty;
+import org.apache.fesod.sheet.annotation.format.DateTimeFormat;
+import org.apache.fesod.sheet.annotation.format.NumberFormat;
+import org.apache.fesod.sheet.annotation.write.style.ContentFontStyle;
+import org.apache.fesod.sheet.annotation.write.style.ContentStyle;
+import org.apache.fesod.sheet.converters.AutoConverter;
+import org.apache.fesod.sheet.converters.Converter;
+import org.apache.fesod.sheet.enums.CacheLocationEnum;
+import org.apache.fesod.sheet.exception.ExcelCommonException;
+import org.apache.fesod.sheet.metadata.ConfigurationHolder;
+import org.apache.fesod.sheet.metadata.property.DateTimeFormatProperty;
+import org.apache.fesod.sheet.metadata.property.ExcelContentProperty;
+import org.apache.fesod.sheet.metadata.property.FontProperty;
+import org.apache.fesod.sheet.metadata.property.NumberFormatProperty;
+import org.apache.fesod.sheet.metadata.property.StyleProperty;
+import org.apache.fesod.sheet.util.ClassUtils.ContentPropertyKey;
+
+/**
+ * Resolves the converter, format and style of a single field, merged from the head class and the
+ * runtime class of the data.
+ */
+final class SheetContentPropertyResolver {
+
+    /**
+     * The cache configuration information for each of the class
+     */
+    private static final ThreadLocal<Map<Class<?>, Map<String, ExcelContentProperty>>> CLASS_CONTENT_THREAD_LOCAL =
+            new ThreadLocal<>();
+
+    /**
+     * The cache configuration information for each of the class
+     */
+    private static final ThreadLocal<Map<ContentPropertyKey, ExcelContentProperty>> CONTENT_THREAD_LOCAL =
+            new ThreadLocal<>();
+
+    private static final Map<CacheLocationEnum, MetadataCacheStrategy<ContentPropertyKey, ExcelContentProperty>>
+            CONTENT_STRATEGIES = MetadataCacheStrategy.byLocation(ClassUtils.CONTENT_CACHE, CONTENT_THREAD_LOCAL);
+
+    private static final Map<CacheLocationEnum, MetadataCacheStrategy<Class<?>, Map<String, ExcelContentProperty>>>
+            CLASS_CONTENT_STRATEGIES =
+                    MetadataCacheStrategy.byLocation(ClassUtils.CLASS_CONTENT_CACHE, CLASS_CONTENT_THREAD_LOCAL);
+
+    private SheetContentPropertyResolver() {}
+
+    /**
+     * Calculate the configuration information for the class
+     *
+     * @param dataMap
+     * @param headClazz
+     * @param fieldName
+     * @return
+     */
+    static ExcelContentProperty resolve(
+            Map<?, ?> dataMap, Class<?> headClazz, String fieldName, ConfigurationHolder configurationHolder) {
+        Class<?> clazz = null;
+        if (dataMap instanceof BeanMap) {
+            Object bean = ((BeanMap) dataMap).getBean();
+            if (bean != null) {
+                clazz = bean.getClass();
+            }
+        }
+        return getExcelContentProperty(clazz, headClazz, fieldName, configurationHolder);
+    }
+
+    static void removeThreadLocalCache() {
+        CLASS_CONTENT_THREAD_LOCAL.remove();
+        CONTENT_THREAD_LOCAL.remove();
+    }
+
+    private static ExcelContentProperty getExcelContentProperty(
+            Class<?> clazz, Class<?> headClass, String fieldName, ConfigurationHolder configurationHolder) {
+        return MetadataCacheStrategy.select(
+                        CONTENT_STRATEGIES,
+                        configurationHolder.globalConfiguration().getFiledCacheLocation())
+                .get(
+                        buildKey(clazz, headClass, fieldName),
+                        key -> doGetExcelContentProperty(clazz, headClass, fieldName, configurationHolder));
+    }
+
+    private static ExcelContentProperty doGetExcelContentProperty(
+            Class<?> clazz, Class<?> headClass, String fieldName, ConfigurationHolder configurationHolder) {
+        ExcelContentProperty excelContentProperty = Optional.ofNullable(
+                        declaredFieldContentMap(clazz, configurationHolder))
+                .map(map -> map.get(fieldName))
+                .orElse(null);
+        ExcelContentProperty headExcelContentProperty = Optional.ofNullable(
+                        declaredFieldContentMap(headClass, configurationHolder))
+                .map(map -> map.get(fieldName))
+                .orElse(null);
+        ExcelContentProperty combineExcelContentProperty = new ExcelContentProperty();
+
+        combineExcelContentProperty(combineExcelContentProperty, headExcelContentProperty);
+        if (clazz != headClass) {
+            combineExcelContentProperty(combineExcelContentProperty, excelContentProperty);
+        }
+        return combineExcelContentProperty;
+    }
+
+    static void combineExcelContentProperty(
+            ExcelContentProperty combineExcelContentProperty, ExcelContentProperty excelContentProperty) {
+        if (excelContentProperty == null) {
+            return;
+        }
+        if (excelContentProperty.getField() != null) {
+            combineExcelContentProperty.setField(excelContentProperty.getField());
+        }
+        if (excelContentProperty.getConverter() != null) {
+            combineExcelContentProperty.setConverter(excelContentProperty.getConverter());
+        }
+        if (excelContentProperty.getDateTimeFormatProperty() != null) {
+            combineExcelContentProperty.setDateTimeFormatProperty(excelContentProperty.getDateTimeFormatProperty());
+        }
+        if (excelContentProperty.getNumberFormatProperty() != null) {
+            combineExcelContentProperty.setNumberFormatProperty(excelContentProperty.getNumberFormatProperty());
+        }
+        if (excelContentProperty.getContentStyleProperty() != null) {
+            combineExcelContentProperty.setContentStyleProperty(excelContentProperty.getContentStyleProperty());
+        }
+        if (excelContentProperty.getContentFontProperty() != null) {
+            combineExcelContentProperty.setContentFontProperty(excelContentProperty.getContentFontProperty());
+        }
+    }
+
+    private static ContentPropertyKey buildKey(Class<?> clazz, Class<?> headClass, String fieldName) {
+        return new ContentPropertyKey(clazz, headClass, fieldName);
+    }
+
+    private static Map<String, ExcelContentProperty> declaredFieldContentMap(
+            Class<?> clazz, ConfigurationHolder configurationHolder) {
+        if (clazz == null) {
+            return null;
+        }
+        return MetadataCacheStrategy.select(
+                        CLASS_CONTENT_STRATEGIES,
+                        configurationHolder.globalConfiguration().getFiledCacheLocation())
+                .get(clazz, key -> doDeclaredFieldContentMap(clazz));
+    }
+
+    private static Map<String, ExcelContentProperty> doDeclaredFieldContentMap(Class<?> clazz) {
+        if (clazz == null) {
+            return null;
+        }
+        List<Field> tempFieldList = FieldUtils.resolveAllFields(clazz);
+
+        ContentStyle parentContentStyle = clazz.getAnnotation(ContentStyle.class);
+        ContentFontStyle parentContentFontStyle = clazz.getAnnotation(ContentFontStyle.class);
+        Map<String, ExcelContentProperty> fieldContentMap = MapUtils.newHashMapWithExpectedSize(tempFieldList.size());
+        for (Field field : tempFieldList) {
+            ExcelContentProperty excelContentProperty = new ExcelContentProperty();
+            excelContentProperty.setField(field);
+
+            ExcelProperty excelProperty = field.getAnnotation(ExcelProperty.class);
+            if (excelProperty != null) {
+                Class<? extends Converter<?>> convertClazz = excelProperty.converter();
+                if (convertClazz != AutoConverter.class) {
+                    try {
+                        Converter<?> converter =
+                                convertClazz.getDeclaredConstructor().newInstance();
+                        excelContentProperty.setConverter(converter);
+                    } catch (Exception e) {
+                        throw new ExcelCommonException("Can not instance custom converter:" + convertClazz.getName());
+                    }
+                }
+            }
+
+            ContentStyle contentStyle = field.getAnnotation(ContentStyle.class);
+            if (contentStyle == null) {
+                contentStyle = parentContentStyle;
+            }
+            excelContentProperty.setContentStyleProperty(StyleProperty.build(contentStyle));
+
+            ContentFontStyle contentFontStyle = field.getAnnotation(ContentFontStyle.class);
+            if (contentFontStyle == null) {
+                contentFontStyle = parentContentFontStyle;
+            }
+            excelContentProperty.setContentFontProperty(FontProperty.build(contentFontStyle));
+
+            excelContentProperty.setDateTimeFormatProperty(
+                    DateTimeFormatProperty.build(field.getAnnotation(DateTimeFormat.class)));
+            excelContentProperty.setNumberFormatProperty(
+                    NumberFormatProperty.build(field.getAnnotation(NumberFormat.class)));
+
+            fieldContentMap.put(field.getName(), excelContentProperty);
+        }
+        return fieldContentMap;
+    }
+}

--- a/fesod-sheet/src/main/java/org/apache/fesod/sheet/util/SheetHeadFieldResolver.java
+++ b/fesod-sheet/src/main/java/org/apache/fesod/sheet/util/SheetHeadFieldResolver.java
@@ -28,6 +28,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
+import java.util.concurrent.ConcurrentHashMap;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.fesod.common.util.ListUtils;
 import org.apache.fesod.common.util.MapUtils;
@@ -50,13 +51,7 @@ import org.apache.fesod.sheet.write.metadata.holder.WriteHolder;
  */
 final class SheetHeadFieldResolver {
 
-    /**
-     * thread local cache
-     */
-    private static final ThreadLocal<Map<FieldCacheKey, FieldCache>> FIELD_THREAD_LOCAL = new ThreadLocal<>();
-
-    private static final MetadataCaches<FieldCacheKey, FieldCache> FIELD_CACHES =
-            new MetadataCaches<>(ClassUtils.FIELD_CACHE, FIELD_THREAD_LOCAL);
+    private static final MetadataCaches<FieldCacheKey, FieldCache> FIELD_CACHES = new MetadataCaches<>();
 
     private SheetHeadFieldResolver() {}
 
@@ -73,8 +68,16 @@ final class SheetHeadFieldResolver {
                 key -> doResolve(clazz, configurationHolder));
     }
 
-    static void removeThreadLocalCache() {
-        FIELD_THREAD_LOCAL.remove();
+    static ConcurrentHashMap<FieldCacheKey, FieldCache> fieldCache() {
+        return FIELD_CACHES.memoryCache();
+    }
+
+    static void clearThreadLocalCache() {
+        FIELD_CACHES.clearThreadLocal();
+    }
+
+    static void clearInMemoryCache() {
+        FIELD_CACHES.clearInMemory();
     }
 
     private static FieldCache doResolve(Class<?> clazz, ConfigurationHolder configurationHolder) {

--- a/fesod-sheet/src/main/java/org/apache/fesod/sheet/util/SheetHeadFieldResolver.java
+++ b/fesod-sheet/src/main/java/org/apache/fesod/sheet/util/SheetHeadFieldResolver.java
@@ -34,7 +34,6 @@ import org.apache.fesod.common.util.MapUtils;
 import org.apache.fesod.sheet.annotation.ExcelIgnore;
 import org.apache.fesod.sheet.annotation.ExcelIgnoreUnannotated;
 import org.apache.fesod.sheet.annotation.ExcelProperty;
-import org.apache.fesod.sheet.enums.CacheLocationEnum;
 import org.apache.fesod.sheet.exception.ExcelCommonException;
 import org.apache.fesod.sheet.metadata.ConfigurationHolder;
 import org.apache.fesod.sheet.metadata.FieldCache;
@@ -56,8 +55,8 @@ final class SheetHeadFieldResolver {
      */
     private static final ThreadLocal<Map<FieldCacheKey, FieldCache>> FIELD_THREAD_LOCAL = new ThreadLocal<>();
 
-    private static final Map<CacheLocationEnum, MetadataCacheStrategy<FieldCacheKey, FieldCache>> STRATEGIES =
-            MetadataCacheStrategy.byLocation(ClassUtils.FIELD_CACHE, FIELD_THREAD_LOCAL);
+    private static final MetadataCaches<FieldCacheKey, FieldCache> FIELD_CACHES =
+            new MetadataCaches<>(ClassUtils.FIELD_CACHE, FIELD_THREAD_LOCAL);
 
     private SheetHeadFieldResolver() {}
 
@@ -68,9 +67,10 @@ final class SheetHeadFieldResolver {
      * @param configurationHolder configuration
      */
     static FieldCache resolve(Class<?> clazz, ConfigurationHolder configurationHolder) {
-        return MetadataCacheStrategy.select(
-                        STRATEGIES, configurationHolder.globalConfiguration().getFiledCacheLocation())
-                .get(new FieldCacheKey(clazz, configurationHolder), key -> doResolve(clazz, configurationHolder));
+        return FIELD_CACHES.get(
+                configurationHolder,
+                new FieldCacheKey(clazz, configurationHolder),
+                key -> doResolve(clazz, configurationHolder));
     }
 
     static void removeThreadLocalCache() {

--- a/fesod-sheet/src/main/java/org/apache/fesod/sheet/util/SheetHeadFieldResolver.java
+++ b/fesod-sheet/src/main/java/org/apache/fesod/sheet/util/SheetHeadFieldResolver.java
@@ -1,0 +1,277 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.fesod.sheet.util;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+import org.apache.commons.collections4.CollectionUtils;
+import org.apache.fesod.common.util.ListUtils;
+import org.apache.fesod.common.util.MapUtils;
+import org.apache.fesod.sheet.annotation.ExcelIgnore;
+import org.apache.fesod.sheet.annotation.ExcelIgnoreUnannotated;
+import org.apache.fesod.sheet.annotation.ExcelProperty;
+import org.apache.fesod.sheet.enums.CacheLocationEnum;
+import org.apache.fesod.sheet.exception.ExcelCommonException;
+import org.apache.fesod.sheet.metadata.ConfigurationHolder;
+import org.apache.fesod.sheet.metadata.FieldCache;
+import org.apache.fesod.sheet.metadata.FieldWrapper;
+import org.apache.fesod.sheet.util.ClassUtils.FieldCacheKey;
+import org.apache.fesod.sheet.write.metadata.holder.WriteHolder;
+
+/**
+ * Resolves which declared fields of a class become spreadsheet columns, and in which order.
+ */
+final class SheetHeadFieldResolver {
+
+    /**
+     * thread local cache
+     */
+    private static final ThreadLocal<Map<FieldCacheKey, FieldCache>> FIELD_THREAD_LOCAL = new ThreadLocal<>();
+
+    private static final Map<CacheLocationEnum, MetadataCacheStrategy<FieldCacheKey, FieldCache>> STRATEGIES =
+            MetadataCacheStrategy.byLocation(ClassUtils.FIELD_CACHE, FIELD_THREAD_LOCAL);
+
+    private SheetHeadFieldResolver() {}
+
+    /**
+     * Parsing field in the class
+     *
+     * @param clazz               Need to parse the class
+     * @param configurationHolder configuration
+     */
+    static FieldCache resolve(Class<?> clazz, ConfigurationHolder configurationHolder) {
+        return MetadataCacheStrategy.select(
+                        STRATEGIES, configurationHolder.globalConfiguration().getFiledCacheLocation())
+                .get(new FieldCacheKey(clazz, configurationHolder), key -> doResolve(clazz, configurationHolder));
+    }
+
+    static void removeThreadLocalCache() {
+        FIELD_THREAD_LOCAL.remove();
+    }
+
+    private static FieldCache doResolve(Class<?> clazz, ConfigurationHolder configurationHolder) {
+        List<Field> tempFieldList = FieldUtils.resolveAllFields(clazz);
+
+        ExcelIgnoreUnannotated excelIgnoreUnannotated = clazz.getAnnotation(ExcelIgnoreUnannotated.class);
+        Set<String> ignoreSet = new HashSet<>();
+        // First collect all field names annotated with ExcelIgnore (including subclass overrides)
+        for (Field field : tempFieldList) {
+            if (field.getAnnotation(ExcelIgnore.class) != null) {
+                ignoreSet.add(FieldUtils.resolveCglibFieldName(field));
+            }
+        }
+        Map<Integer, List<FieldWrapper>> orderFieldMap = new TreeMap<>();
+        Map<Integer, FieldWrapper> indexFieldMap = new TreeMap<>();
+        for (Field field : tempFieldList) {
+            String fieldName = FieldUtils.resolveCglibFieldName(field);
+            // Skip if ignored
+            if (ignoreSet.contains(fieldName)) {
+                continue;
+            }
+            declaredOneField(field, orderFieldMap, indexFieldMap, ignoreSet, excelIgnoreUnannotated);
+        }
+        Map<Integer, FieldWrapper> sortedFieldMap = buildSortedAllFieldMap(orderFieldMap, indexFieldMap);
+        FieldCache fieldCache = new FieldCache(sortedFieldMap, indexFieldMap);
+
+        if (!(configurationHolder instanceof WriteHolder)) {
+            return fieldCache;
+        }
+
+        WriteHolder writeHolder = (WriteHolder) configurationHolder;
+
+        boolean needIgnore = !CollectionUtils.isEmpty(writeHolder.excludeColumnFieldNames())
+                || !CollectionUtils.isEmpty(writeHolder.excludeColumnIndexes())
+                || !CollectionUtils.isEmpty(writeHolder.includeColumnFieldNames())
+                || !CollectionUtils.isEmpty(writeHolder.includeColumnIndexes());
+
+        if (!needIgnore) {
+            return fieldCache;
+        }
+        // ignore filed
+        Map<Integer, FieldWrapper> tempSortedFieldMap = MapUtils.newHashMap();
+        int index = 0;
+        for (Map.Entry<Integer, FieldWrapper> entry : sortedFieldMap.entrySet()) {
+            Integer key = entry.getKey();
+            FieldWrapper field = entry.getValue();
+
+            // The current field needs to be ignored
+            if (writeHolder.ignore(field.getFieldName(), entry.getKey())) {
+                ignoreSet.add(field.getFieldName());
+                // indexFieldMap is keyed by the field's explicit @ExcelProperty(index), which for
+                // explicit-index fields equals the sortedFieldMap position (entry.getKey()); remove
+                // by that key, not the running counter, otherwise an unrelated explicit-index entry
+                // is dropped and the ignored field's entry may survive.
+                indexFieldMap.remove(key);
+            } else {
+                // Mandatory sorted fields
+                if (indexFieldMap.containsKey(key)) {
+                    tempSortedFieldMap.put(key, field);
+                } else {
+                    // Need to reorder automatically
+                    // Check whether the current key is already in use
+                    while (tempSortedFieldMap.containsKey(index)) {
+                        index++;
+                    }
+                    tempSortedFieldMap.put(index++, field);
+                }
+            }
+        }
+        fieldCache.setSortedFieldMap(tempSortedFieldMap);
+
+        // resort field
+        resortField(writeHolder, fieldCache);
+        return fieldCache;
+    }
+
+    /**
+     * it only works when {@link WriteHolder#includeColumnFieldNames()}  or
+     * {@link WriteHolder#includeColumnIndexes()}  has value
+     * and {@link WriteHolder#orderByIncludeColumn()}  is true
+     **/
+    private static void resortField(WriteHolder writeHolder, FieldCache fieldCache) {
+        if (!writeHolder.orderByIncludeColumn()) {
+            return;
+        }
+        Map<Integer, FieldWrapper> indexFieldMap = fieldCache.getIndexFieldMap();
+
+        Collection<String> includeColumnFieldNames = writeHolder.includeColumnFieldNames();
+        if (!CollectionUtils.isEmpty(includeColumnFieldNames)) {
+            // Field sorted map
+            Map<String, Integer> filedIndexMap = MapUtils.newHashMap();
+            int fieldIndex = 0;
+            for (String includeColumnFieldName : includeColumnFieldNames) {
+                filedIndexMap.put(includeColumnFieldName, fieldIndex++);
+            }
+
+            // rebuild sortedFieldMap
+            Map<Integer, FieldWrapper> tempSortedFieldMap = MapUtils.newHashMap();
+            fieldCache.getSortedFieldMap().forEach((index, field) -> {
+                Integer tempFieldIndex = filedIndexMap.get(field.getFieldName());
+                if (tempFieldIndex != null) {
+                    tempSortedFieldMap.put(tempFieldIndex, field);
+
+                    //  The user has redefined the ordering and the ordering of annotations needs to be invalidated
+                    if (!tempFieldIndex.equals(index)) {
+                        indexFieldMap.remove(index);
+                    }
+                }
+            });
+            fieldCache.setSortedFieldMap(tempSortedFieldMap);
+            return;
+        }
+
+        Collection<Integer> includeColumnIndexes = writeHolder.includeColumnIndexes();
+        if (!CollectionUtils.isEmpty(includeColumnIndexes)) {
+            // Index sorted map
+            Map<Integer, Integer> filedIndexMap = MapUtils.newHashMap();
+            int fieldIndex = 0;
+            for (Integer includeColumnIndex : includeColumnIndexes) {
+                filedIndexMap.put(includeColumnIndex, fieldIndex++);
+            }
+
+            // rebuild sortedFieldMap
+            Map<Integer, FieldWrapper> tempSortedFieldMap = MapUtils.newHashMap();
+            fieldCache.getSortedFieldMap().forEach((index, field) -> {
+                Integer tempFieldIndex = filedIndexMap.get(index);
+
+                //  The user has redefined the ordering and the ordering of annotations needs to be invalidated
+                if (tempFieldIndex != null) {
+                    tempSortedFieldMap.put(tempFieldIndex, field);
+                }
+            });
+            fieldCache.setSortedFieldMap(tempSortedFieldMap);
+        }
+    }
+
+    private static Map<Integer, FieldWrapper> buildSortedAllFieldMap(
+            Map<Integer, List<FieldWrapper>> orderFieldMap, Map<Integer, FieldWrapper> indexFieldMap) {
+
+        Map<Integer, FieldWrapper> sortedAllFieldMap =
+                new HashMap<>((orderFieldMap.size() + indexFieldMap.size()) * 4 / 3 + 1);
+
+        Map<Integer, FieldWrapper> tempIndexFieldMap = new HashMap<>(indexFieldMap);
+        int index = 0;
+        for (List<FieldWrapper> fieldList : orderFieldMap.values()) {
+            for (FieldWrapper field : fieldList) {
+                while (tempIndexFieldMap.containsKey(index)) {
+                    sortedAllFieldMap.put(index, tempIndexFieldMap.get(index));
+                    tempIndexFieldMap.remove(index);
+                    index++;
+                }
+                sortedAllFieldMap.put(index, field);
+                index++;
+            }
+        }
+        sortedAllFieldMap.putAll(tempIndexFieldMap);
+        return sortedAllFieldMap;
+    }
+
+    private static void declaredOneField(
+            Field field,
+            Map<Integer, List<FieldWrapper>> orderFieldMap,
+            Map<Integer, FieldWrapper> indexFieldMap,
+            Set<String> ignoreSet,
+            ExcelIgnoreUnannotated excelIgnoreUnannotated) {
+        String fieldName = FieldUtils.resolveCglibFieldName(field);
+        // skip if the field is in ignoreSet
+        if (ignoreSet.contains(fieldName)) {
+            return;
+        }
+        FieldWrapper fieldWrapper = new FieldWrapper();
+        fieldWrapper.setField(field);
+        fieldWrapper.setFieldName(fieldName);
+
+        ExcelProperty excelProperty = field.getAnnotation(ExcelProperty.class);
+        boolean noExcelProperty = excelProperty == null && excelIgnoreUnannotated != null;
+        boolean isStaticFinalOrTransient =
+                (Modifier.isStatic(field.getModifiers()) && Modifier.isFinal(field.getModifiers()))
+                        || Modifier.isTransient(field.getModifiers());
+        if (noExcelProperty || (excelProperty == null && isStaticFinalOrTransient)) {
+            ignoreSet.add(fieldName);
+            return;
+        }
+        // set heads
+        if (excelProperty != null) {
+            fieldWrapper.setHeads(excelProperty.value());
+        }
+        if (excelProperty != null && excelProperty.index() >= 0) {
+            if (indexFieldMap.containsKey(excelProperty.index())) {
+                throw new ExcelCommonException("The index of '"
+                        + indexFieldMap.get(excelProperty.index()).getFieldName() + "' and '" + field.getName()
+                        + "' must be inconsistent");
+            }
+            indexFieldMap.put(excelProperty.index(), fieldWrapper);
+            return;
+        }
+        int order = Integer.MAX_VALUE;
+        if (excelProperty != null) {
+            order = excelProperty.order();
+        }
+        List<FieldWrapper> orderFieldList = orderFieldMap.computeIfAbsent(order, key -> ListUtils.newArrayList());
+        orderFieldList.add(fieldWrapper);
+    }
+}

--- a/fesod-sheet/src/main/java/org/apache/fesod/sheet/util/SheetHeadFieldResolver.java
+++ b/fesod-sheet/src/main/java/org/apache/fesod/sheet/util/SheetHeadFieldResolver.java
@@ -43,7 +43,11 @@ import org.apache.fesod.sheet.util.ClassUtils.FieldCacheKey;
 import org.apache.fesod.sheet.write.metadata.holder.WriteHolder;
 
 /**
- * Resolves which declared fields of a class become spreadsheet columns, and in which order.
+ * Internal helper used by {@link ClassUtils} for resolving which declared fields of a class become
+ * spreadsheet columns, and in which order.
+ * <p>
+ * Not intended for direct use; use {@link ClassUtils} as the primary entry point instead.
+ * </p>
  */
 final class SheetHeadFieldResolver {
 

--- a/fesod-sheet/src/test/java/org/apache/fesod/sheet/readwrite/CacheDataTest.java
+++ b/fesod-sheet/src/test/java/org/apache/fesod/sheet/readwrite/CacheDataTest.java
@@ -42,7 +42,6 @@ import org.apache.fesod.sheet.testkit.Tags;
 import org.apache.fesod.sheet.testkit.base.AbstractExcelTest;
 import org.apache.fesod.sheet.testkit.builders.TestDataBuilder;
 import org.apache.fesod.sheet.testkit.enums.ExcelFormat;
-import org.apache.fesod.sheet.util.ClassUtils;
 import org.apache.fesod.sheet.util.FieldUtils;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Tag;
@@ -57,9 +56,10 @@ public class CacheDataTest extends AbstractExcelTest {
     @Test
     void clearsThreadLocalFieldCacheAfterRead() throws Exception {
         File file07 = createTempFile("cache", ExcelFormat.XLSX);
-        Field field = FieldUtils.getField(ClassUtils.class, "FIELD_THREAD_LOCAL", true);
+        Class<?> resolver = Class.forName("org.apache.fesod.sheet.util.SheetHeadFieldResolver");
+        Field field = FieldUtils.getField(resolver, "FIELD_THREAD_LOCAL", true);
         ThreadLocal<Map<Class<?>, FieldCache>> fieldThreadLocal =
-                (ThreadLocal<Map<Class<?>, FieldCache>>) field.get(ClassUtils.class.newInstance());
+                (ThreadLocal<Map<Class<?>, FieldCache>>) field.get(null);
         Assertions.assertNull(fieldThreadLocal.get());
         FesodSheet.write(file07, CacheData.class).sheet().doWrite(TestDataBuilder.cacheData(10));
         FesodSheet.read(file07, CacheData.class, new PageReadListener<CacheData>(dataList -> {

--- a/fesod-sheet/src/test/java/org/apache/fesod/sheet/readwrite/CacheDataTest.java
+++ b/fesod-sheet/src/test/java/org/apache/fesod/sheet/readwrite/CacheDataTest.java
@@ -36,7 +36,6 @@ import org.apache.fesod.sheet.annotation.ExcelProperty;
 import org.apache.fesod.sheet.context.AnalysisContext;
 import org.apache.fesod.sheet.enums.CacheLocationEnum;
 import org.apache.fesod.sheet.event.AnalysisEventListener;
-import org.apache.fesod.sheet.metadata.FieldCache;
 import org.apache.fesod.sheet.read.listener.PageReadListener;
 import org.apache.fesod.sheet.testkit.Tags;
 import org.apache.fesod.sheet.testkit.base.AbstractExcelTest;
@@ -56,10 +55,7 @@ public class CacheDataTest extends AbstractExcelTest {
     @Test
     void clearsThreadLocalFieldCacheAfterRead() throws Exception {
         File file07 = createTempFile("cache", ExcelFormat.XLSX);
-        Class<?> resolver = Class.forName("org.apache.fesod.sheet.util.SheetHeadFieldResolver");
-        Field field = FieldUtils.getField(resolver, "FIELD_THREAD_LOCAL", true);
-        ThreadLocal<Map<Class<?>, FieldCache>> fieldThreadLocal =
-                (ThreadLocal<Map<Class<?>, FieldCache>>) field.get(null);
+        ThreadLocal<?> fieldThreadLocal = headFieldThreadLocal();
         Assertions.assertNull(fieldThreadLocal.get());
         FesodSheet.write(file07, CacheData.class).sheet().doWrite(TestDataBuilder.cacheData(10));
         FesodSheet.read(file07, CacheData.class, new PageReadListener<CacheData>(dataList -> {
@@ -68,6 +64,13 @@ public class CacheDataTest extends AbstractExcelTest {
                 .sheet()
                 .doRead();
         Assertions.assertNull(fieldThreadLocal.get());
+    }
+
+    private static ThreadLocal<?> headFieldThreadLocal() throws Exception {
+        Class<?> resolver = Class.forName("org.apache.fesod.sheet.util.SheetHeadFieldResolver");
+        Object caches = FieldUtils.getField(resolver, "FIELD_CACHES", true).get(null);
+        Field threadLocalCache = FieldUtils.getField(caches.getClass(), "threadLocalCache", true);
+        return (ThreadLocal<?>) threadLocalCache.get(caches);
     }
 
     @Test

--- a/fesod-sheet/src/test/java/org/apache/fesod/sheet/util/ClassUtilsTest.java
+++ b/fesod-sheet/src/test/java/org/apache/fesod/sheet/util/ClassUtilsTest.java
@@ -74,9 +74,7 @@ class ClassUtilsTest {
     @AfterEach
     void tearDown() {
         ClassUtils.removeThreadLocalCache();
-        ClassUtils.FIELD_CACHE.clear();
-        ClassUtils.CONTENT_CACHE.clear();
-        ClassUtils.CLASS_CONTENT_CACHE.clear();
+        ClassUtils.removeInMemoryCache();
     }
 
     private static class SimpleEntity {
@@ -121,10 +119,23 @@ class ClassUtilsTest {
         FieldCache cache1 = ClassUtils.declaredFields(SimpleEntity.class, writeHolder);
         Assertions.assertNotNull(cache1);
 
-        Assertions.assertFalse(ClassUtils.FIELD_CACHE.isEmpty());
+        Assertions.assertFalse(ClassUtils.getFieldCache().isEmpty());
 
         FieldCache cache2 = ClassUtils.declaredFields(SimpleEntity.class, writeHolder);
         Assertions.assertSame(cache1, cache2);
+    }
+
+    @Test
+    void test_getFieldCache_immutableViewOfTheLiveCache() {
+        Mockito.when(globalConfiguration.getFiledCacheLocation()).thenReturn(CacheLocationEnum.MEMORY);
+        ClassUtils.declaredFields(SimpleEntity.class, writeHolder);
+
+        Map<?, ?> fieldCache = ClassUtils.getFieldCache();
+        Assertions.assertFalse(fieldCache.isEmpty());
+        Assertions.assertThrows(UnsupportedOperationException.class, fieldCache::clear);
+
+        ClassUtils.removeInMemoryCache();
+        Assertions.assertTrue(fieldCache.isEmpty());
     }
 
     @Test
@@ -134,7 +145,7 @@ class ClassUtilsTest {
         FieldCache cache1 = ClassUtils.declaredFields(SimpleEntity.class, writeHolder);
         Assertions.assertNotNull(cache1);
 
-        Assertions.assertTrue(ClassUtils.FIELD_CACHE.isEmpty());
+        Assertions.assertTrue(ClassUtils.getFieldCache().isEmpty());
 
         FieldCache cache2 = ClassUtils.declaredFields(SimpleEntity.class, writeHolder);
         Assertions.assertSame(cache1, cache2);
@@ -148,7 +159,7 @@ class ClassUtilsTest {
         FieldCache cache2 = ClassUtils.declaredFields(SimpleEntity.class, writeHolder);
 
         Assertions.assertNotSame(cache1, cache2);
-        Assertions.assertTrue(ClassUtils.FIELD_CACHE.isEmpty());
+        Assertions.assertTrue(ClassUtils.getFieldCache().isEmpty());
     }
 
     @Test


### PR DESCRIPTION
Closed: #989 

## Purpose of the pull request

As title

## What's changed?

- Extracted column-layout resolution (`declaredFields` and its helpers) into a package-private `SheetHeadFieldResolver`.
- Extracted per-field formatting resolution (`declaredExcelContentProperty` and its helpers) into a package-private `SheetContentPropertyResolver`.
- Replaced the three switches with a `MetadataCacheStrategy` per `CacheLocationEnum` constant (`InMemoryCache`, `ThreadLocalCache`, `NoOpCache`), each owning its own storage.  `MetadataCaches` composes the three for one kind of metadata and picks the tier from the `ConfigurationHolder`, so `CacheLocationEnum` is now referenced in one class instead of three switches. `InMemoryCache` and `ThreadLocalCache` also accept a map or map factory, to allow map types other than the defaults later.
- `ClassUtils` keeps `getAllInterfaces`, both key classes, and every public entry point, delegating to the resolvers.
- Deprecated `FIELD_CACHE`, `CLASS_CONTENT_CACHE` and `CONTENT_CACHE` in favour of `getFieldCache()` / `getClassContentCache()` / `getContentCache()` (unmodifiable, live views; the cached values are shared and must not be modified) and a new `removeInMemoryCache()`. The fields still alias the same live, mutable maps, so downstream reads and writes behave exactly as today - only a deprecation warning is added.
- Tests: `CacheDataTest` no longer reads a private `ThreadLocal` field of `ClassUtils` and checks that the thread-local cache is cleared after a read through `ClassUtils` itself; `ClassUtilsTest` covers the three views; new `MetadataCacheStrategyTest` checks that `ThreadLocalCache.clear()` detaches the map from the thread.

## Checklist

- [x] I have read the [Contributor Guide](https://fesod.apache.org/community/contribution/).
- [x] I have written the necessary doc or comment.
- [x] I have added the necessary unit tests and all cases have passed.
